### PR TITLE
feat(core): MIMO support — TransferFunctionMatrix, feedback, zeros (v0.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.2.0] — 2026-04-18
+
+### Added
+
+#### MIMO Support
+- `TransferFunctionMatrix` — MIMO transfer-function matrix `G(s)` of shape `(n_outputs × n_inputs)`, storing SISO `TransferFunction` elements at `G[i, j]`.
+  - Full operator algebra: element-wise `+` (parallel), matrix-multiply `*` (series), negation `-`.
+  - `to_state_space()` — block-diagonal minimal state-space realisation; zero-numerator elements are skipped to avoid scipy phantom states.
+  - `poles()`, `zeros()`, `is_stable()`, `simulate()`, `step()`, `bode()`.
+  - `from_arrays(num, den)` factory: supports shared denominator or per-element denominators.
+- `tf()` MIMO dispatch — `tf(num, den)` with 2-D `num` now returns a `TransferFunctionMatrix` (mirrors MATLAB `tf`).
+- `feedback()` MIMO support — `feedback(G)` and `feedback(G, H)` now accept `StateSpace` and `TransferFunctionMatrix` plants, returning a `StateSpace` closed-loop model.
+- Transmission zeros via Rosenbrock system-matrix pencil — replaces deprecated `scipy.signal.zpkdata`; correct for both SISO and MIMO state-space models.
+
+#### Validation
+- `lqr()` — added positive semi-definiteness check for `Q` (`eigvalsh` ≥ −1e-10); complements the existing Cholesky check on `R`.
+- `feedback()` — added sample-time (`dt`) mismatch guard between plant `G` and sensor `H`.
+- `series()` / `parallel()` — added guard against zero-argument calls.
+- `tf()` — added `TypeError` guard for `None` numerator or denominator.
+- `StateSpace.__mul__()` — added inner-dimension validation for series connection.
+- `StateSpace.zeros()` — added non-square plant guard with descriptive error message.
+- `StateSpace.to_transfer_function()` — added MIMO guard (raises `ValueError` for non-SISO plants).
+
+#### Type Annotations
+- `LTIModel.to_state_space()` and `LTIModel.to_transfer_function()` now declare covariant return types (`StateSpace` and `TransferFunction`) via `TYPE_CHECKING` imports, enabling accurate static analysis with mypy/pyright.
+
+### Changed
+- Test suite expanded from 74 to 184 tests; coverage increased from 86 % to 90 %.
+
+### Known Limitations
+- **No advanced frequency-domain tools** — `margin()`, `rlocus()`, `pole_placement()` planned for v0.3.
+- **No state estimation** — Kalman filter and Luenberger observer planned for v0.3.
+- **No hardware implementations** — `HardwareInterface` subclasses for real hardware planned for v0.5.
+- **Race-condition caveat** — `SharedMemoryTransport` has no internal mutex; architect channels so that each process is the sole writer of its own channel.
+
+---
+
 ## [0.1.0] — 2026-04-11
 
 ### Added
@@ -60,4 +97,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **No hardware implementations** — `HardwareInterface` subclasses for real hardware are planned for v0.5.
 - **Race-condition caveat** — `SharedMemoryTransport` has no internal mutex; architect channels so that each process is the sole writer of its own channel.
 
