### PR TITLE
chore: sync develop → main (branch strategy bootstrap)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# All files — maintainer is auto-assigned as reviewer on every PR
+* @Oseiasdfarias

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## What and why
+
+<!-- Describe the change and the motivation.
+     Link the related issue: Closes #N -->
+
+## Type of change
+
+- [ ] `feat` — new feature
+- [ ] `fix` — bug fix
+- [ ] `docs` — documentation only
+- [ ] `chore` / `ci` — tooling, dependencies, CI
+
+## Checklist
+
+- [ ] `uv run pytest` passes locally
+- [ ] `uv run ruff check .` clean
+- [ ] `uv run mypy synapsys` clean
+- [ ] New public API has type hints and Google-style docstring
+- [ ] Tests added or updated (required for `feat` and `fix`)
+- [ ] `CHANGELOG.md` updated under `[Unreleased]` (required for `feat` and `fix`)
+- [ ] Branch was created from `develop`, not `main`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, develop, "release/**", "hotfix/**"]
   pull_request:
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+### Changed
+### Fixed
+
+---
+
 ## [0.1.0] — 2026-04-11
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,15 +57,19 @@ uv run mypy synapsys   # no type errors
 
 ## Branch Policy
 
-| Branch | Purpose |
-|--------|---------|
-| `main` | Stable — direct commits are not allowed |
-| `develop` | Integration branch for new features |
-| `feat/<name>` | New features |
-| `fix/<name>` | Bug fixes |
-| `docs/<name>` | Documentation changes |
+| Branch | Created from | Merges into | Purpose |
+|--------|-------------|-------------|---------|
+| `main` | — | — | Always releasable — no direct pushes |
+| `develop` | `main` | — | Integration buffer — default PR target |
+| `feat/<name>` | `develop` | `develop` (PR) | New features |
+| `fix/<name>` | `develop` | `develop` (PR) | Non-urgent bug fixes |
+| `docs/<name>` | `develop` | `develop` (PR) | Documentation changes |
+| `chore/<name>` / `ci/<name>` | `develop` | `develop` (PR) | Tooling, deps, CI |
+| `release/vX.Y.Z` | `develop` | `main` + back-merge `develop` | Release stabilisation |
+| `hotfix/vX.Y.Z` | tag on `main` | `main` + back-merge `develop` | Urgent production fix |
 
-All changes must go through a pull request targeting `main` or `develop`.
+**All topic branches must be created from `develop`, not `main`.**
+Pull requests from external contributors must target `develop`.
 
 ---
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -111,7 +111,7 @@ const config: Config = {
     },
     prism: {
       theme: prismThemes.github,
-      darkTheme: prismThemes.dracula,
+      darkTheme: prismThemes.vsDark,
       additionalLanguages: ['python', 'bash', 'yaml', 'toml'],
     },
     mermaid: {

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -89,6 +89,36 @@ h1, h2, h3, h4 { letter-spacing: -0.02em; }
   margin: 0 auto;
 }
 
