### PR TITLE
chore(ci): enable PyPI publish job via OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -95,28 +95,27 @@ jobs:
           files: dist/*
 
   # ── Job 4: Publish to PyPI ────────────────────────────────────────────────
-  # TODO: enable after configuring OIDC Trusted Publishing on pypi.org
-  # publish-pypi:
-  #   name: Publish to PyPI
-  #   needs: build
-  #   if: >
-  #     github.event_name == 'release' ||
-  #     (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'pypi')
-  #   runs-on: ubuntu-latest
-  #
-  #   environment:
-  #     name: pypi
-  #     url: https://pypi.org/p/synapsys
-  #
-  #   permissions:
-  #     id-token: write   # OIDC trusted publishing — no API token needed
-  #
-  #   steps:
-  #     - name: Download dist artifacts
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         name: dist
-  #         path: dist/
-  #
-  #     - name: Publish to PyPI
-  #       uses: pypa/gh-action-pypi-publish@release/v1
+  publish-pypi:
+    name: Publish to PyPI
+    needs: build
+    if: >
+      github.event_name == 'release' ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'pypi')
+    runs-on: ubuntu-latest
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/synapsys
+
+    permissions:
+      id-token: write   # OIDC trusted publishing — no API token needed
+
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary

- Uncomments the `publish-pypi` job in `publish.yml`
- Uses OIDC Trusted Publishing — no API token or secret needed
- Triggers on: GitHub Release published **or** manual `workflow_dispatch` with target `pypi`

## Setup required before merging

1. **PyPI**: `pypi.org` → project `synapsys` → Manage → Publishing → Add pending publisher
   - Owner: `synapsys-lab` · Repo: `synapsys` · Workflow: `publish.yml` · Environment: `pypi`
2. **GitHub**: Settings → Environments → New environment → name: `pypi`

After both steps the linter warning disappears and the job will work on the next release.