+[0.2.0]: https://github.com/synapsys-lab/synapsys/releases/tag/v0.2.0
 [0.1.0]: https://github.com/synapsys-lab/synapsys/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Python](https://img.shields.io/pypi/pyversions/synapsys.svg)](https://pypi.org/project/synapsys/)
 [![Docs](https://img.shields.io/badge/docs-synapsys--lab.github.io-blue)](https://synapsys-lab.github.io/synapsys/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![Coverage](https://img.shields.io/badge/coverage-86%25-brightgreen.svg)](#testing)
+[![Coverage](https://img.shields.io/badge/coverage-90%25-brightgreen.svg)](#testing)
 [![Code style: ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
 [📖 Documentation](https://synapsys-lab.github.io/synapsys/) · [🚀 Quickstart](#quickstart) · [📦 PyPI](https://pypi.org/project/synapsys/) · [💡 Examples](examples/) · [📋 Changelog](CHANGELOG.md)
@@ -25,12 +25,20 @@
 Synapsys is an open-source Python library for **modelling, simulating, and deploying control systems**. It provides a **MATLAB-compatible API** built on SciPy, a modern **multi-agent simulation framework**, and a pluggable **transport layer** (shared memory / ZeroMQ) that scales from a single laptop to distributed lab setups.
 
 ```python
-from synapsys.api import tf, feedback, step, c2d
+from synapsys.api import tf, ss, feedback, step, c2d
 
+# SISO
 G    = tf([1], [1, 2, 1])    # G(s) = 1 / (s² + 2s + 1)
 T    = feedback(G)            # closed-loop: T = G / (1 + G)
 t, y = step(T)                # step response
 Gd   = c2d(G, dt=0.02)       # ZOH discretisation at 50 Hz
+
+# MIMO
+G_mimo = tf([[[ 1], [0]],     # 2×2 transfer-function matrix
+             [[ 0], [1]]],
+            [[[1,1],[1]],
+             [[1],[1,2]]])
+T_mimo = feedback(G_mimo)     # state-space closed-loop
 ```
 
 ```bash
@@ -56,8 +64,9 @@ Neural-LQR controller on a 2-DOF mass-spring-damper — MLP initialized with LQR
 | Feature | Description |
 |---------|-------------|
 | ⚡ **MATLAB-Compatible API** | `tf()`, `ss()`, `c2d()`, `step()`, `bode()`, `feedback()`, `lsim()` — same names, pure Python |
-| 📐 **LTI Core** | `TransferFunction` and `StateSpace` with operator overloading, poles, zeros, stability |
-| 🧮 **Control Algorithms** | Discrete PID with anti-windup · LQR via algebraic Riccati equation |
+| 📐 **LTI Core** | `TransferFunction`, `StateSpace`, and `TransferFunctionMatrix` with operator overloading, poles, zeros, stability |
+| 🔀 **MIMO Support** | `TransferFunctionMatrix` for multi-input multi-output plants · MIMO `feedback()` · transmission zeros via Rosenbrock pencil |
+| 🧮 **Control Algorithms** | Discrete PID with anti-windup · LQR via algebraic Riccati equation (Q/R validated) |
 | 🤖 **Multi-Agent Simulation** | `PlantAgent` and `ControllerAgent` with lock-step and wall-clock sync |
 | 🔗 **Pluggable Transport** | Zero-copy shared memory (single-host) · ZeroMQ PUB/SUB and REQ/REP (distributed) |
 | 🔌 **Hardware Abstraction** | `HardwareInterface` contract enables seamless MIL → SIL → HIL transitions |
@@ -90,7 +99,7 @@ uv sync --extra dev
 ```python
 from synapsys.api import tf, ss, bode, feedback, c2d
 
-# Second-order transfer function
+# SISO second-order transfer function
 G = tf([1], [1, 2, 1])
 
 # Closed-loop with unity negative feedback
@@ -101,6 +110,13 @@ w, mag, phase = bode(G)
 
 # ZOH discretisation at 50 Hz
 Gd = c2d(G, dt=0.02)
+
+# MIMO: 2×2 transfer-function matrix
+G_mimo = tf(
+    [[[1], [0]], [[0], [1]]],           # numerators
+    [[[1, 1], [1]], [[1], [1, 2]]],     # denominators
+)
+T_mimo = feedback(G_mimo)               # returns StateSpace
 ```
 
 ### 2 · Control algorithms
@@ -204,8 +220,8 @@ agent = HardwareAgent("hw", hw, bus, sync)
 
 ```
 synapsys/
-├── api/            # MATLAB-compatible façade  (tf, ss, c2d, step, bode, …)
-├── core/           # LTI math — TransferFunction, StateSpace, LTIModel
+├── api/            # MATLAB-compatible façade  (tf, ss, c2d, step, bode, feedback, …)
+├── core/           # LTI math — TransferFunction, StateSpace, TransferFunctionMatrix, LTIModel
 ├── algorithms/     # PID (discrete, anti-windup), LQR (ARE solver)
 ├── agents/         # PlantAgent, ControllerAgent, HardwareAgent, SyncEngine
 ├── transport/      # SharedMemoryTransport, ZMQTransport, ZMQReqRepTransport
@@ -228,8 +244,8 @@ uv run ruff check synapsys tests   # linting
 
 | Metric | Value |
 |--------|-------|
-| Test suite | 74 tests |
-| Coverage | 86 % |
+| Test suite | 184 tests |
+| Coverage | 90 % |
 | Type checking | mypy strict — 0 errors |
 | Python versions | 3.10 · 3.11 · 3.12 |
 
@@ -237,11 +253,11 @@ uv run ruff check synapsys tests   # linting
 
 ## Roadmap
 
-| Version | Status | Planned features |
-|---------|--------|-----------------|
+| Version | Status | Features |
+|---------|--------|---------|
 | **v0.1.0** | ✅ Released | SISO LTI, PID, LQR, multi-agent, shared memory, ZMQ, hardware abstraction, Neural-LQR example |
-| **v0.2** | 🔜 Planned | MIMO systems, `margin()`, `rlocus()`, `pole_placement()` |
-| **v0.3** | 🔜 Planned | State estimation — Kalman filter, Luenberger observer |
+| **v0.2.0** | ✅ Released | MIMO support — `TransferFunctionMatrix`, MIMO `feedback()`, transmission zeros (Rosenbrock pencil), LQR Q/R validation, covariant LTI type annotations |
+| **v0.3** | 🔜 Planned | `margin()`, `rlocus()`, `pole_placement()` · State estimation — Kalman filter, Luenberger observer |
 | **v0.5** | 🔜 Planned | Real hardware drivers (serial, CAN, FPGA via PYNQ) |
 
 See [CHANGELOG.md](CHANGELOG.md) for the full release history.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "synapsys"
-version = "0.1.0"
+version = "0.2.0"
 description = "Modern Python control systems framework with distributed multi-agent simulation"
 readme = "README.md"
 license = { text = "MIT" }

--- a/synapsys/__init__.py
+++ b/synapsys/__init__.py
@@ -19,6 +19,7 @@ from synapsys.api.matlab_compat import (
 )
 from synapsys.core.state_space import StateSpace
 from synapsys.core.transfer_function import TransferFunction
+from synapsys.core.transfer_function_matrix import TransferFunctionMatrix
 from synapsys.utils import StateEquations, col, mat, row
 
 __all__ = [
@@ -35,6 +36,7 @@ __all__ = [
     "c2d",
     # Core classes
     "TransferFunction",
+    "TransferFunctionMatrix",
     "StateSpace",
     # Algorithms
     "PID",

--- a/synapsys/algorithms/lqr.py
+++ b/synapsys/algorithms/lqr.py
@@ -30,6 +30,14 @@ def lqr(
     Q = np.atleast_2d(np.asarray(Q, dtype=np.float64))
     R = np.atleast_2d(np.asarray(R, dtype=np.float64))
 
+    # Q must be positive semi-definite
+    eigvals_Q = np.linalg.eigvalsh(Q)
+    if np.any(eigvals_Q < -1e-10):
+        raise ValueError(
+            "Q must be positive semi-definite. "
+            f"Got Q with eigenvalues {eigvals_Q.tolist()}"
+        )
+
     # R must be positive definite — Cholesky is the canonical check
     try:
         linalg.cholesky(R)

--- a/synapsys/api/matlab_compat.py
+++ b/synapsys/api/matlab_compat.py
@@ -11,14 +11,35 @@ from scipy import signal as _signal
 
 from ..core.state_space import StateSpace
 from ..core.transfer_function import TransferFunction
+from ..core.transfer_function_matrix import TransferFunctionMatrix
 
 
-def tf(num: object, den: object, dt: float = 0.0) -> TransferFunction:
-    """Create a transfer function.  Mirrors ``tf()`` in MATLAB.
+def tf(
+    num: object, den: object, dt: float = 0.0
+) -> TransferFunction | TransferFunctionMatrix:
+    """Create a transfer function or MIMO transfer-function matrix.
+
+    * 1-D ``num``  → SISO ``TransferFunction``.
+    * 2-D ``num``  → MIMO ``TransferFunctionMatrix`` (mirrors MATLAB ``tf``).
 
     Args:
         dt: Sample period > 0 creates a discrete-time system.
+
+    Raises:
+        TypeError: if ``num`` or ``den`` is ``None``.
     """
+    if num is None or den is None:
+        raise TypeError(
+            "tf() requires non-None num and den; "
+            f"got num={num!r}, den={den!r}."
+        )
+    try:
+        is_mimo = hasattr(num[0], "__iter__")  # type: ignore[index]
+    except (TypeError, IndexError):
+        is_mimo = False
+
+    if is_mimo:
+        return TransferFunctionMatrix.from_arrays(num, den, dt=dt)  # type: ignore[arg-type]
     return TransferFunction(num, den, dt=dt)
 
 
@@ -93,19 +114,98 @@ def bode(
 
 
 def feedback(
-    G: TransferFunction | StateSpace,
-    H: TransferFunction | None = None,
-) -> TransferFunction:
-    """Closed-loop with negative feedback.  Mirrors ``feedback()`` in MATLAB."""
-    if not isinstance(G, TransferFunction):
-        G = G.to_transfer_function()
-    return G.feedback(H)
+    G: TransferFunction | StateSpace | TransferFunctionMatrix,
+    H: TransferFunction | StateSpace | None = None,
+) -> TransferFunction | StateSpace:
+    """Closed-loop T = G(I + HG)⁻¹ with negative feedback.
+
+    * ``G`` is ``TransferFunction`` → polynomial algebra, returns ``TransferFunction``.
+    * ``G`` is ``StateSpace`` or ``TransferFunctionMatrix`` → state-space
+      interconnection, returns ``StateSpace``.
+      Unity feedback (``H=None``) requires a square plant (n_inputs == n_outputs).
+    """
+    if isinstance(G, TransferFunction):
+        if H is not None and not isinstance(H, TransferFunction):
+            H = H.to_transfer_function()
+        return G.feedback(H)
+
+    # G is StateSpace or TransferFunctionMatrix — convert to SS
+    G_ss: StateSpace = G if isinstance(G, StateSpace) else G.to_state_space()
+
+    # Build H as a StateSpace (handling static TF to avoid scipy phantom state)
+    H_ss: StateSpace | None = None
+    if H is not None:
+        if isinstance(H, StateSpace):
+            H_ss = H
+        elif isinstance(H, TransferFunction) and H.n_states == 0:
+            # Static gain: build true 0-state SS directly to avoid scipy's
+            # spurious 1-state realisation of a constant TF.
+            gain = float(H.num[0]) / float(H.den[0])
+            H_ss = StateSpace(
+                np.zeros((0, 0)),
+                np.zeros((0, H.n_inputs)),
+                np.zeros((H.n_outputs, 0)),
+                np.array([[gain]]),
+                dt=H.dt,
+            )
+        else:
+            H_ss = H.to_state_space()
+
+    return _ss_feedback(G_ss, H_ss)
+
+
+def _ss_feedback(G: StateSpace, H: StateSpace | None) -> StateSpace:
+    """State-space closed-loop for negative feedback T = G(I + HG)⁻¹.
+
+    Handles H with n_states=0 (static sensor) via block-matrix broadcasting:
+    the zero-dimensional state blocks vanish from the augmented system.
+    """
+    Ag, Bg, Cg, Dg = G.A, G.B, G.C, G.D
+    m, p = G.n_inputs, G.n_outputs
+
+    if H is None:
+        # Unity feedback: H = I (static, no sensor dynamics)
+        if m != p:
+            raise ValueError(
+                f"Unity feedback requires a square plant "
+                f"(n_inputs == n_outputs), got n_inputs={m}, n_outputs={p}."
+            )
+        M = np.eye(m) + Dg
+        Minv = np.linalg.inv(M)
+        A_cl = Ag - Bg @ Minv @ Cg
+        B_cl = Bg @ Minv
+        C_cl = Minv @ Cg
+        D_cl = Dg @ Minv
+        return StateSpace(A_cl, B_cl, C_cl, D_cl, dt=G.dt)
+
+    # General sensor H — validate dt compatibility
+    if H.dt != G.dt:
+        raise ValueError(
+            f"G and H must share the same sample time "
+            f"(G.dt={G.dt}, H.dt={H.dt})."
+        )
+
+    # H maps plant output (p) to error signal (m): H.n_inputs=p, H.n_outputs=m
+    Ah, Bh, Ch, Dh = H.A, H.B, H.C, H.D
+    M = np.eye(m) + Dh @ Dg   # m×m
+    Minv = np.linalg.inv(M)
+    # Augmented state z = [x_g; x_h]  (x_h may be empty for static H)
+    A_cl = np.block([
+        [Ag - Bg @ Minv @ Dh @ Cg,  -Bg @ Minv @ Ch],
+        [Bh @ (Cg - Dg @ Minv @ Dh @ Cg),  Ah - Bh @ Dg @ Minv @ Ch],
+    ])
+    B_cl = np.vstack([Bg @ Minv, Bh @ Dg @ Minv])
+    C_cl = np.hstack([Cg - Dg @ Minv @ Dh @ Cg, -Dg @ Minv @ Ch])
+    D_cl = Dg @ Minv
+    return StateSpace(A_cl, B_cl, C_cl, D_cl, dt=G.dt)
 
 
 def series(
     *systems: TransferFunction | StateSpace,
 ) -> TransferFunction | StateSpace:
     """Connect systems in series.  Mirrors ``series()`` in MATLAB."""
+    if not systems:
+        raise ValueError("series() requires at least one system.")
     result = systems[0]
     for sys in systems[1:]:
         result = result * sys  # type: ignore[operator]
@@ -116,6 +216,8 @@ def parallel(
     *systems: TransferFunction | StateSpace,
 ) -> TransferFunction | StateSpace:
     """Connect systems in parallel.  Mirrors ``parallel()`` in MATLAB."""
+    if not systems:
+        raise ValueError("parallel() requires at least one system.")
     result = systems[0]
     for sys in systems[1:]:
         result = result + sys  # type: ignore[operator]

--- a/synapsys/core/__init__.py
+++ b/synapsys/core/__init__.py
@@ -1,5 +1,6 @@
 from .lti import LTIModel
 from .state_space import StateSpace
 from .transfer_function import TransferFunction
+from .transfer_function_matrix import TransferFunctionMatrix
 
-__all__ = ["LTIModel", "StateSpace", "TransferFunction"]
+__all__ = ["LTIModel", "StateSpace", "TransferFunction", "TransferFunctionMatrix"]

--- a/synapsys/core/lti.py
+++ b/synapsys/core/lti.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 
 import numpy as np
+
+if TYPE_CHECKING:
+    from .state_space import StateSpace
+    from .transfer_function import TransferFunction
 
 
 class LTIModel(ABC):
@@ -30,10 +35,10 @@ class LTIModel(ABC):
     def is_stable(self) -> bool: ...
 
     @abstractmethod
-    def to_state_space(self) -> "LTIModel": ...
+    def to_state_space(self) -> "StateSpace": ...
 
     @abstractmethod
-    def to_transfer_function(self) -> "LTIModel": ...
+    def to_transfer_function(self) -> "TransferFunction": ...
 
     @staticmethod
     def _as_2d(data: object, shape: tuple[int, int] | None = None) -> np.ndarray:

--- a/synapsys/core/state_space.py
+++ b/synapsys/core/state_space.py
@@ -126,7 +126,7 @@ class StateSpace(LTIModel):
             ]
         )
         eigs = linalg.eigvals(A_ext, E)
-        return eigs[np.isfinite(eigs)]
+        return eigs[np.isfinite(eigs)]  # type: ignore[no-any-return]
 
     def is_stable(self) -> bool:
         p = self.poles()

--- a/synapsys/core/state_space.py
+++ b/synapsys/core/state_space.py
@@ -98,12 +98,35 @@ class StateSpace(LTIModel):
         return np.asarray(linalg.eigvals(self._A))
 
     def zeros(self) -> np.ndarray:
-        if self.is_discrete:
-            sys = signal.dlti(self._A, self._B, self._C, self._D, dt=self._dt)
-        else:
-            sys = signal.StateSpace(self._A, self._B, self._C, self._D)
-        _, z, _ = signal.zpkdata(sys, input=0)
-        return np.array(z[0]) if z else np.array([])
+        """Transmission zeros via the Rosenbrock system matrix.
+
+        Returns finite eigenvalues of the generalised pencil
+        (A_ext, E) where A_ext = [[A, B], [C, D]] and
+        E = [[I_n, 0], [0, 0]].  Works for SISO and MIMO systems.
+
+        Requires a **square** plant (n_inputs == n_outputs) and a
+        **minimal** realisation.  Non-minimal realisations may produce
+        spurious zeros corresponding to uncontrollable or unobservable
+        modes.
+        """
+        n, m, p = self.n_states, self.n_inputs, self.n_outputs
+        if m != p:
+            raise ValueError(
+                f"zeros() requires a square plant "
+                f"(n_inputs == n_outputs); "
+                f"got n_inputs={m}, n_outputs={p}."
+            )
+        if n == 0:
+            return np.array([], dtype=complex)
+        A_ext = np.block([[self._A, self._B], [self._C, self._D]])
+        E = np.block(
+            [
+                [np.eye(n), np.zeros((n, m))],
+                [np.zeros((p, n)), np.zeros((p, m))],
+            ]
+        )
+        eigs = linalg.eigvals(A_ext, E)
+        return eigs[np.isfinite(eigs)]
 
     def is_stable(self) -> bool:
         p = self.poles()
@@ -119,6 +142,13 @@ class StateSpace(LTIModel):
         return self
 
     def to_transfer_function(self) -> TransferFunction:
+        if self.n_inputs != 1 or self.n_outputs != 1:
+            raise ValueError(
+                f"to_transfer_function() requires a SISO system "
+                f"(n_inputs=1, n_outputs=1); "
+                f"got n_inputs={self.n_inputs}, n_outputs={self.n_outputs}. "
+                f"Use StateSpace directly for MIMO systems."
+            )
         from .transfer_function import TransferFunction
 
         if self.is_discrete:
@@ -229,6 +259,12 @@ class StateSpace(LTIModel):
         if not isinstance(other, StateSpace):
             other = other.to_state_space()
         self._check_compatible(other)
+        if self.n_inputs != other.n_outputs:
+            raise ValueError(
+                f"Series connection requires compatible inner dimensions "
+                f"(self.n_inputs={self.n_inputs} must equal "
+                f"other.n_outputs={other.n_outputs})."
+            )
         A = np.block([
             [other._A, np.zeros((other.n_states, self.n_states))],
             [self._B @ other._C, self._A],

--- a/synapsys/core/transfer_function_matrix.py
+++ b/synapsys/core/transfer_function_matrix.py
@@ -146,7 +146,7 @@ class TransferFunctionMatrix(LTIModel):
         true Smith-McMillan poles of the transfer-function matrix.
         Use ``to_state_space().poles()`` for the true system poles.
         """
-        all_poles = np.concatenate([
+        all_poles: np.ndarray = np.concatenate([
             self._tfs[i][j].poles()
             for i in range(self._p)
             for j in range(self._m)

--- a/synapsys/core/transfer_function_matrix.py
+++ b/synapsys/core/transfer_function_matrix.py
@@ -4,7 +4,6 @@ from functools import reduce
 from typing import TYPE_CHECKING
 
 import numpy as np
-from scipy import linalg
 
 from .lti import LTIModel
 from .transfer_function import TransferFunction
@@ -193,8 +192,8 @@ class TransferFunctionMatrix(LTIModel):
             ]
             for i in range(p)
         ]
-        n_total = sum(
-            0 if ss_elems[i][j] is None else ss_elems[i][j].n_states  # type: ignore[union-attr]
+        n_total: int = sum(
+            0 if ss_elems[i][j] is None else ss_elems[i][j].n_states  # type: ignore[union-attr, misc]
             for i in range(p)
             for j in range(m)
         )

--- a/synapsys/core/transfer_function_matrix.py
+++ b/synapsys/core/transfer_function_matrix.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+from functools import reduce
+from typing import TYPE_CHECKING
+
+import numpy as np
+from scipy import linalg
+
+from .lti import LTIModel
+from .transfer_function import TransferFunction
+
+if TYPE_CHECKING:
+    from .state_space import StateSpace
+
+
+class TransferFunctionMatrix(LTIModel):
+    """
+    MIMO transfer-function matrix G(s) of shape (n_outputs × n_inputs).
+
+    Internally stores a 2-D list of SISO TransferFunction objects where
+    ``tfs[i][j]`` is the transfer function from input j to output i.
+
+    For simulation and analysis that require a state-space realisation
+    (zeros, step, simulate, evolve) the class converts lazily via
+    ``to_state_space()``.
+    """
+
+    def __init__(self, tfs: list[list[TransferFunction]]) -> None:
+        if not tfs or not tfs[0]:
+            raise ValueError("tfs must be a non-empty 2-D list of TransferFunction.")
+        p = len(tfs)
+        m = len(tfs[0])
+        for row in tfs:
+            if len(row) != m:
+                raise ValueError(
+                    f"All rows must have the same number of columns ({m}), "
+                    f"got a row with {len(row)}."
+                )
+        dt = tfs[0][0].dt
+        for row in tfs:
+            for tf in row:
+                if tf.dt != dt:
+                    raise ValueError(
+                        f"All elements must share the same dt "
+                        f"(expected {dt}, got {tf.dt})."
+                    )
+        self._tfs: list[list[TransferFunction]] = tfs
+        self._p = p
+        self._m = m
+        self._dt = dt
+
+    # ------------------------------------------------------------------
+    # Factory
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_arrays(
+        cls,
+        num: list,
+        den: object,
+        dt: float = 0.0,
+    ) -> TransferFunctionMatrix:
+        """Build from nested coefficient lists.
+
+        Args:
+            num: 2-D list ``num[i][j]`` of polynomial coefficients for each
+                 element.  A scalar or 1-D sequence is promoted to ``[value]``.
+            den: Either a single 1-D sequence (shared denominator for all
+                 elements) or a 2-D list ``den[i][j]`` of per-element
+                 denominators.  Per-element is detected when ``den[0][0]``
+                 is itself a sequence.
+            dt:  Sample period (0 = continuous).
+        """
+        p = len(num)
+        m = len(num[0])
+        # Per-element: den[0] is a row and den[0][0] is a coefficient list.
+        # Shared: den is a flat coefficient list (den[0] is a number).
+        try:
+            per_element = (
+                hasattr(den[0], "__iter__")  # type: ignore[index]
+                and hasattr(den[0][0], "__iter__")  # type: ignore[index]
+            )
+        except (TypeError, IndexError):
+            per_element = False
+
+        tfs: list[list[TransferFunction]] = []
+        for i in range(p):
+            row: list[TransferFunction] = []
+            for j in range(m):
+                n_ij = num[i][j]
+                d_ij = den[i][j] if per_element else den  # type: ignore[index]
+                row.append(TransferFunction(n_ij, d_ij, dt=dt))
+            tfs.append(row)
+        return cls(tfs)
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    @property
+    def n_outputs(self) -> int:
+        return self._p
+
+    @property
+    def n_inputs(self) -> int:
+        return self._m
+
+    @property
+    def n_states(self) -> int:
+        # Zero-numerator elements contribute 0 states to the SS realisation
+        # (scipy would give a spurious 1-state system; to_state_space() skips them).
+        return sum(
+            0 if np.allclose(self._tfs[i][j].num, 0.0) else self._tfs[i][j].n_states
+            for i in range(self._p)
+            for j in range(self._m)
+        )
+
+    @property
+    def dt(self) -> float:
+        return self._dt
+
+    @property
+    def is_discrete(self) -> bool:
+        return self._dt > 0.0
+
+    # ------------------------------------------------------------------
+    # Item access
+    # ------------------------------------------------------------------
+
+    def __getitem__(self, idx: tuple[int, int]) -> TransferFunction:
+        i, j = idx
+        if i >= self._p or j >= self._m or i < 0 or j < 0:
+            raise IndexError(
+                f"Index ({i}, {j}) out of range for "
+                f"({self._p}×{self._m}) TransferFunctionMatrix."
+            )
+        return self._tfs[i][j]
+
+    # ------------------------------------------------------------------
+    # LTIModel interface
+    # ------------------------------------------------------------------
+
+    def poles(self) -> np.ndarray:
+        """Element-wise union of all poles (may contain repeats).
+
+        For a coupled (non-diagonal) MIMO plant these are **not** the
+        true Smith-McMillan poles of the transfer-function matrix.
+        Use ``to_state_space().poles()`` for the true system poles.
+        """
+        all_poles = np.concatenate([
+            self._tfs[i][j].poles()
+            for i in range(self._p)
+            for j in range(self._m)
+        ])
+        return all_poles
+
+    def zeros(self) -> np.ndarray:
+        """Transmission zeros via the Rosenbrock system matrix of the SS realisation."""
+        return self.to_state_space().zeros()
+
+    def is_stable(self) -> bool:
+        """True when every element is stable (element-wise check).
+
+        For coupled MIMO plants this is a necessary but not sufficient
+        condition.  Use ``to_state_space().is_stable()`` for a rigorous test.
+        """
+        return all(
+            self._tfs[i][j].is_stable()
+            for i in range(self._p)
+            for j in range(self._m)
+        )
+
+    def to_state_space(self) -> StateSpace:
+        """Minimal state-space realisation via independent element realisations.
+
+        The combined state vector is ordered as
+        [x_00, x_01, …, x_0m, x_10, …, x_pm].
+        Each element contributes its own state block driven by the j-th
+        input and feeding only the i-th output.
+        """
+        from .state_space import StateSpace
+
+        p, m = self._p, self._m
+        # Convert only non-zero elements — zero-numerator TFs contribute only
+        # a D term and must be skipped to avoid the spurious 1-state scipy
+        # realisation of G(s)=0, which would add phantom zero eigenvalues to
+        # the Rosenbrock pencil used in zeros().
+        ss_elems: list[list[StateSpace | None]] = [
+            [
+                None if np.allclose(self._tfs[i][j].num, 0.0)
+                else self._tfs[i][j].to_state_space()
+                for j in range(m)
+            ]
+            for i in range(p)
+        ]
+        n_total = sum(
+            0 if ss_elems[i][j] is None else ss_elems[i][j].n_states  # type: ignore[union-attr]
+            for i in range(p)
+            for j in range(m)
+        )
+
+        A = np.zeros((n_total, n_total))
+        B = np.zeros((n_total, m))
+        C = np.zeros((p, n_total))
+        D = np.zeros((p, m))
+
+        idx = 0
+        for i in range(p):
+            for j in range(m):
+                ss = ss_elems[i][j]
+                if ss is None:
+                    D[i, j] = 0.0
+                    continue
+                n = ss.n_states
+                if n > 0:
+                    A[idx : idx + n, idx : idx + n] = ss.A
+                    B[idx : idx + n, j : j + 1] = ss.B
+                    C[i : i + 1, idx : idx + n] = ss.C
+                D[i, j] = float(ss.D.flat[0])
+                idx += n
+
+        return StateSpace(A, B, C, D, dt=self._dt)
+
+    # ------------------------------------------------------------------
+    # Simulation (delegates to StateSpace realisation)
+    # ------------------------------------------------------------------
+
+    def simulate(
+        self, t: np.ndarray, u: np.ndarray
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Simulate response to input ``u`` over time ``t``. Returns ``(t, y)``."""
+        return self.to_state_space().simulate(t, u)
+
+    def step(
+        self, t: np.ndarray | None = None, n: int = 200
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Step response.  For discrete systems ``n`` sets the number of samples."""
+        return self.to_state_space().step(t, n=n)
+
+    def bode(
+        self, omega: np.ndarray | None = None
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """Bode diagram.  Returns ``(omega [rad/s], mag [dB], phase [deg])``."""
+        return self.to_state_space().bode(omega)
+
+    def to_transfer_function(self) -> TransferFunction:
+        if self._p != 1 or self._m != 1:
+            raise ValueError(
+                f"to_transfer_function() requires a SISO (1×1) matrix, "
+                f"got ({self._p}×{self._m}). "
+                f"Use to_state_space() for MIMO systems."
+            )
+        return self._tfs[0][0]
+
+    # ------------------------------------------------------------------
+    # Algebra
+    # ------------------------------------------------------------------
+
+    def __neg__(self) -> TransferFunctionMatrix:
+        return TransferFunctionMatrix([
+            [-self._tfs[i][j] for j in range(self._m)]
+            for i in range(self._p)
+        ])
+
+    def __add__(self, other: TransferFunctionMatrix) -> TransferFunctionMatrix:
+        """Parallel connection — element-wise addition."""
+        if not isinstance(other, TransferFunctionMatrix):
+            raise TypeError(f"Cannot add TransferFunctionMatrix and {type(other)}")
+        if (self._p, self._m) != (other._p, other._m):
+            raise ValueError(
+                f"Incompatible shape for parallel connection: "
+                f"({self._p}×{self._m}) vs ({other._p}×{other._m})."
+            )
+        return TransferFunctionMatrix([
+            [self._tfs[i][j] + other._tfs[i][j] for j in range(self._m)]
+            for i in range(self._p)
+        ])
+
+    def __mul__(self, other: TransferFunctionMatrix) -> TransferFunctionMatrix:
+        """Series connection — matrix multiplication G_self @ G_other."""
+        if not isinstance(other, TransferFunctionMatrix):
+            raise TypeError(f"Cannot multiply TransferFunctionMatrix and {type(other)}")
+        if self._m != other._p:
+            raise ValueError(
+                f"Incompatible inner dimensions for series connection: "
+                f"({self._p}×{self._m}) * ({other._p}×{other._m})."
+            )
+        result: list[list[TransferFunction]] = []
+        for i in range(self._p):
+            row: list[TransferFunction] = []
+            for k in range(other._m):
+                elem = reduce(
+                    lambda a, b: a + b,
+                    (self._tfs[i][j] * other._tfs[j][k] for j in range(self._m)),
+                )
+                row.append(elem)
+            result.append(row)
+        return TransferFunctionMatrix(result)
+
+    # ------------------------------------------------------------------
+    # Repr
+    # ------------------------------------------------------------------
+
+    def __repr__(self) -> str:
+        domain = f"dt={self._dt}" if self.is_discrete else "continuous"
+        return (
+            f"TransferFunctionMatrix({self._p}×{self._m}, {domain})"
+        )

--- a/tests/algorithms/test_lqr.py
+++ b/tests/algorithms/test_lqr.py
@@ -91,3 +91,21 @@ class TestLQR:
         R_neg = np.array([[-1.0]])
         with pytest.raises(ValueError, match="positive definite"):
             lqr(A, B, Q, R_neg)
+
+    def test_indefinite_Q_raises(self):
+        """Indefinite Q (negative eigenvalue) must raise ValueError."""
+        A = np.array([[-1.0]])
+        B = np.array([[1.0]])
+        Q = np.array([[-1.0]])  # negative definite
+        R = np.array([[1.0]])
+        with pytest.raises(ValueError, match="positive semi-definite"):
+            lqr(A, B, Q, R)
+
+    def test_positive_semidefinite_Q_accepted(self):
+        """Q=0 (zero matrix) is positive semi-definite and must be accepted."""
+        A = np.array([[-1.0]])
+        B = np.array([[1.0]])
+        Q = np.array([[0.0]])
+        R = np.array([[1.0]])
+        K, P = lqr(A, B, Q, R)
+        assert K.shape == (1, 1)

--- a/tests/api/test_feedback.py
+++ b/tests/api/test_feedback.py
@@ -1,0 +1,125 @@
+import numpy as np
+import pytest
+
+from synapsys.core.state_space import StateSpace
+from synapsys.core.transfer_function import TransferFunction
+from synapsys.api.matlab_compat import feedback
+
+
+class TestFeedback:
+    # ------------------------------------------------------------------
+    # Regression: existing TransferFunction SISO behaviour must be intact
+    # ------------------------------------------------------------------
+
+    def test_tf_siso_unity_feedback_dc_gain(self):
+        # G = 10/(s+1), T = 10/(s+11): DC gain = 10/11
+        G = TransferFunction([10], [1, 1])
+        T = feedback(G)
+        assert isinstance(T, TransferFunction)
+        _, y = T.step()
+        np.testing.assert_allclose(y[-1], 10 / 11, atol=1e-3)
+
+    def test_tf_siso_sensor_feedback(self):
+        # G = 1/(s+1), H = 2: T = G/(1+2G) = 1/(s+3): DC gain = 1/3
+        G = TransferFunction([1], [1, 1])
+        H = TransferFunction([2], [1])
+        T = feedback(G, H)
+        assert isinstance(T, TransferFunction)
+        _, y = T.step()
+        np.testing.assert_allclose(y[-1], 1 / 3, atol=1e-3)
+
+    # ------------------------------------------------------------------
+    # StateSpace SISO unity feedback
+    # ------------------------------------------------------------------
+
+    def test_ss_siso_unity_feedback_returns_statespace(self):
+        # G(s) = 1/(s+1): T(s) = 1/(s+2)
+        G = StateSpace([[-1]], [[1]], [[1]], [[0]])
+        T = feedback(G)
+        assert isinstance(T, StateSpace)
+
+    def test_ss_siso_unity_feedback_pole(self):
+        G = StateSpace([[-1]], [[1]], [[1]], [[0]])
+        T = feedback(G)
+        np.testing.assert_allclose(
+            np.sort(np.real(T.poles())), [-2.0], atol=1e-8
+        )
+
+    def test_ss_siso_unity_feedback_dc_gain(self):
+        # T = 1/(s+2): DC gain = 0.5
+        G = StateSpace([[-1]], [[1]], [[1]], [[0]])
+        T = feedback(G)
+        _, y = T.step()
+        np.testing.assert_allclose(y[-1], 0.5, atol=1e-3)
+
+    # ------------------------------------------------------------------
+    # StateSpace MIMO unity feedback
+    # ------------------------------------------------------------------
+
+    def test_ss_mimo_unity_feedback_dimensions(self):
+        # G = diag(1/(s+1), 1/(s+2)): 2-in 2-out
+        G = StateSpace(
+            np.diag([-1.0, -2.0]), np.eye(2), np.eye(2), np.zeros((2, 2))
+        )
+        T = feedback(G)
+        assert isinstance(T, StateSpace)
+        assert T.n_inputs == 2
+        assert T.n_outputs == 2
+
+    def test_ss_mimo_unity_feedback_poles(self):
+        # T = diag(1/(s+2), 1/(s+3)): poles at -2 and -3
+        G = StateSpace(
+            np.diag([-1.0, -2.0]), np.eye(2), np.eye(2), np.zeros((2, 2))
+        )
+        T = feedback(G)
+        poles = np.sort(np.real(T.poles()))
+        np.testing.assert_allclose(poles, [-3.0, -2.0], atol=1e-8)
+
+    def test_ss_mimo_unity_feedback_nonsquare_raises(self):
+        # 1-input 2-output: not square, unity feedback undefined
+        G = StateSpace(
+            np.diag([-1.0, -2.0]),
+            np.ones((2, 1)),
+            np.eye(2),
+            np.zeros((2, 1)),
+        )
+        with pytest.raises(ValueError, match="square"):
+            feedback(G)
+
+    # ------------------------------------------------------------------
+    # StateSpace MIMO with TransferFunction sensor H
+    # ------------------------------------------------------------------
+
+    def test_ss_siso_with_tf_sensor(self):
+        # G = 1/(s+1), H = 2: T = G/(1+2G) = 1/(s+3): DC gain = 1/3
+        G = StateSpace([[-1]], [[1]], [[1]], [[0]])
+        H = TransferFunction([2], [1])
+        T = feedback(G, H)
+        assert isinstance(T, StateSpace)
+        _, y = T.step()
+        np.testing.assert_allclose(y[-1], 1 / 3, atol=1e-3)
+
+    def test_ss_siso_with_static_tf_sensor_no_phantom_state(self):
+        # Static H (n_states=0) must NOT add a phantom state via scipy quirk
+        G = StateSpace([[-1.]], [[1.]], [[1.]], [[0.]])
+        H = TransferFunction([2.], [1.])   # static gain 2
+        T = feedback(G, H)
+        assert T.n_states == 1             # only plant's state
+        np.testing.assert_allclose(np.sort(np.real(T.poles())), [-3.0], atol=1e-8)
+
+    def test_feedback_dt_mismatch_raises(self):
+        G = StateSpace([[-1.]], [[1.]], [[1.]], [[0.]])
+        H = StateSpace([[-2.]], [[1.]], [[1.]], [[0.]], dt=0.1)
+        with pytest.raises(ValueError, match="dt"):
+            feedback(G, H)
+
+    def test_feedback_transfer_function_matrix_auto_converts(self):
+        from synapsys.core.transfer_function_matrix import TransferFunctionMatrix
+        G = TransferFunctionMatrix([
+            [TransferFunction([1], [1, 1]), TransferFunction([0], [1])],
+            [TransferFunction([0], [1]),    TransferFunction([1], [1, 2])],
+        ])
+        T = feedback(G)
+        assert isinstance(T, StateSpace)
+        assert T.n_inputs == 2
+        assert T.n_outputs == 2

--- a/tests/api/test_feedback.py
+++ b/tests/api/test_feedback.py
@@ -1,9 +1,9 @@
 import numpy as np
 import pytest
 
+from synapsys.api.matlab_compat import feedback
 from synapsys.core.state_space import StateSpace
 from synapsys.core.transfer_function import TransferFunction
-from synapsys.api.matlab_compat import feedback
 
 
 class TestFeedback:

--- a/tests/api/test_matlab_compat.py
+++ b/tests/api/test_matlab_compat.py
@@ -1,0 +1,25 @@
+"""Tests for edge-cases in matlab_compat API layer."""
+import numpy as np
+import pytest
+
+from synapsys.api.matlab_compat import parallel, series, tf
+
+
+class TestSeriesParallel:
+    def test_series_no_args_raises(self):
+        with pytest.raises(ValueError, match="at least one"):
+            series()
+
+    def test_parallel_no_args_raises(self):
+        with pytest.raises(ValueError, match="at least one"):
+            parallel()
+
+
+class TestTfFactory:
+    def test_tf_none_num_raises(self):
+        with pytest.raises(TypeError):
+            tf(None, [1, 1])
+
+    def test_tf_none_den_raises(self):
+        with pytest.raises(TypeError):
+            tf([1], None)

--- a/tests/api/test_matlab_compat.py
+++ b/tests/api/test_matlab_compat.py
@@ -1,5 +1,4 @@
 """Tests for edge-cases in matlab_compat API layer."""
-import numpy as np
 import pytest
 
 from synapsys.api.matlab_compat import parallel, series, tf

--- a/tests/api/test_tf_factory.py
+++ b/tests/api/test_tf_factory.py
@@ -1,0 +1,41 @@
+"""Tests for tf() factory — SISO vs MIMO dispatch."""
+import numpy as np
+import pytest
+
+from synapsys.api.matlab_compat import tf
+from synapsys.core.transfer_function import TransferFunction
+from synapsys.core.transfer_function_matrix import TransferFunctionMatrix
+
+
+class TestTfFactory:
+    def test_1d_num_returns_transfer_function(self):
+        G = tf([1], [1, 1])
+        assert isinstance(G, TransferFunction)
+
+    def test_2d_num_returns_transfer_function_matrix(self):
+        G = tf([[1, 2], [3, 4]], [1, 3, 2])
+        assert isinstance(G, TransferFunctionMatrix)
+
+    def test_2d_num_correct_dimensions(self):
+        G = tf([[1, 2], [3, 4]], [1, 3, 2])
+        assert G.n_outputs == 2
+        assert G.n_inputs == 2
+
+    def test_2d_num_per_element_den(self):
+        G = tf(
+            [[[1], [2]], [[3], [4]]],
+            [[[1, 1], [1, 2]], [[1, 3], [1, 4]]],
+        )
+        assert isinstance(G, TransferFunctionMatrix)
+        assert G.n_states == 4
+
+    def test_1x1_matrix_via_factory(self):
+        G = tf([[1]], [1, 1])
+        assert isinstance(G, TransferFunctionMatrix)
+        assert G.n_outputs == 1
+        assert G.n_inputs == 1
+
+    def test_dt_propagated_to_matrix(self):
+        G = tf([[1, 2], [3, 4]], [1, 3, 2], dt=0.1)
+        assert G.dt == 0.1
+        assert G.is_discrete

--- a/tests/api/test_tf_factory.py
+++ b/tests/api/test_tf_factory.py
@@ -1,6 +1,4 @@
 """Tests for tf() factory — SISO vs MIMO dispatch."""
-import numpy as np
-import pytest
 
 from synapsys.api.matlab_compat import tf
 from synapsys.core.transfer_function import TransferFunction

--- a/tests/core/test_state_space.py
+++ b/tests/core/test_state_space.py
@@ -35,10 +35,7 @@ class TestStateSpace:
             StateSpace([[-1, 0], [0, -2]], [[1], [1]], [[1]], [[0]])
 
     def test_mul_series_incompatible_inner_dim_raises(self):
-        # G1: 2-in 1-out; G2: 1-in 2-out → series G1*G2 ok
-        # G1: 1-in 1-out; G2: 2-in 1-out → series G1*G2 fails (G1.n_inputs=1 != G2.n_outputs=1... wait)
-        # Need: self.n_inputs != other.n_outputs to fail
-        # G1 has n_inputs=1, G2 has n_outputs=2 → incompatible
+        # G1 has n_inputs=1, G2 has n_outputs=2 → incompatible inner dims
         G1 = StateSpace([[-1]], [[1]], [[1]], [[0]])           # 1-in 1-out
         G2 = StateSpace(np.diag([-1.0, -2.0]),
                         np.ones((2, 2)), np.eye(2), np.zeros((2, 2)))  # 2-in 2-out

--- a/tests/core/test_state_space.py
+++ b/tests/core/test_state_space.py
@@ -34,9 +34,75 @@ class TestStateSpace:
             # C has wrong number of columns
             StateSpace([[-1, 0], [0, -2]], [[1], [1]], [[1]], [[0]])
 
+    def test_mul_series_incompatible_inner_dim_raises(self):
+        # G1: 2-in 1-out; G2: 1-in 2-out → series G1*G2 ok
+        # G1: 1-in 1-out; G2: 2-in 1-out → series G1*G2 fails (G1.n_inputs=1 != G2.n_outputs=1... wait)
+        # Need: self.n_inputs != other.n_outputs to fail
+        # G1 has n_inputs=1, G2 has n_outputs=2 → incompatible
+        G1 = StateSpace([[-1]], [[1]], [[1]], [[0]])           # 1-in 1-out
+        G2 = StateSpace(np.diag([-1.0, -2.0]),
+                        np.ones((2, 2)), np.eye(2), np.zeros((2, 2)))  # 2-in 2-out
+        # G1 * G2: G1.n_inputs=1 != G2.n_outputs=2
+        with pytest.raises(ValueError, match="inner"):
+            G1 * G2
+
     def test_to_transfer_function(self):
         sys = self._first_order()
         tf = sys.to_transfer_function()
         # G(s) = 1/(s+1): step should reach 1.0
         _, y = tf.step()
         np.testing.assert_allclose(y[-1], 1.0, atol=1e-3)
+
+    def test_to_transfer_function_raises_for_mimo(self):
+        sys = StateSpace(
+            np.diag([-1.0, -2.0]), np.eye(2), np.eye(2), np.zeros((2, 2))
+        )
+        with pytest.raises(ValueError, match="MIMO"):
+            sys.to_transfer_function()
+
+    # ------------------------------------------------------------------
+    # zeros() — Rosenbrock system matrix (SISO + MIMO)
+    # ------------------------------------------------------------------
+
+    def test_zeros_siso_no_zeros(self):
+        # G(s) = 1/(s+1): no finite zeros
+        z = self._first_order().zeros()
+        assert len(z) == 0
+
+    def test_zeros_siso_with_zero(self):
+        # G(s) = (s+2)/(s+1)^2 — zero at -2
+        from synapsys.core.transfer_function import TransferFunction
+        sys = TransferFunction([1, 2], [1, 2, 1]).to_state_space()
+        z = sys.zeros()
+        np.testing.assert_allclose(np.sort(np.real(z)), [-2.0], atol=1e-6)
+
+    def test_zeros_mimo_no_transmission_zeros(self):
+        # G = diag(1/(s+1), 1/(s+2)): no transmission zeros
+        sys = StateSpace(
+            np.diag([-1.0, -2.0]), np.eye(2), np.eye(2), np.zeros((2, 2))
+        )
+        z = sys.zeros()
+        assert len(z) == 0
+
+    def test_zeros_non_square_raises_descriptive(self):
+        # 2-in 3-out: must raise with n_inputs/n_outputs context, not a raw scipy error
+        sys = StateSpace(
+            np.diag([-1.0, -2.0]),
+            np.ones((2, 2)),
+            np.ones((3, 2)),
+            np.zeros((3, 2)),
+        )
+        with pytest.raises(ValueError, match="n_inputs"):
+            sys.zeros()
+
+    def test_zeros_mimo_with_transmission_zero(self):
+        # G = diag((s+3)/(s+1), 1/(s+2)): transmission zero at -3
+        # State-space realisation: A=diag(-1,-2), B=I, C=diag(2,1), D=diag(1,0)
+        sys = StateSpace(
+            np.diag([-1.0, -2.0]),
+            np.eye(2),
+            np.array([[2.0, 0.0], [0.0, 1.0]]),
+            np.array([[1.0, 0.0], [0.0, 0.0]]),
+        )
+        z = sys.zeros()
+        np.testing.assert_allclose(np.sort(np.real(z)), [-3.0], atol=1e-6)

--- a/tests/core/test_transfer_function_matrix.py
+++ b/tests/core/test_transfer_function_matrix.py
@@ -5,7 +5,6 @@ import pytest
 from synapsys.core.transfer_function import TransferFunction
 from synapsys.core.transfer_function_matrix import TransferFunctionMatrix
 
-
 # ---------------------------------------------------------------------------
 # Shared fixtures
 # ---------------------------------------------------------------------------
@@ -167,7 +166,6 @@ class TestAnalysis:
 
     def test_zeros_diagonal_with_known_zero(self):
         # G = diag((s+3)/(s+1), 1/(s+2)) — transmission zero at -3
-        from synapsys.core.state_space import StateSpace
         G = TransferFunctionMatrix([
             [TransferFunction([1, 3], [1, 1]), TransferFunction([0], [1])],
             [TransferFunction([0], [1]),        TransferFunction([1], [1, 2])],
@@ -250,7 +248,8 @@ class TestAlgebra:
         # G[0,0] = 1/(s+1); (G+G)[0,0] has DC gain = 2
         G = _2x2()
         result = G + G
-        np.testing.assert_allclose(result[0, 0].num[0] / result[0, 0].den[-1], 2.0, atol=1e-8)
+        dc = result[0, 0].num[0] / result[0, 0].den[-1]
+        np.testing.assert_allclose(dc, 2.0, atol=1e-8)
 
     def test_add_incompatible_shapes_raises(self):
         G1 = _2x2()

--- a/tests/core/test_transfer_function_matrix.py
+++ b/tests/core/test_transfer_function_matrix.py
@@ -1,0 +1,319 @@
+"""Tests for TransferFunctionMatrix — driven before any production code."""
+import numpy as np
+import pytest
+
+from synapsys.core.transfer_function import TransferFunction
+from synapsys.core.transfer_function_matrix import TransferFunctionMatrix
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+def _2x2() -> TransferFunctionMatrix:
+    """G = [[1/(s+1), 2/(s+2)], [3/(s+3), 4/(s+4)]]"""
+    return TransferFunctionMatrix([
+        [TransferFunction([1], [1, 1]), TransferFunction([2], [1, 2])],
+        [TransferFunction([3], [1, 3]), TransferFunction([4], [1, 4])],
+    ])
+
+
+def _1x1() -> TransferFunctionMatrix:
+    return TransferFunctionMatrix([[TransferFunction([1], [1, 1])]])
+
+
+def _diagonal_2x2() -> TransferFunctionMatrix:
+    """G = diag(1/(s+1), 1/(s+2)) — useful for step/evolve checks."""
+    return TransferFunctionMatrix([
+        [TransferFunction([1], [1, 1]), TransferFunction([0], [1])],
+        [TransferFunction([0], [1]), TransferFunction([1], [1, 2])],
+    ])
+
+
+# ---------------------------------------------------------------------------
+# Construction and dimensions
+# ---------------------------------------------------------------------------
+
+class TestConstruction:
+    def test_dimensions_2x2(self):
+        G = _2x2()
+        assert G.n_outputs == 2
+        assert G.n_inputs == 2
+
+    def test_dimensions_1x1(self):
+        G = _1x1()
+        assert G.n_outputs == 1
+        assert G.n_inputs == 1
+
+    def test_dimensions_1x3(self):
+        G = TransferFunctionMatrix([[
+            TransferFunction([1], [1, 1]),
+            TransferFunction([1], [1, 2]),
+            TransferFunction([1], [1, 3]),
+        ]])
+        assert G.n_outputs == 1
+        assert G.n_inputs == 3
+
+    def test_n_states_is_sum_of_element_orders(self):
+        # Each 1/(s+k) is order-1; 2x2 has 4 elements → 4 states
+        G = _2x2()
+        assert G.n_states == 4
+
+    def test_n_states_skips_zero_numerator_elements(self):
+        # Zero-gain TFs ([0]/den) contribute 0 states to the SS realisation
+        G = _diagonal_2x2()  # [[1/(s+1), 0], [0, 1/(s+2)]]
+        # TF property len(den)-1: [1,0,0,0] = 2 active + 0+0 skipped = 2
+        assert G.n_states == G.to_state_space().n_states
+
+    def test_n_states_matches_statespace_realisation(self):
+        # Explicit: 2 non-zero + 2 zero-numerator elements → 2 real states
+        G = _diagonal_2x2()
+        assert G.n_states == 2
+
+    def test_n_states_zero_num_nontrivial_den(self):
+        # TransferFunction([0], [1, 2]) has TF.n_states=1 but contributes 0
+        # states to the SS realisation (zero-numerator skip)
+        G = TransferFunctionMatrix([[
+            TransferFunction([1], [1, 1]),
+            TransferFunction([0], [1, 2]),  # zero num, non-trivial den
+        ]])
+        assert G.n_states == G.to_state_space().n_states
+
+    def test_jagged_rows_raises(self):
+        with pytest.raises(ValueError, match="same number"):
+            TransferFunctionMatrix([
+                [TransferFunction([1], [1, 1])],
+                [TransferFunction([1], [1, 1]), TransferFunction([1], [1, 2])],
+            ])
+
+    def test_empty_raises(self):
+        with pytest.raises(ValueError):
+            TransferFunctionMatrix([])
+
+    def test_mixed_dt_raises(self):
+        with pytest.raises(ValueError, match="dt"):
+            TransferFunctionMatrix([
+                [TransferFunction([1], [1, 1], dt=0.0),
+                 TransferFunction([1], [1, 2], dt=0.1)],
+            ])
+
+
+# ---------------------------------------------------------------------------
+# from_arrays factory
+# ---------------------------------------------------------------------------
+
+class TestFromArrays:
+    def test_shared_denominator(self):
+        G = TransferFunctionMatrix.from_arrays(
+            num=[[1, 2], [3, 4]],
+            den=[1, 3, 2],   # shared: (s+1)(s+2)
+        )
+        assert G.n_outputs == 2
+        assert G.n_inputs == 2
+        assert G[0, 0].den.tolist() == pytest.approx([1, 3, 2])
+        assert G[1, 1].den.tolist() == pytest.approx([1, 3, 2])
+
+    def test_per_element_denominator(self):
+        G = TransferFunctionMatrix.from_arrays(
+            num=[[[1], [2]], [[3], [4]]],
+            den=[[[1, 1], [1, 2]], [[1, 3], [1, 4]]],
+        )
+        assert G.n_states == 4  # four first-order elements
+
+
+# ---------------------------------------------------------------------------
+# Item access
+# ---------------------------------------------------------------------------
+
+class TestItemAccess:
+    def test_getitem_returns_transfer_function(self):
+        G = _2x2()
+        assert isinstance(G[0, 0], TransferFunction)
+
+    def test_getitem_correct_numerator(self):
+        G = _2x2()
+        # G[1, 0] = 3/(s+3) — num = [3]
+        np.testing.assert_allclose(G[1, 0].num, [3.0])
+
+    def test_getitem_out_of_range_raises(self):
+        G = _2x2()
+        with pytest.raises(IndexError):
+            _ = G[2, 0]
+
+
+# ---------------------------------------------------------------------------
+# LTIModel properties
+# ---------------------------------------------------------------------------
+
+class TestAnalysis:
+    def test_poles_contains_all_element_poles(self):
+        G = _2x2()
+        p = np.sort(np.real(G.poles()))
+        np.testing.assert_allclose(p, [-4.0, -3.0, -2.0, -1.0], atol=1e-8)
+
+    def test_is_stable_true_for_stable_system(self):
+        assert _2x2().is_stable()
+
+    def test_is_stable_false_when_one_element_unstable(self):
+        G = TransferFunctionMatrix([
+            [TransferFunction([1], [1, -1]),   # unstable pole at +1
+             TransferFunction([1], [1, 2])],
+        ])
+        assert not G.is_stable()
+
+    def test_zeros_returns_ndarray(self):
+        z = _2x2().zeros()
+        assert isinstance(z, np.ndarray)
+
+    def test_zeros_diagonal_with_known_zero(self):
+        # G = diag((s+3)/(s+1), 1/(s+2)) — transmission zero at -3
+        from synapsys.core.state_space import StateSpace
+        G = TransferFunctionMatrix([
+            [TransferFunction([1, 3], [1, 1]), TransferFunction([0], [1])],
+            [TransferFunction([0], [1]),        TransferFunction([1], [1, 2])],
+        ])
+        z = G.zeros()
+        np.testing.assert_allclose(np.sort(np.real(z)), [-3.0], atol=1e-6)
+
+    def test_dt_is_zero_for_continuous(self):
+        assert _2x2().dt == 0.0
+
+    def test_is_discrete_false_for_continuous(self):
+        assert not _2x2().is_discrete
+
+
+# ---------------------------------------------------------------------------
+# to_state_space
+# ---------------------------------------------------------------------------
+
+class TestToStateSpace:
+    def test_returns_statespace(self):
+        from synapsys.core.state_space import StateSpace
+        assert isinstance(_2x2().to_state_space(), StateSpace)
+
+    def test_dimensions(self):
+        ss = _2x2().to_state_space()
+        assert ss.n_inputs == 2
+        assert ss.n_outputs == 2
+        assert ss.n_states == 4
+
+    def test_dc_gains(self):
+        # DC gain of 1/(s+k) at s=0 is 1/k
+        # G DC = [[1/1, 2/2], [3/3, 4/4]] = [[1, 1], [1, 1]]
+        ss = _2x2().to_state_space()
+        # Simulate to steady state
+        t = np.linspace(0, 30, 3000)
+        u = np.ones((len(t), 2))
+        _, y = ss.simulate(t, u)
+        np.testing.assert_allclose(y[-1], [1.0 + 1.0, 1.0 + 1.0], atol=1e-2)
+
+    def test_1x1_to_state_space_matches_single_tf(self):
+        G = _1x1()
+        ss = G.to_state_space()
+        _, y_ss = ss.step()
+        _, y_tf = G[0, 0].step()
+        np.testing.assert_allclose(y_ss[-1], y_tf[-1], atol=1e-3)
+
+
+# ---------------------------------------------------------------------------
+# to_transfer_function
+# ---------------------------------------------------------------------------
+
+class TestToTransferFunction:
+    def test_1x1_returns_transfer_function(self):
+        G = _1x1()
+        tf = G.to_transfer_function()
+        assert isinstance(tf, TransferFunction)
+
+    def test_mimo_raises(self):
+        with pytest.raises(ValueError, match="SISO"):
+            _2x2().to_transfer_function()
+
+
+# ---------------------------------------------------------------------------
+# Algebra
+# ---------------------------------------------------------------------------
+
+class TestAlgebra:
+    def test_neg_flips_numerator_sign(self):
+        G = _1x1()
+        neg = -G
+        np.testing.assert_allclose(neg[0, 0].num, -G[0, 0].num)
+
+    def test_add_parallel_dimensions(self):
+        G = _2x2()
+        result = G + G
+        assert result.n_inputs == 2
+        assert result.n_outputs == 2
+
+    def test_add_parallel_doubles_dc_gain(self):
+        # G[0,0] = 1/(s+1); (G+G)[0,0] has DC gain = 2
+        G = _2x2()
+        result = G + G
+        np.testing.assert_allclose(result[0, 0].num[0] / result[0, 0].den[-1], 2.0, atol=1e-8)
+
+    def test_add_incompatible_shapes_raises(self):
+        G1 = _2x2()
+        G2 = TransferFunctionMatrix([[TransferFunction([1], [1, 1])]])
+        with pytest.raises(ValueError, match="shape"):
+            G1 + G2
+
+    def test_mul_series_dimensions(self):
+        # (2×2) * (2×2) → (2×2)
+        G = _2x2()
+        result = G * G
+        assert result.n_inputs == 2
+        assert result.n_outputs == 2
+
+    def test_mul_series_incompatible_raises(self):
+        G1 = _2x2()
+        G3 = TransferFunctionMatrix([
+            [TransferFunction([1], [1, 1])],
+            [TransferFunction([1], [1, 2])],
+            [TransferFunction([1], [1, 3])],
+        ])
+        with pytest.raises(ValueError, match="inner"):
+            G1 * G3
+
+
+# ---------------------------------------------------------------------------
+# Simulation (delegates to StateSpace)
+# ---------------------------------------------------------------------------
+
+class TestSimulation:
+    def test_step_returns_arrays(self):
+        G = _1x1()  # step() delegates to SS, only well-defined for SISO/single-input
+        t, y = G.step()
+        assert t.ndim == 1
+        assert y.ndim >= 1
+
+    def test_simulate_via_tfm(self):
+        G = _diagonal_2x2()
+        t = np.linspace(0, 10, 500)
+        u = np.ones((len(t), 2))
+        t_out, y = G.simulate(t, u)
+        assert y.shape[1] == 2
+
+    def test_bode_returns_three_arrays(self):
+        G = _1x1()  # bode() delegates to SS; only well-defined for single-channel
+        w, mag, phase = G.bode()
+        assert w.ndim == 1 and mag.ndim >= 1
+
+    def test_evolve_returns_correct_shapes(self):
+        Gd = _diagonal_2x2().to_state_space()
+        from synapsys.api.matlab_compat import c2d
+        Gd_disc = c2d(Gd, dt=0.1)
+        x = np.zeros(Gd_disc.n_states)
+        u = np.array([1.0, 1.0])
+        x_next, y = Gd_disc.evolve(x, u)
+        assert x_next.shape == (Gd_disc.n_states,)
+        assert y.shape == (2,)
+
+    def test_simulate_dc_gain(self):
+        G = _diagonal_2x2().to_state_space()
+        t = np.linspace(0, 20, 2000)
+        u = np.ones((len(t), 2))
+        _, y = G.simulate(t, u)
+        # DC gain: 1/(s+1)|s=0 = 1.0, 1/(s+2)|s=0 = 0.5
+        np.testing.assert_allclose(y[-1, 0], 1.0, atol=1e-2)
+        np.testing.assert_allclose(y[-1, 1], 0.5, atol=1e-2)

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -24,11 +24,14 @@ flowchart TB
         M1["LTIModel (ABC)"]
         M2["StateSpace"]
         M3["TransferFunction"]
+        M5["TransferFunctionMatrix"]
         M4["NumPy / SciPy solvers"]
         M1 --> M2
         M1 --> M3
+        M1 --> M5
         M2 --> M4
         M3 --> M4
+        M5 --> M3
     end
 
     subgraph ControlLogic["3. Algorithms — synapsys.algorithms"]
@@ -82,6 +85,8 @@ The `synapsys.api` layer is a convenience wrapper only. All mathematics lives in
 ```python
 T = (C * G).feedback()   # closed loop: C in series with G
 ```
+
+`TransferFunctionMatrix` extends this algebra to MIMO plants: `*` performs matrix multiplication (series) and `+` is element-wise (parallel). Simulation and analysis delegate to a minimal `StateSpace` realisation built lazily by `to_state_space()`.
 
 ### Strategy pattern in transport
 

--- a/website/docs/roadmap.md
+++ b/website/docs/roadmap.md
@@ -6,26 +6,39 @@ sidebar_position: 99
 
 # Roadmap
 
-## Current state — v0.1.0
+## Current state — v0.2.0
 
-The foundation is complete and tested (40 tests, Python 3.10–3.12).
+The library is complete and tested (184 tests, Python 3.10–3.12, 90 % coverage).
 
 | Module | Status |
 |--------|--------|
-| `synapsys.core` — TransferFunction, StateSpace (continuous + discrete) | Done |
-| `synapsys.algorithms` — PID (anti-windup), LQR | Done |
+| `synapsys.core` — TransferFunction, StateSpace, TransferFunctionMatrix (continuous + discrete) | Done |
+| `synapsys.algorithms` — PID (anti-windup), LQR (Q/R validated) | Done |
 | `synapsys.agents` — PlantAgent, ControllerAgent, FIPA ACL, SyncEngine | Done |
 | `synapsys.transport` — SharedMemory (zero-copy), ZMQ (PUB/SUB, REQ/REP) | Done |
-| `synapsys.api` — tf(), ss(), c2d(), step(), bode(), feedback() | Done |
+| `synapsys.api` — tf(), ss(), c2d(), step(), bode(), feedback() (SISO + MIMO) | Done |
 | `synapsys.hw` — Interface defined, no concrete implementations yet | Pending |
 
 ---
 
-## v0.2 — Advanced analysis
+## v0.1.0 ✅ — Foundation
+
+- SISO LTI (`TransferFunction`, `StateSpace`), PID, LQR, multi-agent, shared memory, ZMQ, hardware abstraction.
+
+## v0.2.0 ✅ — MIMO
+
+- `TransferFunctionMatrix` — MIMO transfer-function matrix with operator algebra, `to_state_space()`, poles/zeros/stability.
+- MIMO `feedback()` — state-space closed-loop for `StateSpace` and `TransferFunctionMatrix` plants.
+- Transmission zeros via Rosenbrock system-matrix pencil.
+- `lqr()` Q positive semi-definiteness validation.
+- Covariant LTI type annotations for mypy/pyright.
+
+---
+
+## v0.3 — Advanced analysis
 
 **Core:**
 
-- [ ] **MIMO systems** — `TransferFunction` and `StateSpace` for multiple inputs/outputs
 - [ ] **Transport delay** — Pade approximation `pade(T, n)`
 - [ ] **Phase and gain margin** — `margin(G)` returning $G_m$, $\phi_m$, $\omega_{gc}$, $\omega_{pc}$
 - [ ] **Root locus** — `rlocus(G)` for root locus analysis
@@ -33,17 +46,16 @@ The foundation is complete and tested (40 tests, Python 3.10–3.12).
 
 **Algorithms:**
 
-- [ ] **PID in state space** — formulation with integrated Luenberger observer
 - [ ] **LQI** — LQR with integral action for disturbance rejection
+- [ ] **Observers** — `ObserverAgent` with Kalman filter and Luenberger observer
 
 ---
 
-## v0.3 — Advanced control
+## v0.4 — Advanced control
 
 - [ ] **MPC** — Model Predictive Control with sliding horizon and state/input constraints
 - [ ] **Adaptive control** — MRAC (Model Reference Adaptive Control) for plants with varying parameters
 - [ ] **Real-time reconfiguration** — swap the control law without stopping the simulation
-- [ ] **Observers** — `ObserverAgent` with Kalman filter and Luenberger observer
 
 ---
 

--- a/website/i18n/pt/docusaurus-plugin-content-docs/current/architecture.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/current/architecture.md
@@ -24,11 +24,14 @@ flowchart TB
         M1["LTIModel (ABC)"]
         M2["StateSpace"]
         M3["TransferFunction"]
+        M5["TransferFunctionMatrix"]
         M4["NumPy / SciPy solvers"]
         M1 --> M2
         M1 --> M3
+        M1 --> M5
         M2 --> M4
         M3 --> M4
+        M5 --> M3
     end
 
     subgraph ControlLogic["3. Algoritmos — synapsys.algorithms"]
@@ -82,6 +85,8 @@ A camada `synapsys.api` é apenas um wrapper de conveniência. Toda a matemátic
 ```python
 T = (C * G).feedback()   # malha fechada: C em série com G
 ```
+
+`TransferFunctionMatrix` estende essa álgebra para plantas MIMO: `*` realiza multiplicação matricial (série) e `+` é elemento a elemento (paralelo). Simulação e análise delegam para uma realização mínima em `StateSpace` construída de forma lazy por `to_state_space()`.
 
 ### Padrão Strategy no transporte
 

--- a/website/i18n/pt/docusaurus-plugin-content-docs/current/roadmap.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/current/roadmap.md
@@ -6,38 +6,51 @@ sidebar_position: 99
 
 # Roadmap
 
-## Estado atual — v0.1.0
+## Estado atual — v0.2.0
 
-A fundação esta pronta e testada (40 testes, Python 3.10–3.12).
+A biblioteca está completa e testada (184 testes, Python 3.10–3.12, cobertura 90 %).
 
 | Módulo | Status |
 |--------|--------|
-| `synapsys.core` — TransferFunction, StateSpace (continuo + discreto) | Concluído |
-| `synapsys.algorithms` — PID (anti-windup), LQR | Concluído |
+| `synapsys.core` — TransferFunction, StateSpace, TransferFunctionMatrix (contínuo + discreto) | Concluído |
+| `synapsys.algorithms` — PID (anti-windup), LQR (Q/R validados) | Concluído |
 | `synapsys.agents` — PlantAgent, ControllerAgent, FIPA ACL, SyncEngine | Concluído |
 | `synapsys.transport` — SharedMemory (zero-copy), ZMQ (PUB/SUB, REQ/REP) | Concluído |
-| `synapsys.api` — tf(), ss(), c2d(), step(), bode(), feedback() | Concluído |
+| `synapsys.api` — tf(), ss(), c2d(), step(), bode(), feedback() (SISO + MIMO) | Concluído |
 | `synapsys.hw` — Interface definida, sem implementações concretas | Pendente |
 
 ---
 
-## v0.2 — Análise avançada
+## v0.1.0 ✅ — Fundação
 
-- [ ] **Sistemas MIMO** — múltiplas entradas/saídas
+- LTI SISO (`TransferFunction`, `StateSpace`), PID, LQR, multi-agente, memória compartilhada, ZMQ, abstração de hardware.
+
+## v0.2.0 ✅ — MIMO
+
+- `TransferFunctionMatrix` — matriz de funções de transferência MIMO com álgebra de operadores, `to_state_space()`, polos/zeros/estabilidade.
+- `feedback()` MIMO — malha fechada em espaço de estados para plantas `StateSpace` e `TransferFunctionMatrix`.
+- Zeros de transmissão via matriz de Rosenbrock.
+- Validação de semi-definição positiva de Q no `lqr()`.
+- Anotações de tipo covariantes no `LTIModel` para mypy/pyright.
+
+---
+
+## v0.3 — Análise avançada
+
 - [ ] **Atraso de transporte** — aproximação de Pade `pade(T, n)`
 - [ ] **Margem de fase e ganho** — `margin(G)`
 - [ ] **Root locus** — `rlocus(G)`
 - [ ] **Alocação de polos** — `place(A, B, poles)`
 - [ ] **LQI** — LQR com ação integral
+- [ ] **Observadores** — filtro de Kalman e Luenberger
 
 ---
 
-## v0.3 — Controle avançado
+## v0.4 — Controle avançado
 
 - [ ] **MPC** — Model Predictive Control com restrições
 - [ ] **Controle adaptativo** — MRAC para plantas com parâmetros variantes
 - [ ] **Reconfiguração em tempo real** — troca de lei sem parar a simulação
-- [ ] **Observadores** — filtro de Kalman e Luenberger
 
 ---
 


### PR DESCRIPTION
## Summary

- **`TransferFunctionMatrix`** — new MIMO TF matrix class with operator algebra (`+`, `*`, negation), `to_state_space()`, poles/zeros/stability, `step`/`simulate`/`bode`, and `from_arrays()` factory
- **MIMO `feedback()`** — handles `StateSpace` and `TransferFunctionMatrix` plants; fixes static-TF phantom pole by building a true 0-state SS for constant sensors; adds `dt` mismatch guard
- **Transmission zeros** via Rosenbrock system-matrix pencil — replaces deprecated `scipy.signal.zpkdata`, correct for SISO and MIMO
- **`tf()` MIMO dispatch** — 2-D `num` now returns `TransferFunctionMatrix` (mirrors MATLAB)
- **`StateSpace`** — non-square guard on `zeros()`, inner-dimension check on `__mul__()`, MIMO guard on `to_transfer_function()`
- **`lqr()`** — Q positive semi-definiteness validated via `eigvalsh`
- **`series()`/`parallel()`** — guard against zero-argument calls; `tf()` — guard against `None` numerator/denominator
- **`LTIModel`** — covariant return types on `to_state_space`/`to_transfer_function` via `TYPE_CHECKING`
- **Version bump** `0.1.0 → 0.2.0`; README, CHANGELOG, website docs and roadmap updated
- **Test suite** expanded from 74 to 184 tests; coverage 86 % → 90 %

## Test plan

- [x] `python -m pytest` — 184 passed, 0 failed
- [x] All new classes covered: `TransferFunctionMatrix` (39 tests), MIMO `feedback` (12 tests), `tf()` factory (8 tests), `lqr` Q validation (2 tests)
- [x] Regression: existing SISO `TransferFunction` and `StateSpace` behaviour unchanged