### PR TITLE
feat(homepage): install columns, PyPI badge and remove replay button

### DIFF
--- a/website/src/components/MassSpringDamper.tsx
+++ b/website/src/components/MassSpringDamper.tsx
@@ -201,9 +201,6 @@ export default function MassSpringDamper() {
         </text>
       </svg>
 
-      <div className="msd-controls">
-        <button onClick={replay} className="msd-btn msd-btn--secondary">↺ Replay</button>
-      </div>
     </div>
   );
 }

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -176,6 +176,18 @@ h1, h2, h3, h4 { letter-spacing: -0.02em; }
   color: var(--text-muted);
 }
 
+.doc-badge--pypi {
+  background: rgba(37,99,235,0.10);
+  border-color: var(--brand-blue);
+  color: var(--brand-blue);
+  text-decoration: none;
+  transition: background 0.15s;
+}
+.doc-badge--pypi:hover {
+  background: rgba(37,99,235,0.18);
+  color: var(--brand-blue);
+}
+
 .doc-header__title {
   font-size: clamp(2rem, 5vw, 2.8rem);
   font-weight: 700;
@@ -192,24 +204,45 @@ h1, h2, h3, h4 { letter-spacing: -0.02em; }
   margin-bottom: 1.75rem;
 }
 
-.doc-header__install {
-  display: inline-flex;
-  align-items: center;
+/* ── Install columns ─────────────────────────────────────────────────────────── */
+.install-cols {
+  display: flex;
   gap: 0.75rem;
-  padding: 0.55rem 1rem;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  background: var(--ifm-background-surface-color);
-  font-family: var(--ifm-font-family-monospace);
-  font-size: 0.875rem;
+  flex-wrap: wrap;
   margin-bottom: 1.75rem;
-  color: var(--ifm-font-color-base);
 }
 
-.doc-header__sep {
-  color: var(--text-subtle);
-  font-family: var(--ifm-font-family-base);
-  font-size: 0.8rem;
+.install-col {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.6rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--ifm-background-surface-color);
+  min-width: 0;
+  flex: 1 1 160px;
+  transition: border-color 0.15s;
+}
+
+.install-col:hover { border-color: var(--brand-blue); }
+
+.install-col__label {
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--brand-blue);
+}
+
+.install-col__cmd {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.82rem;
+  color: var(--ifm-font-color-base);
+  background: none;
+  border: none;
+  padding: 0;
+  white-space: nowrap;
 }
 
 .doc-header__actions {
@@ -595,14 +628,9 @@ pre {
   .content-section    { padding: 2.5rem 1.25rem; }
   .nav-cards__section { padding: 1.25rem; }
 
-  /* Install bar: wrap and fill width on small screens */
-  .doc-header__install {
-    display: flex;
-    flex-wrap: wrap;
-    width: 100%;
-    box-sizing: border-box;
-    gap: 0.5rem 0.75rem;
-  }
+  /* Install columns: stack to 2-col on small screens */
+  .install-cols { gap: 0.5rem; }
+  .install-col  { flex: 1 1 calc(50% - 0.25rem); }
 
   /* Module table: horizontal scroll instead of overflow */
   .module-table {
@@ -616,9 +644,11 @@ pre {
   /* AI showcase: disable float animation (save battery, avoid jitter) */
   .ai-showcase__figure { animation: none; }
 
-  /* Action buttons: full-width row on very small screens */
+  /* Action buttons: wrap and fill on small screens */
   .doc-header__actions { gap: 0.5rem; }
   .doc-header__actions .btn { flex: 1 1 auto; justify-content: center; }
+  /* Install columns: single column on very small screens */
+  .install-col { flex: 1 1 100%; }
 }
 
 @media (max-width: 480px) {

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -16,10 +16,12 @@ import {
   GitBranch,
   ArrowRight,
   BrainCircuit,
+  Package,
   type LucideIcon,
 } from 'lucide-react';
 
 const GITHUB = 'https://github.com/synapsys-lab/synapsys';
+const PYPI   = 'https://pypi.org/project/synapsys/';
 
 // ── Quick-navigation cards ───────────────────────────���────────────────────────
 const NAV_CARDS: { Icon: LucideIcon; title: string; desc: string; href: string }[] = [
@@ -107,7 +109,7 @@ export default function Home(): ReactElement {
             {/* ── Content column ── */}
             <div className="doc-header__content-col">
               <div className="doc-header__meta">
-                <span className="doc-badge">v0.1.0</span>
+                <a href={PYPI} className="doc-badge doc-badge--pypi" target="_blank" rel="noreferrer">v0.1.0 · PyPI</a>
                 <span className="doc-badge doc-badge--neutral">Python 3.10+</span>
                 <span className="doc-badge doc-badge--neutral">MIT</span>
                 <a href={`${GITHUB}/actions`} className="doc-badge doc-badge--neutral" target="_blank" rel="noreferrer">CI passing</a>
@@ -124,10 +126,19 @@ export default function Home(): ReactElement {
                 </Translate>
               </p>
 
-              <div className="doc-header__install">
-                <code>pip install synapsys</code>
-                <span className="doc-header__sep">or</span>
-                <code>uv add synapsys</code>
+              <div className="install-cols">
+                <div className="install-col">
+                  <span className="install-col__label">pip</span>
+                  <code className="install-col__cmd">pip install synapsys</code>
+                </div>
+                <div className="install-col">
+                  <span className="install-col__label">uv</span>
+                  <code className="install-col__cmd">uv add synapsys</code>
+                </div>
+                <div className="install-col">
+                  <span className="install-col__label">dev</span>
+                  <code className="install-col__cmd">uv sync --extra dev</code>
+                </div>
               </div>
 
               <div className="doc-header__actions">
@@ -137,8 +148,8 @@ export default function Home(): ReactElement {
                 <Link className="btn btn--outline" to={GITHUB}>
                   <GitBranch size={15} /> GitHub
                 </Link>
-                <Link className="btn btn--outline" to="/docs/getting-started/quickstart">
-                  <Translate id="home.header.cta.quickstart">Quickstart</Translate>
+                <Link className="btn btn--outline" href={PYPI} target="_blank" rel="noreferrer">
+                  <Package size={15} /> PyPI
                 </Link>
               </div>
             </div>


### PR DESCRIPTION
- Remove botão ↺ Replay do MassSpringDamper (animação já faz loop automático)
- Seção de instalação redesenhada: 3 colunas (pip / uv / dev) com label colorido e hover
- Badge **v0.1.0 · PyPI** no cabeçalho com link para pypi.org/project/synapsys
- Botão **PyPI** adicionado nas actions do header (ao lado de Documentation e GitHub)
- CSS responsivo: 2 colunas em ≤768px, 1 coluna em ≤480px