### PR TITLE
fix(docs): correct broken links and outdated example paths

### DIFF
--- a/website/docs/examples/index.md
+++ b/website/docs/examples/index.md
@@ -16,24 +16,24 @@ Each example lives in its own subfolder under `examples/` and includes a detaile
 
 | Example | Concepts |
 |---|---|
-| [Step Response](basic/step-response) | Transfer function, `tf()`, `step()`, poles, stability |
+| [Step Response](./basic/step-response) | Transfer function, `tf()`, `step()`, poles, stability |
 
 ## Advanced
 
 | Example | Concepts |
 |---|---|
-| [Custom Signal Injection](advanced/custom-signals) | MIL, superposition, `simulate()`, arbitrary waveforms |
-| [SIL + AI Controller](advanced/sil-ai-controller) | SIL, `PlantAgent`, `ControllerAgent`, PyTorch integration, real-time plot |
-| [Real-Time Scope (Terminal)](advanced/realtime-scope) | Read-only bus monitor, headless display |
-| [Real-Time Oscilloscope](advanced/realtime-oscilloscope) | Three-role architecture, PID, sinusoidal reference, `FuncAnimation` |
-| [Digital Twin](advanced/digital-twin) | Virtual twin, wear injection, divergence metric, anomaly detection |
+| [Custom Signal Injection](./advanced/custom-signals) | MIL, superposition, `simulate()`, arbitrary waveforms |
+| [SIL + AI Controller](./advanced/sil-ai-controller) | SIL, `PlantAgent`, `ControllerAgent`, PyTorch integration, real-time plot |
+| [Real-Time Scope (Terminal)](./advanced/realtime-scope) | Read-only bus monitor, headless display |
+| [Real-Time Oscilloscope](./advanced/realtime-oscilloscope) | Three-role architecture, PID, sinusoidal reference, `FuncAnimation` |
+| [Digital Twin](./advanced/digital-twin) | Virtual twin, wear injection, divergence metric, anomaly detection |
 
 ## Distributed
 
 | Example | Concepts |
 |---|---|
-| [Shared Memory](distributed/shared-memory) | Multi-process IPC, bus ownership, rate decoupling |
-| [ZeroMQ Network](distributed/zmq) | PUB/SUB, cross-machine simulation, ZOH fallback |
+| [Shared Memory](./distributed/shared-memory-example) | Multi-process IPC, bus ownership, rate decoupling |
+| [ZeroMQ Network](./distributed/zmq-example) | PUB/SUB, cross-machine simulation, ZOH fallback |
 
 ---
 

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -57,10 +57,10 @@ Run in two separate terminals:
 
 ```bash
 # Terminal 1 — start the plant first
-python examples/distributed/plant.py
+python examples/distributed/01_shared_memory/plant.py
 
 # Terminal 2 — then the controller
-python examples/distributed/controller.py
+python examples/distributed/01_shared_memory/controller.py
 ```
 
 The plant exposes its state via **shared memory** (zero-copy). The controller reads `y`, computes `u` with PID, and writes it back — no network sockets involved.
@@ -69,8 +69,8 @@ The plant exposes its state via **shared memory** (zero-copy). The controller re
 
 ```bash
 # Machine A — plant
-python examples/distributed/plant_zmq.py
+python examples/distributed/02_zmq/plant_zmq.py
 
 # Machine B — controller (set PLANT_HOST to Machine A's IP)
-PLANT_HOST=192.168.1.10 python examples/distributed/controller_zmq.py
+PLANT_HOST=192.168.1.10 python examples/distributed/02_zmq/controller_zmq.py
 ```

--- a/website/docs/guide/transport/zmq.md
+++ b/website/docs/guide/transport/zmq.md
@@ -34,7 +34,7 @@ Plant:       PUB :5555  ->  SUB :5556
 Controller:  PUB :5556  ->  SUB :5555
 ```
 
-See `examples/distributed/plant_zmq.py` and `examples/distributed/controller_zmq.py` in the repository.
+See `examples/distributed/02_zmq/plant_zmq.py` and `examples/distributed/02_zmq/controller_zmq.py` in the repository.
 
 ## REQ/REP — Lock-step
 


### PR DESCRIPTION
Fixes the CI build failure from PR #9.

**Root cause:** `examples/index.md` used bare relative links (e.g. `basic/step-response`) which Docusaurus resolved from the docs root instead of the file's directory.

**Also fixed:** `getting-started/quickstart.md` and `guide/transport/zmq.md` still referenced the old flat example paths before the subfolder reorganisation.