### PR TITLE
docs(readme): add GIF showcase, absolute URLs, PyPI metadata and version badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 <div align="center">
 
-<img src="website/static/img/logo.svg" width="96" height="96" alt="Synapsys logo" />
+<img src="https://raw.githubusercontent.com/synapsys-lab/synapsys/main/website/static/img/logo.svg" width="96" height="96" alt="Synapsys logo" />
 
 # Synapsys
 
 **Modern Python control systems framework with distributed multi-agent simulation**
 
 [![CI](https://github.com/synapsys-lab/synapsys/actions/workflows/ci.yml/badge.svg)](https://github.com/synapsys-lab/synapsys/actions/workflows/ci.yml)
-[![Deploy Docs](https://github.com/synapsys-lab/synapsys/actions/workflows/docs.yml/badge.svg)](https://synapsys-lab.github.io/synapsys/)
-[![PyPI version](https://img.shields.io/pypi/v/synapsys.svg?color=blue)](https://pypi.org/project/synapsys/)
+[![PyPI version](https://img.shields.io/pypi/v/synapsys.svg?color=blue&label=PyPI)](https://pypi.org/project/synapsys/)
 [![Python](https://img.shields.io/pypi/pyversions/synapsys.svg)](https://pypi.org/project/synapsys/)
+[![Docs](https://img.shields.io/badge/docs-synapsys--lab.github.io-blue)](https://synapsys-lab.github.io/synapsys/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Coverage](https://img.shields.io/badge/coverage-86%25-brightgreen.svg)](#testing)
 [![Code style: ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
-[Documentation](https://synapsys-lab.github.io/synapsys/) · [Quickstart](#quickstart) · [Examples](examples/) · [Changelog](CHANGELOG.md)
+[📖 Documentation](https://synapsys-lab.github.io/synapsys/) · [🚀 Quickstart](#quickstart) · [📦 PyPI](https://pypi.org/project/synapsys/) · [💡 Examples](examples/) · [📋 Changelog](CHANGELOG.md)
 
 </div>
 
@@ -22,17 +22,32 @@
 
 ## Overview
 
-Synapsys is an open-source Python library for modelling, simulating, and deploying control systems. It provides a **MATLAB-compatible API** that lowers the barrier for engineers already familiar with control toolboxes, while adding a modern **multi-agent simulation layer** with pluggable transports that scales from a single laptop to a distributed lab setup.
+Synapsys is an open-source Python library for **modelling, simulating, and deploying control systems**. It provides a **MATLAB-compatible API** built on SciPy, a modern **multi-agent simulation framework**, and a pluggable **transport layer** (shared memory / ZeroMQ) that scales from a single laptop to distributed lab setups.
 
 ```python
 from synapsys.api import tf, feedback, step, c2d
 
-G  = tf([1], [1, 2, 1])      # G(s) = 1 / (s² + 2s + 1)
-T  = feedback(G)              # closed-loop T = G / (1 + G)
+G    = tf([1], [1, 2, 1])    # G(s) = 1 / (s² + 2s + 1)
+T    = feedback(G)            # closed-loop: T = G / (1 + G)
 t, y = step(T)                # step response
-
-Gd = c2d(G, dt=0.02)         # ZOH discretisation at 50 Hz
+Gd   = c2d(G, dt=0.02)       # ZOH discretisation at 50 Hz
 ```
+
+```bash
+pip install synapsys
+```
+
+---
+
+## See it in action
+
+Neural-LQR controller on a 2-DOF mass-spring-damper — MLP initialized with LQR optimal gains tracking setpoint x₂ = 1 m:
+
+<div align="center">
+<img src="https://raw.githubusercontent.com/synapsys-lab/synapsys/main/website/static/img/examples/03_sil_ai_controller.gif" alt="Neural-LQR 2-DOF simulation — position tracking, velocities, control force and phase portrait" width="720" />
+</div>
+
+> Full walkthrough: [SIL + Neural-LQR example →](https://synapsys-lab.github.io/synapsys/docs/examples/advanced/sil-ai-controller)
 
 ---
 
@@ -43,9 +58,10 @@ Gd = c2d(G, dt=0.02)         # ZOH discretisation at 50 Hz
 | ⚡ **MATLAB-Compatible API** | `tf()`, `ss()`, `c2d()`, `step()`, `bode()`, `feedback()`, `lsim()` — same names, pure Python |
 | 📐 **LTI Core** | `TransferFunction` and `StateSpace` with operator overloading, poles, zeros, stability |
 | 🧮 **Control Algorithms** | Discrete PID with anti-windup · LQR via algebraic Riccati equation |
-| 🤖 **Multi-Agent Simulation** | `PlantAgent` and `ControllerAgent` with FIPA ACL messaging, lock-step and wall-clock sync |
+| 🤖 **Multi-Agent Simulation** | `PlantAgent` and `ControllerAgent` with lock-step and wall-clock sync |
 | 🔗 **Pluggable Transport** | Zero-copy shared memory (single-host) · ZeroMQ PUB/SUB and REQ/REP (distributed) |
 | 🔌 **Hardware Abstraction** | `HardwareInterface` contract enables seamless MIL → SIL → HIL transitions |
+| 🧱 **Matrix Builders** | `StateEquations`, `mat()`, `col()`, `row()` — define state-space models from named equations |
 
 ---
 
@@ -55,7 +71,7 @@ Gd = c2d(G, dt=0.02)         # ZOH discretisation at 50 Hz
 pip install synapsys
 ```
 
-**Requirements:** Python ≥ 3.10, NumPy ≥ 1.24, SciPy ≥ 1.10, pyzmq ≥ 25.0
+**Requirements:** Python ≥ 3.10 · NumPy ≥ 1.24 · SciPy ≥ 1.10 · pyzmq ≥ 25.0
 
 For development:
 
@@ -83,8 +99,8 @@ T = feedback(G)
 # Frequency response
 w, mag, phase = bode(G)
 
-# ZOH discretisation
-Gd = c2d(G, dt=0.02)          # 50 Hz
+# ZOH discretisation at 50 Hz
+Gd = c2d(G, dt=0.02)
 ```
 
 ### 2 · Control algorithms
@@ -93,7 +109,7 @@ Gd = c2d(G, dt=0.02)          # 50 Hz
 from synapsys.algorithms import PID, lqr
 import numpy as np
 
-# Discrete PID with anti-windup
+# Discrete PID with anti-windup saturation
 pid = PID(Kp=3.0, Ki=0.5, Kd=0.1, dt=0.01, u_min=-10.0, u_max=10.0)
 u   = pid.compute(setpoint=5.0, measurement=y)
 
@@ -101,42 +117,65 @@ u   = pid.compute(setpoint=5.0, measurement=y)
 A = np.array([[0., 1.], [-2., -3.]])
 B = np.array([[0.], [1.]])
 K, P = lqr(A, B, Q=np.eye(2), R=np.eye(1))
+# Control law: u = −K · x
 ```
 
-### 3 · Distributed simulation
-
-Run plant and controller as independent processes connected by shared memory:
-
-```bash
-# Terminal 1 — physics engine
-python examples/distributed/plant.py
-
-# Terminal 2 — PID controller
-python examples/distributed/controller.py
-```
-
-Or connect over a network using ZeroMQ:
-
-```bash
-python examples/distributed/plant_zmq.py
-python examples/distributed/controller_zmq.py
-```
-
-### 4 · MIL → SIL → HIL — swap transport, keep algorithm
+### 3 · State-space from named equations
 
 ```python
-# MIL (Model-in-the-Loop) — shared memory, single process
+from synapsys.utils import StateEquations
+
+m, c, k = 1.0, 0.1, 2.0
+
+eqs = (
+    StateEquations(states=["x1", "x2", "v1", "v2"], inputs=["F"])
+    .eq("x1", v1=1).eq("x2", v2=1)
+    .eq("v1", x1=-2*k/m, x2=k/m,  v1=-c/m)
+    .eq("v2", x1=k/m,  x2=-2*k/m, v2=-c/m, F=1/m)
+)
+
+print(eqs.A)   # 4×4 system matrix
+print(eqs.B)   # 4×1 input matrix
+```
+
+### 4 · Multi-agent closed-loop simulation
+
+```python
+from synapsys.api import ss, c2d
+from synapsys.agents import PlantAgent, ControllerAgent, SyncEngine, SyncMode
+from synapsys.algorithms import PID
+from synapsys.transport import SharedMemoryTransport
+import numpy as np
+
+# Discretise G(s) = 1/(s+1) at 100 Hz
+plant_d = c2d(ss([[-1]], [[1]], [[1]], [[0]]), dt=0.01)
+
+with SharedMemoryTransport("demo", {"y": 1, "u": 1}, create=True) as bus:
+    bus.write("y", np.zeros(1))
+    bus.write("u", np.zeros(1))
+
+    pid  = PID(Kp=4.0, Ki=1.0, dt=0.01)
+    law  = lambda y: np.array([pid.compute(setpoint=3.0, measurement=y[0])])
+    sync = SyncEngine(SyncMode.WALL_CLOCK, dt=0.01)
+
+    PlantAgent("plant", plant_d, bus, sync).start(blocking=False)
+    ControllerAgent("ctrl",  law,  bus, sync).start(blocking=True)
+```
+
+### 5 · MIL → SIL → HIL — swap transport, keep algorithm
+
+```python
+# MIL — shared memory, single host
 from synapsys.transport import SharedMemoryTransport
 bus = SharedMemoryTransport("demo", {"y": 1, "u": 1}, create=True)
 
-# SIL (Software-in-the-Loop) — ZeroMQ, cross-process / cross-machine
+# SIL — ZeroMQ, cross-process / cross-machine
 from synapsys.transport import ZMQTransport
 bus = ZMQTransport("tcp://localhost:5555", mode="pub")
 
-# HIL (Hardware-in-the-Loop) — real hardware driver
+# HIL — real hardware
 from synapsys.agents import HardwareAgent
 from synapsys.hw import MockHardwareInterface   # replace with your driver
-
 hw    = MockHardwareInterface(n_inputs=1, n_outputs=1, plant_fn=my_hw)
 agent = HardwareAgent("hw", hw, bus, sync)
 
@@ -151,13 +190,13 @@ agent = HardwareAgent("hw", hw, bus, sync)
 |---------|-------------|
 | [`basic/step_response.py`](examples/basic/step_response.py) | Step response of a 2nd-order system |
 | [`distributed/plant.py`](examples/distributed/plant.py) + [`controller.py`](examples/distributed/controller.py) | Two-process PID loop via shared memory |
-| [`distributed/plant_zmq.py`](examples/distributed/plant_zmq.py) | Same loop over ZeroMQ |
+| [`distributed/plant_zmq.py`](examples/distributed/plant_zmq.py) | Same loop over ZeroMQ (cross-machine) |
 | [`advanced/01_custom_signals.py`](examples/advanced/01_custom_signals.py) | Custom reference signals with `lsim()` |
-| [`advanced/02a_sil_plant.py`](examples/advanced/02a_sil_plant.py) | SIL plant process |
+| [`advanced/02a_sil_plant.py`](examples/advanced/02a_sil_plant.py) + [`02b_sil_ai_controller.py`](examples/advanced/02_sil_ai_controller/02b_sil_ai_controller.py) | SIL + Neural-LQR PyTorch controller |
 | [`advanced/03_realtime_scope.py`](examples/advanced/03_realtime_scope.py) | Text-mode real-time oscilloscope |
-| [`advanced/04_realtime_matplotlib.py`](examples/advanced/04_realtime_matplotlib.py) | Live matplotlib oscilloscope with sinusoidal reference |
+| [`advanced/04_realtime_matplotlib.py`](examples/advanced/04_realtime_matplotlib.py) | Live matplotlib oscilloscope |
 | [`advanced/05_digital_twin.py`](examples/advanced/05_digital_twin.py) | Digital twin with mechanical wear detection |
-| [`quickstart.ipynb`](examples/quickstart.ipynb) | Interactive Jupyter notebook walkthrough |
+| [`quickstart_en.ipynb`](examples/quickstart_en.ipynb) | Interactive Jupyter notebook walkthrough |
 
 ---
 
@@ -165,25 +204,26 @@ agent = HardwareAgent("hw", hw, bus, sync)
 
 ```
 synapsys/
-├── api/            # MATLAB-compatible façade (tf, ss, c2d, step, bode, …)
+├── api/            # MATLAB-compatible façade  (tf, ss, c2d, step, bode, …)
 ├── core/           # LTI math — TransferFunction, StateSpace, LTIModel
-├── algorithms/     # PID, LQR
+├── algorithms/     # PID (discrete, anti-windup), LQR (ARE solver)
 ├── agents/         # PlantAgent, ControllerAgent, HardwareAgent, SyncEngine
 ├── transport/      # SharedMemoryTransport, ZMQTransport, ZMQReqRepTransport
-└── hw/             # HardwareInterface (abstract) + MockHardwareInterface
+├── hw/             # HardwareInterface (abstract) + MockHardwareInterface
+└── utils/          # StateEquations, mat(), col(), row()
 ```
 
-The transport layer is the key abstraction: agents communicate exclusively through a `TransportStrategy` interface. Swapping the concrete transport (shared memory ↔ ZMQ ↔ real hardware) requires changing **one line** at the call site — algorithms and agents are untouched.
+The transport layer is the key abstraction: agents communicate exclusively through a `TransportStrategy` interface. Swapping the concrete transport (shared memory ↔ ZMQ ↔ real hardware) requires changing **one line** — algorithms and agents are untouched.
 
 ---
 
 ## Testing
 
 ```bash
-uv run pytest                          # run all tests
-uv run pytest --cov=synapsys           # with coverage report
-uv run mypy synapsys                   # type checking
-uv run ruff check synapsys tests       # linting
+uv run pytest                      # run all tests
+uv run pytest --cov=synapsys       # with coverage report
+uv run mypy synapsys               # type checking
+uv run ruff check synapsys tests   # linting
 ```
 
 | Metric | Value |
@@ -197,12 +237,12 @@ uv run ruff check synapsys tests       # linting
 
 ## Roadmap
 
-| Version | Planned features |
-|---------|-----------------|
-| **v0.1.0** | ✅ Current release — SISO LTI, PID, LQR, multi-agent, shared memory, ZMQ, hardware abstraction |
-| **v0.2** | MIMO systems, `margin()`, `rlocus()`, `pole_placement()` |
-| **v0.3** | State estimation — Kalman filter, Luenberger observer |
-| **v0.5** | Real hardware drivers (serial, CAN, FPGA via PYNQ) |
+| Version | Status | Planned features |
+|---------|--------|-----------------|
+| **v0.1.0** | ✅ Released | SISO LTI, PID, LQR, multi-agent, shared memory, ZMQ, hardware abstraction, Neural-LQR example |
+| **v0.2** | 🔜 Planned | MIMO systems, `margin()`, `rlocus()`, `pole_placement()` |
+| **v0.3** | 🔜 Planned | State estimation — Kalman filter, Luenberger observer |
+| **v0.5** | 🔜 Planned | Real hardware drivers (serial, CAN, FPGA via PYNQ) |
 
 See [CHANGELOG.md](CHANGELOG.md) for the full release history.
 
@@ -219,7 +259,6 @@ If you use Synapsys in academic work, please cite it as:
   title     = {Synapsys: A Python Framework for Modelling and
                Real-Time Simulation of Linear Control Systems},
   year      = {2026},
-  version   = {0.1.0},
   url       = {https://github.com/synapsys-lab/synapsys},
   license   = {MIT},
 }
@@ -228,18 +267,11 @@ If you use Synapsys in academic work, please cite it as:
 **APA**
 ```
 Farias, O. D., & contributors. (2026). Synapsys: A Python framework for
-modelling and real-time simulation of linear control systems (v0.1.0).
+modelling and real-time simulation of linear control systems.
 https://github.com/synapsys-lab/synapsys
 ```
 
-**LaTeX (plain)**
-```latex
-\bibitem{synapsys2026}
-O.~D. Farias and contributors,
-\textit{Synapsys: A Python Framework for Modelling and Real-Time Simulation
-of Linear Control Systems}, version~0.1.0, 2026.
-Available: \url{https://github.com/synapsys-lab/synapsys}
-```
+> For the version number, use the version shown on [PyPI](https://pypi.org/project/synapsys/).
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,15 +10,28 @@ readme = "README.md"
 license = { text = "MIT" }
 requires-python = ">=3.10"
 authors = [{ name = "synapsys contributors" }]
-keywords = ["control systems", "simulation", "multi-agent", "LTI", "state-space"]
+keywords = [
+    "control systems", "control theory", "simulation", "multi-agent",
+    "LTI", "state-space", "transfer function", "PID", "LQR",
+    "MATLAB", "scipy", "real-time", "distributed", "ZeroMQ", "SIL", "HIL",
+]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Science/Research",
+    "Intended Audience :: Education",
+    "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering",
+    "Topic :: Scientific/Engineering :: Mathematics",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: System :: Hardware",
+    "Typing :: Typed",
 ]
 dependencies = [
     "numpy>=1.24",
@@ -27,6 +40,7 @@ dependencies = [
 ]
 
 [project.urls]
+Homepage      = "https://synapsys-lab.github.io/synapsys/"
 Repository    = "https://github.com/synapsys-lab/synapsys"
 Documentation = "https://synapsys-lab.github.io/synapsys/"
 "Bug Tracker" = "https://github.com/synapsys-lab/synapsys/issues"

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -9,6 +9,10 @@ slug: /
 
 **Modern Python control systems framework with distributed multi-agent simulation.**
 
+[![PyPI version](https://img.shields.io/pypi/v/synapsys.svg?color=blue&label=PyPI)](https://pypi.org/project/synapsys/)
+[![Python](https://img.shields.io/pypi/pyversions/synapsys.svg)](https://pypi.org/project/synapsys/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/synapsys-lab/synapsys/blob/main/LICENSE)
+
 Synapsys is designed as a MATLAB-compatible alternative for control engineers who want:
 
 - A **clean Python API** that mirrors MATLAB/Simulink syntax


### PR DESCRIPTION
## Summary

- **README.md** — reescrito para funcionar corretamente no GitHub e no PyPI:
  - Logo e GIF com URLs absolutas (`raw.githubusercontent.com`) — obrigatório para o PyPI renderizar imagens
  - Seção **"See it in action"** com o GIF `03_sil_ai_controller.gif` animado (720px)
  - Badge `PyPI` mais proeminente, badge `Docs` adicionado
  - Links para docs, PyPI, GitHub, changelog logo no cabeçalho
  - Seção `StateEquations` adicionada ao Quickstart (novo módulo `utils`)
  - Tabela de Roadmap com coluna `Status` (✅ / 🔜)
  - Citação sem versão hardcoded — referencia o PyPI para a versão atual
  - `utils/` adicionado na árvore de arquitetura

- **pyproject.toml** — metadados PyPI melhorados:
  - `Homepage` URL adicionada
  - Keywords expandidas (16 termos de busca relevantes)
  - Classifiers expandidos: `Intended Audience :: Education/Developers`, `Operating System :: OS Independent`, `Typing :: Typed`, `Topic :: System :: Hardware`, `Topic :: Scientific/Engineering :: AI`

- **website/docs/intro.md** — badges de versão PyPI, Python e licença adicionados ao topo

## Result

- PyPI renderiza o GIF animado no topo da página do pacote
- GitHub README exibe o GIF + todos os badges corretamente
- Busca no PyPI por "control systems", "LQR", "PID", "MATLAB", "SIL", "HIL" encontra o pacote