+.doc-header__cols {
+  display: flex;
+  align-items: flex-start;
+  gap: 2rem;
+}
+
+.doc-header__logo-col {
+  flex-shrink: 0;
+  padding-top: 0.25rem;
+}
+
+.doc-header__logo {
+  width: 72px;
+  height: 72px;
+  border-radius: 14px;
+}
+
+.doc-header__content-col {
+  flex: 1;
+  min-width: 0;
+}
+
+@media (max-width: 540px) {
+  .doc-header__cols {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+}
+
 .doc-header__meta {
   display: flex;
   gap: 0.4rem;

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -2,6 +2,7 @@ import type { ReactElement } from 'react';
 import Link from '@docusaurus/Link';
 import Translate, { translate } from '@docusaurus/Translate';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import useBaseUrl from '@docusaurus/useBaseUrl';
 import Layout from '@theme/Layout';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -80,6 +81,7 @@ function NavCard({ Icon, title, desc, href }: { Icon: LucideIcon; title: string;
 // ── Page ──────────────────────────────────────────────────────────────────────
 export default function Home(): ReactElement {
   const { siteConfig } = useDocusaurusContext();
+  const logoUrl = useBaseUrl('/img/logo.svg');
 
   return (
     <Layout
@@ -93,40 +95,52 @@ export default function Home(): ReactElement {
       {/* ── Header ────────────────────────────────────────────────────────── */}
       <header className="doc-header">
         <div className="doc-header__inner">
-          <div className="doc-header__meta">
-            <span className="doc-badge">v0.1.0</span>
-            <span className="doc-badge doc-badge--neutral">Python 3.10+</span>
-            <span className="doc-badge doc-badge--neutral">MIT</span>
-            <a href={`${GITHUB}/actions`} className="doc-badge doc-badge--neutral" target="_blank" rel="noreferrer">CI passing</a>
-          </div>
+          <div className="doc-header__cols">
 
-          <h1 className="doc-header__title">{siteConfig.title}</h1>
+            {/* ── Logo column ── */}
+            <div className="doc-header__logo-col">
+              <img src={logoUrl} alt="Synapsys logo" className="doc-header__logo" />
+            </div>
 
-          <p className="doc-header__tagline">
-            <Translate id="home.header.tagline">
-              A Python library for modelling, analysis and real-time simulation of linear
-              control systems. Provides a MATLAB-compatible API over SciPy, a multi-agent
-              simulation framework, and a pluggable transport layer (shared memory / ZMQ)
-              for MIL → SIL → HIL workflows.
-            </Translate>
-          </p>
+            {/* ── Content column ── */}
+            <div className="doc-header__content-col">
+              <div className="doc-header__meta">
+                <span className="doc-badge">v0.1.0</span>
+                <span className="doc-badge doc-badge--neutral">Python 3.10+</span>
+                <span className="doc-badge doc-badge--neutral">MIT</span>
+                <a href={`${GITHUB}/actions`} className="doc-badge doc-badge--neutral" target="_blank" rel="noreferrer">CI passing</a>
+              </div>
 
-          <div className="doc-header__install">
-            <code>pip install synapsys</code>
-            <span className="doc-header__sep">or</span>
-            <code>uv add synapsys</code>
-          </div>
+              <h1 className="doc-header__title">{siteConfig.title}</h1>
 
-          <div className="doc-header__actions">
-            <Link className="btn btn--primary" to="/docs/getting-started/installation">
-              <Translate id="home.header.cta.docs">Documentation</Translate>
-            </Link>
-            <Link className="btn btn--outline" to={GITHUB}>
-              <GitBranch size={15} /> GitHub
-            </Link>
-            <Link className="btn btn--outline" to="/docs/getting-started/quickstart">
-              <Translate id="home.header.cta.quickstart">Quickstart</Translate>
-            </Link>
+              <p className="doc-header__tagline">
+                <Translate id="home.header.tagline">
+                  A Python library for modelling, analysis and real-time simulation of linear
+                  control systems. Provides a MATLAB-compatible API over SciPy, a multi-agent
+                  simulation framework, and a pluggable transport layer (shared memory / ZMQ)
+                  for MIL → SIL → HIL workflows.
+                </Translate>
+              </p>
+
+              <div className="doc-header__install">
+                <code>pip install synapsys</code>
+                <span className="doc-header__sep">or</span>
+                <code>uv add synapsys</code>
+              </div>
+
+              <div className="doc-header__actions">
+                <Link className="btn btn--primary" to="/docs/getting-started/installation">
+                  <Translate id="home.header.cta.docs">Documentation</Translate>
+                </Link>
+                <Link className="btn btn--outline" to={GITHUB}>
+                  <GitBranch size={15} /> GitHub
+                </Link>
+                <Link className="btn btn--outline" to="/docs/getting-started/quickstart">
+                  <Translate id="home.header.cta.quickstart">Quickstart</Translate>
+                </Link>
+              </div>
+            </div>
+
           </div>
         </div>
       </header>

--- a/website/static/img/logo.svg
+++ b/website/static/img/logo.svg
@@ -1,35 +1,37 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48" height="48" fill="none">
-  <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="48" y2="48" gradientUnits="userSpaceOnUse">
-      <stop offset="0%"   stop-color="#3b82f6"/>
-      <stop offset="55%"  stop-color="#8b5cf6"/>
-      <stop offset="100%" stop-color="#14b8a6"/>
-    </linearGradient>
-    <linearGradient id="arrow" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%"  stop-color="#ffffff" stop-opacity="0.95"/>
-      <stop offset="100%" stop-color="#bfdbfe" stop-opacity="0.80"/>
-    </linearGradient>
-  </defs>
 
-  <!-- Background rounded square -->
-  <rect width="48" height="48" rx="11" fill="url(#bg)"/>
+  <!-- Background — flat color, no gradient -->
+  <rect width="48" height="48" rx="10" fill="#1e3a8a"/>
 
-  <!-- Closed-loop feedback arrows -->
-  <!-- Top arc (forward path): left → right -->
-  <path d="M 10 20 Q 10 13 17 13 L 31 13 Q 38 13 38 20"
-        stroke="white" stroke-width="2.2" stroke-linecap="round" fill="none" opacity="0.92"/>
-  <!-- Arrowhead pointing right at top-right -->
-  <polyline points="35,10.5 38,13 35,15.5"
-            stroke="white" stroke-width="2.0" stroke-linecap="round" stroke-linejoin="round" fill="none" opacity="0.92"/>
+  <!-- Y axis -->
+  <line x1="9" y1="5" x2="9" y2="41"
+        stroke="white" stroke-width="2.2" stroke-linecap="round" opacity="0.75"/>
+  <!-- Y axis arrowhead -->
+  <polyline points="7,7 9,5 11,7"
+            stroke="white" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"
+            fill="none" opacity="0.75"/>
 
-  <!-- Bottom arc (feedback path): right → left -->
-  <path d="M 38 28 Q 38 35 31 35 L 17 35 Q 10 35 10 28"
-        stroke="white" stroke-width="2.2" stroke-linecap="round" fill="none" opacity="0.70"/>
-  <!-- Arrowhead pointing left at bottom-left -->
-  <polyline points="13,25.5 10,28 13,30.5"
-            stroke="white" stroke-width="2.0" stroke-linecap="round" stroke-linejoin="round" fill="none" opacity="0.70"/>
+  <!-- X axis -->
+  <line x1="9" y1="41" x2="44" y2="41"
+        stroke="white" stroke-width="2.2" stroke-linecap="round" opacity="0.75"/>
+  <!-- X axis arrowhead -->
+  <polyline points="42,39 44,41 42,43"
+            stroke="white" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"
+            fill="none" opacity="0.75"/>
 
-  <!-- Center dot — plant/controller block hint -->
-  <circle cx="24" cy="24" r="3.2" fill="white" opacity="0.95"/>
-  <circle cx="24" cy="24" r="1.5" fill="url(#bg)" opacity="0.85"/>
+  <!-- Setpoint reference line (dashed) -->
+  <line x1="9" y1="17" x2="44" y2="17"
+        stroke="white" stroke-width="2.2" stroke-dasharray="2.5,2.5"
+        stroke-linecap="round" opacity="0.35"/>
+
+  <!-- Step response curve -->
+  <path d="M 9,41
+           L 12,41
+           C 13,41 14,7 20,7
+           C 24,7 25,24 28,22
+           C 31,20 32,14 35,15
+           C 38,16 40,17 44,17"
+        stroke="white" stroke-width="2.2"
+        stroke-linecap="round" stroke-linejoin="round"
+        fill="none" opacity="0.95"/>
 </svg>


### PR DESCRIPTION
## What and why

Syncs all commits from `develop` into `main` that accumulated during the branch strategy bootstrap:

- `ci.yml`: CI now runs on `release/**` and `hotfix/**` branches
- `.github/CODEOWNERS`: auto-assign `@Oseiasdfarias` as reviewer on every PR
- `.github/pull_request_template.md`: standard checklist for contributors
- `CHANGELOG.md`: add `[Unreleased]` section for next development cycle
- `CONTRIBUTING.md`: update branch policy table to match the new strategy

## Type of change
- [x] `chore` / `ci` — tooling, dependencies, CI

## Checklist
- [x] CI passes
- [x] No functional code changes