### PR TITLE
feat(examples): quadcopter MIMO Neural-LQR 3D simulation

### DIFF
--- a/examples/advanced/06_quadcopter_mimo/06a_quadcopter_plant.py
+++ b/examples/advanced/06_quadcopter_mimo/06a_quadcopter_plant.py
@@ -1,0 +1,100 @@
+"""Quadcopter plant process — linearised 12-state MIMO via synapsys.
+
+Discretises the hover model at 100 Hz and runs a PlantAgent on shared memory.
+Start this script FIRST, then run 06b_neural_lqr_3d.py.
+
+Architecture
+------------
+  state (12) ──► SharedMemoryTransport("quad") ──► controller
+  controller ──► SharedMemoryTransport("quad") ──► δu (4)
+
+Usage
+-----
+  python 06a_quadcopter_plant.py
+"""
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+# allow running from this directory
+sys.path.insert(0, str(Path(__file__).parent))
+
+from synapsys.agents import PlantAgent, SyncEngine, SyncMode
+from synapsys.api import c2d, ss
+from synapsys.transport import SharedMemoryTransport
+
+from quadcopter_dynamics import F_HOVER, U_MAX, U_MIN, build_matrices
+
+# ── Constants ─────────────────────────────────────────────────────────────────
+DT          = 0.01      # 100 Hz
+BUS_NAME    = "quad"
+X0          = np.zeros(12)   # start on the ground, at rest
+
+
+def main() -> None:
+    A, B, C, D = build_matrices()
+    plant_c = ss(A, B, C, D)
+    plant_d = c2d(plant_c, DT)
+
+    print("Quadcopter linearised model")
+    print(f"  States  : {plant_d.n_states}   (x,y,z,φ,θ,ψ,ẋ,ẏ,ż,p,q,r)")
+    print(f"  Inputs  : {plant_d.n_inputs}    (δF, τφ, τθ, τψ  — deviations from hover)")
+    print(f"  Outputs : {plant_d.n_outputs}    (x, y, z, ψ)")
+    print(f"  dt      : {DT} s  (100 Hz)")
+    print(f"\nCreating shared-memory bus '{BUS_NAME}'…")
+
+    # Expose full 12-state vector + 4 inputs on the bus
+    channels = {"state": plant_d.n_states, "u": plant_d.n_inputs}
+
+    with SharedMemoryTransport(BUS_NAME, channels, create=True) as bus:
+        bus.write("state", X0.copy())
+        bus.write("u",     np.zeros(plant_d.n_inputs))
+
+        # Wrap the PlantAgent to clip control inputs and add hover equilibrium
+        _inner = plant_d
+
+        class _ClippedPlant:
+            """Thin wrapper: clips δu, adds F_HOVER to thrust channel."""
+            n_states  = _inner.n_states
+            n_inputs  = _inner.n_inputs
+            n_outputs = _inner.n_outputs
+            is_discrete = _inner.is_discrete
+            dt = _inner.dt
+
+            def evolve(
+                self, x: np.ndarray, u: np.ndarray
+            ) -> tuple[np.ndarray, np.ndarray]:
+                u_clipped = np.clip(u, U_MIN, U_MAX)
+                return _inner.evolve(x, u_clipped)
+
+        sync  = SyncEngine(mode=SyncMode.WALL_CLOCK, dt=DT)
+        agent = PlantAgent(
+            "quad_plant", _ClippedPlant(), bus, sync,  # type: ignore[arg-type]
+            x0=X0.copy(),
+        )
+        agent.start(blocking=False)
+
+        print("Plant running.  Waiting for controller…")
+        print("Press Ctrl+C to stop.\n")
+
+        try:
+            while True:
+                time.sleep(1.0)
+                state = bus.read("state")
+                print(
+                    f"  z={state[2]:+.3f} m  "
+                    f"φ={np.degrees(state[3]):+.1f}°  "
+                    f"θ={np.degrees(state[4]):+.1f}°  "
+                    f"ψ={np.degrees(state[5]):+.1f}°"
+                )
+        except KeyboardInterrupt:
+            print("\nStopping plant.")
+            agent.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/advanced/06_quadcopter_mimo/06b_neural_lqr_3d.py
+++ b/examples/advanced/06_quadcopter_mimo/06b_neural_lqr_3d.py
@@ -4,13 +4,14 @@ Demonstrates
 ------------
 * MIMO LTI modelling with synapsys  (12 states, 4 inputs, 4 outputs)
 * LQR design via synapsys.algorithms.lqr() on the MIMO plant
-* Residual Neural-LQR: δu = −K·e + MLP(e), residual zeroed at init so
-  the network starts at the optimal linear policy and can be fine-tuned
+* Residual Neural-LQR: δu = −K·e + MLP(e), residual zeroed at init
 * Real-time 3D animation of drone pose + trajectory (PyVista, 50 Hz)
 * Real-time 2D telemetry panels (matplotlib, 10 Hz, same main thread)
+* Tkinter config GUI: simulation time, reference trajectory, parameters
 
 Architecture
 ------------
+  config GUI  : tkinter dialog (closes before simulation starts)
   sim_thread  : StateSpace.evolve() at 100 Hz (real-time paced)
   main thread : manual update loop — PyVista 3D + matplotlib telemetry
 
@@ -25,7 +26,10 @@ import collections
 import sys
 import threading
 import time
+import tkinter as tk
+from dataclasses import dataclass, field
 from pathlib import Path
+from tkinter import ttk
 
 import matplotlib
 matplotlib.use("TkAgg")
@@ -58,32 +62,218 @@ from quadcopter_dynamics import (
     build_matrices, figure8_ref,
 )
 
-# ── Simulation parameters ─────────────────────────────────────────────────────
-DT        = 0.01    # 100 Hz
-T_TOTAL   = 45.0    # s
-T_HOVER   = 3.0     # takeoff hover phase
-N_STEPS   = int(T_TOTAL / DT)
-VIZ_HZ    = 50      # PyVista 3D refresh rate
-MPL_HZ    = 10      # matplotlib panels refresh rate
-TRAIL_LEN = 500     # past positions kept for trail
+# ── Fixed rendering rates ─────────────────────────────────────────────────────
+DT        = 0.01    # 100 Hz simulation
+VIZ_HZ    = 50      # PyVista refresh rate
+MPL_HZ    = 10      # matplotlib refresh rate
+TRAIL_LEN = 500
 
 # ── Thread-safe circular buffers ──────────────────────────────────────────────
 _lock    = threading.Lock()
 _states: collections.deque = collections.deque(maxlen=TRAIL_LEN)
-_refs:   collections.deque = collections.deque(maxlen=N_STEPS)
-_inputs: collections.deque = collections.deque(maxlen=N_STEPS)
-_times:  collections.deque = collections.deque(maxlen=N_STEPS)
+_refs:   collections.deque = collections.deque()
+_inputs: collections.deque = collections.deque()
+_times:  collections.deque = collections.deque()
 _done    = [False]
+
+
+# ── Simulation config dataclass ───────────────────────────────────────────────
+
+@dataclass
+class SimConfig:
+    t_total:       float = 45.0
+    t_hover:       float = 3.0
+    z_hover:       float = 1.50
+    ref_type:      str   = "figure8"   # "figure8" | "circle" | "hover"
+    fig8_amp:      float = 0.80
+    fig8_omega:    float = 0.35
+    circle_radius: float = 1.00
+    circle_omega:  float = 0.30
+
+
+# ── Reference trajectories ────────────────────────────────────────────────────
+
+def circle_ref(t: float, radius: float, omega: float, z_hover: float) -> np.ndarray:
+    ref = np.zeros(12)
+    ref[0] = radius * np.cos(omega * t)
+    ref[1] = radius * np.sin(omega * t)
+    ref[2] = z_hover
+    return ref
+
+
+def get_ref(t: float, cfg: SimConfig) -> np.ndarray:
+    if t < cfg.t_hover:
+        ref = np.zeros(12)
+        ref[2] = cfg.z_hover
+        return ref
+    t_track = t - cfg.t_hover
+    if cfg.ref_type == "figure8":
+        r = figure8_ref(t_track, amp=cfg.fig8_amp,
+                        omega=cfg.fig8_omega, z_hover=cfg.z_hover)
+    elif cfg.ref_type == "circle":
+        r = circle_ref(t_track, cfg.circle_radius, cfg.circle_omega, cfg.z_hover)
+    else:
+        r = np.zeros(12)
+        r[2] = cfg.z_hover
+    return r
+
+
+# ── Config GUI ────────────────────────────────────────────────────────────────
+
+BG      = "#0f172a"
+PANEL   = "#1e293b"
+BORDER  = "#334155"
+FG      = "#e2e8f0"
+ACCENT  = "#38bdf8"
+BTN_OK  = "#0ea5e9"
+BTN_CAN = "#475569"
+FONT    = ("Segoe UI", 10)
+FONT_H  = ("Segoe UI", 11, "bold")
+FONT_S  = ("Segoe UI", 9)
+
+
+def _show_config_dialog() -> SimConfig | None:
+    """Opens a tkinter config dialog. Returns SimConfig or None if cancelled."""
+    result: list[SimConfig | None] = [None]
+
+    root = tk.Tk()
+    root.title("Quadcopter MIMO — Simulation Config")
+    root.configure(bg=BG)
+    root.resizable(False, False)
+
+    # ── helpers ───────────────────────────────────────────────────────────────
+    def _label(parent: tk.Widget, text: str, font=FONT) -> tk.Label:
+        return tk.Label(parent, text=text, bg=PANEL, fg=FG, font=font)
+
+    def _frame(parent: tk.Widget, **kw) -> tk.Frame:
+        return tk.Frame(parent, bg=PANEL, bd=1, relief="flat", **kw)
+
+    def _section(parent: tk.Widget, title: str) -> tk.Frame:
+        outer = tk.Frame(parent, bg=BG, pady=4)
+        outer.pack(fill="x", padx=14, pady=2)
+        tk.Label(outer, text=title, bg=BG, fg=ACCENT, font=FONT_H).pack(anchor="w")
+        inner = tk.Frame(outer, bg=PANEL, pady=6, padx=10,
+                         highlightbackground=BORDER, highlightthickness=1)
+        inner.pack(fill="x")
+        return inner
+
+    def _slider_row(parent: tk.Widget, label: str,
+                    var: tk.DoubleVar | tk.IntVar,
+                    lo: float, hi: float, step: float,
+                    fmt: str = "{:.2f}") -> None:
+        row = tk.Frame(parent, bg=PANEL)
+        row.pack(fill="x", pady=3)
+        tk.Label(row, text=label, bg=PANEL, fg=FG, font=FONT,
+                 width=22, anchor="w").pack(side="left")
+        val_lbl = tk.Label(row, text=fmt.format(var.get()),
+                           bg=PANEL, fg=ACCENT, font=FONT, width=7)
+        val_lbl.pack(side="right", padx=6)
+
+        def _update(v: str) -> None:
+            val_lbl.config(text=fmt.format(float(v)))
+
+        sc = tk.Scale(
+            row, variable=var, from_=lo, to=hi, resolution=step,
+            orient="horizontal", length=260, bg=PANEL, fg=FG,
+            troughcolor=BORDER, activebackground=ACCENT,
+            highlightthickness=0, bd=0, showvalue=False, command=_update,
+        )
+        sc.pack(side="left", padx=4)
+
+    # ── variables ─────────────────────────────────────────────────────────────
+    v_ttotal  = tk.DoubleVar(value=45.0)
+    v_thover  = tk.DoubleVar(value=3.0)
+    v_zhover  = tk.DoubleVar(value=1.5)
+    v_reftype = tk.StringVar(value="figure8")
+    v_f8amp   = tk.DoubleVar(value=0.80)
+    v_f8omega = tk.DoubleVar(value=0.35)
+    v_crad    = tk.DoubleVar(value=1.00)
+    v_comega  = tk.DoubleVar(value=0.30)
+
+    # ── layout ────────────────────────────────────────────────────────────────
+    tk.Label(root, text="Quadcopter MIMO — Simulation Config",
+             bg=BG, fg=FG, font=("Segoe UI", 13, "bold")).pack(pady=(14, 4))
+    tk.Label(root, text="Configure parameters and click  Run Simulation",
+             bg=BG, fg=BORDER, font=FONT_S).pack(pady=(0, 8))
+
+    # — Time section —
+    sec_time = _section(root, "Simulation Time")
+    _slider_row(sec_time, "Total time  (s)",        v_ttotal,  5.0, 120.0, 1.0, "{:.0f} s")
+    _slider_row(sec_time, "Takeoff hover phase  (s)", v_thover, 1.0,  15.0, 0.5, "{:.1f} s")
+    _slider_row(sec_time, "Hover altitude  z  (m)",  v_zhover, 0.5,   4.0, 0.1, "{:.1f} m")
+
+    # — Reference trajectory section —
+    sec_ref = _section(root, "Reference Trajectory")
+    ref_frame = tk.Frame(sec_ref, bg=PANEL)
+    ref_frame.pack(fill="x", pady=4)
+    tk.Label(ref_frame, text="Trajectory type", bg=PANEL, fg=FG, font=FONT,
+             width=22, anchor="w").pack(side="left")
+    for val, txt in [("figure8", "Figure-8  (lemniscate)"),
+                     ("circle",  "Circle"),
+                     ("hover",   "Hover  (static)")]:
+        tk.Radiobutton(
+            ref_frame, text=txt, variable=v_reftype, value=val,
+            bg=PANEL, fg=FG, selectcolor=BORDER, activebackground=PANEL,
+            activeforeground=ACCENT, font=FONT_S,
+        ).pack(side="left", padx=8)
+
+    # — Figure-8 params —
+    sec_f8 = _section(root, "Figure-8 Parameters")
+    _slider_row(sec_f8, "Amplitude  A  (m)",        v_f8amp,   0.2, 2.0, 0.05, "{:.2f} m")
+    _slider_row(sec_f8, "Angular speed  ω  (rad/s)", v_f8omega, 0.1, 0.8, 0.05, "{:.2f} r/s")
+
+    # — Circle params —
+    sec_ci = _section(root, "Circle Parameters")
+    _slider_row(sec_ci, "Radius  R  (m)",            v_crad,   0.2, 3.0, 0.1,  "{:.1f} m")
+    _slider_row(sec_ci, "Angular speed  ω  (rad/s)", v_comega, 0.1, 0.8, 0.05, "{:.2f} r/s")
+
+    # — Buttons —
+    btn_row = tk.Frame(root, bg=BG)
+    btn_row.pack(pady=14, padx=14, fill="x")
+
+    def _on_run() -> None:
+        result[0] = SimConfig(
+            t_total       = v_ttotal.get(),
+            t_hover       = v_thover.get(),
+            z_hover       = v_zhover.get(),
+            ref_type      = v_reftype.get(),
+            fig8_amp      = v_f8amp.get(),
+            fig8_omega    = v_f8omega.get(),
+            circle_radius = v_crad.get(),
+            circle_omega  = v_comega.get(),
+        )
+        root.destroy()
+
+    def _on_cancel() -> None:
+        root.destroy()
+
+    tk.Button(
+        btn_row, text="  Run Simulation  ", command=_on_run,
+        bg=BTN_OK, fg="white", font=FONT_H, relief="flat",
+        activebackground="#0284c7", activeforeground="white",
+        padx=12, pady=6, cursor="hand2",
+    ).pack(side="right", padx=4)
+    tk.Button(
+        btn_row, text="  Cancel  ", command=_on_cancel,
+        bg=BTN_CAN, fg=FG, font=FONT, relief="flat",
+        activebackground="#64748b", activeforeground="white",
+        padx=12, pady=6, cursor="hand2",
+    ).pack(side="right", padx=4)
+
+    # centre on screen
+    root.update_idletasks()
+    w, h = root.winfo_reqwidth(), root.winfo_reqheight()
+    sw, sh = root.winfo_screenwidth(), root.winfo_screenheight()
+    root.geometry(f"{w}x{h}+{(sw - w) // 2}+{(sh - h) // 2}")
+
+    root.mainloop()
+    return result[0]
 
 
 # ── Neural-LQR ────────────────────────────────────────────────────────────────
 
 def build_neural_lqr(K: np.ndarray) -> "nn.Module":
-    """Residual MLP: δu = −K·e + net(e),  net initialised to zero.
-
-    At t=0 the residual is zero → network == optimal LQR.
-    Fine-tune via RL / imitation learning without API changes.
-    """
+    """Residual MLP: δu = −K·e + net(e),  net initialised to zero."""
 
     class NeuralLQR(nn.Module):
         def __init__(self, K_np: np.ndarray) -> None:
@@ -99,7 +289,7 @@ def build_neural_lqr(K: np.ndarray) -> "nn.Module":
                 nn.init.zeros_(self.residual[0].bias)
                 nn.init.xavier_uniform_(self.residual[2].weight)
                 nn.init.zeros_(self.residual[2].bias)
-                nn.init.zeros_(self.residual[4].weight)   # residual starts at 0
+                nn.init.zeros_(self.residual[4].weight)
                 nn.init.zeros_(self.residual[4].bias)
 
         def forward(self, e: "torch.Tensor") -> "torch.Tensor":
@@ -110,20 +300,24 @@ def build_neural_lqr(K: np.ndarray) -> "nn.Module":
 
 # ── Simulation thread ─────────────────────────────────────────────────────────
 
-def _sim_thread(sys_d: object, K: np.ndarray, net: object | None) -> None:
+def _sim_thread(sys_d: object, K: np.ndarray, net: object | None,
+                cfg: SimConfig) -> None:
+    global _refs, _inputs, _times
+    n_steps = int(cfg.t_total / DT)
     x = np.zeros(12)
 
-    for step in range(N_STEPS):
-        t    = step * DT
-        t0   = time.perf_counter()
+    with _lock:
+        _refs   = collections.deque(maxlen=n_steps)
+        _inputs = collections.deque(maxlen=n_steps)
+        _times  = collections.deque(maxlen=n_steps)
 
-        x_ref = np.zeros(12)
-        if t < T_HOVER:
-            x_ref[2] = 1.50
-        else:
-            x_ref = figure8_ref(t - T_HOVER)
+    for step in range(n_steps):
+        t  = step * DT
+        t0 = time.perf_counter()
 
-        e = x - x_ref
+        x_ref   = get_ref(t, cfg)
+        e       = x - x_ref
+
         if net is not None and HAS_TORCH:
             with torch.no_grad():
                 t_in    = torch.tensor(e, dtype=torch.float32).unsqueeze(0)
@@ -151,17 +345,13 @@ def _sim_thread(sys_d: object, K: np.ndarray, net: object | None) -> None:
 # ── PyVista 3-D drone mesh ────────────────────────────────────────────────────
 
 def _build_drone() -> pv.PolyData:
-    """X-configuration quadcopter mesh centred at origin."""
     L = ARM / np.sqrt(2.0)
     motor_xy = [(L, L), (-L, L), (-L, -L), (L, -L)]
-
     body  = pv.Box(bounds=[-0.065, 0.065, -0.065, 0.065, -0.022, 0.022])
     parts: list[pv.PolyData] = [body]
-
     for mx, my in motor_xy:
         arm = pv.Cylinder(
-            center=(mx / 2, my / 2, 0.0),
-            direction=(mx, my, 0.0),
+            center=(mx / 2, my / 2, 0.0), direction=(mx, my, 0.0),
             radius=0.007, height=ARM, resolution=8, capping=True,
         )
         rotor = pv.Disc(
@@ -169,7 +359,6 @@ def _build_drone() -> pv.PolyData:
             inner=0.0, outer=0.058, r_res=1, c_res=24,
         )
         parts += [arm, rotor]
-
     mesh: pv.PolyData = parts[0]
     for p in parts[1:]:
         mesh = mesh.merge(p)
@@ -178,54 +367,58 @@ def _build_drone() -> pv.PolyData:
 
 # ── PyVista scene ─────────────────────────────────────────────────────────────
 
-def _setup_3d(pl: pv.Plotter, drone_base: pv.PolyData) -> dict:
+def _setup_3d(pl: pv.Plotter, drone_base: pv.PolyData, cfg: SimConfig) -> dict:
     actors: dict = {}
 
-    # Ground grid
-    ground = pv.Plane(center=(0, 0, 0), direction=(0, 0, 1),
-                      i_size=8, j_size=8, i_resolution=16, j_resolution=16)
-    pl.add_mesh(ground, color="#1e293b", style="wireframe",
-                line_width=0.6, opacity=0.5)
+    pl.add_mesh(
+        pv.Plane(center=(0, 0, 0), direction=(0, 0, 1),
+                 i_size=8, j_size=8, i_resolution=16, j_resolution=16),
+        color="#1e293b", style="wireframe", line_width=0.6, opacity=0.5,
+    )
+    pl.add_mesh(
+        pv.Plane(center=(0, 0, cfg.z_hover), direction=(0, 0, 1),
+                 i_size=3, j_size=3, i_resolution=6, j_resolution=6),
+        color="#0ea5e9", style="wireframe", line_width=0.4, opacity=0.22,
+    )
 
-    # Hover altitude reference plane
-    hover_plane = pv.Plane(center=(0, 0, 1.5), direction=(0, 0, 1),
-                           i_size=3, j_size=3, i_resolution=6, j_resolution=6)
-    pl.add_mesh(hover_plane, color="#0ea5e9", style="wireframe",
-                line_width=0.4, opacity=0.22)
-
-    # Figure-8 reference curve (static)
-    ts    = np.linspace(0, 2 * np.pi / 0.35, 400)
-    denom = 1.0 + np.sin(0.35 * ts) ** 2
-    ref_pts = np.column_stack([
-        0.80 * np.cos(0.35 * ts) / denom,
-        0.80 * np.sin(0.35 * ts) * np.cos(0.35 * ts) / denom,
-        np.full(400, 1.50),
-    ])
-    ref_poly        = pv.PolyData(ref_pts)
-    ref_poly.lines  = np.hstack([[400], np.arange(400)])
+    # Reference curve (static preview)
+    ts = np.linspace(0, 2 * np.pi / max(cfg.fig8_omega, cfg.circle_omega), 400)
+    if cfg.ref_type == "figure8":
+        denom   = 1.0 + np.sin(cfg.fig8_omega * ts) ** 2
+        ref_pts = np.column_stack([
+            cfg.fig8_amp * np.cos(cfg.fig8_omega * ts) / denom,
+            cfg.fig8_amp * np.sin(cfg.fig8_omega * ts) * np.cos(cfg.fig8_omega * ts) / denom,
+            np.full(400, cfg.z_hover),
+        ])
+    elif cfg.ref_type == "circle":
+        ref_pts = np.column_stack([
+            cfg.circle_radius * np.cos(cfg.circle_omega * ts),
+            cfg.circle_radius * np.sin(cfg.circle_omega * ts),
+            np.full(400, cfg.z_hover),
+        ])
+    else:
+        ref_pts = np.column_stack([np.zeros(400), np.zeros(400),
+                                   np.full(400, cfg.z_hover)])
+    ref_poly       = pv.PolyData(ref_pts)
+    ref_poly.lines = np.hstack([[400], np.arange(400)])
     pl.add_mesh(ref_poly, color="#22c55e", line_width=1.5, opacity=0.65)
 
-    # Trajectory trail
     trail_pts        = np.zeros((TRAIL_LEN, 3))
     trail_poly       = pv.PolyData(trail_pts)
     trail_poly.lines = np.hstack([[TRAIL_LEN], np.arange(TRAIL_LEN)])
-    actors["trail_actor"] = pl.add_mesh(
-        trail_poly, color="#3b82f6", line_width=2.5, opacity=0.85,
-    )
-    actors["trail_poly"] = trail_poly
+    actors["trail_actor"] = pl.add_mesh(trail_poly, color="#3b82f6",
+                                        line_width=2.5, opacity=0.85)
+    actors["trail_poly"]  = trail_poly
 
-    # Drone
     actors["drone"] = pl.add_mesh(
-        drone_base.copy(),
-        color="#e11d48", specular=0.7, specular_power=15, smooth_shading=True,
+        drone_base.copy(), color="#e11d48",
+        specular=0.7, specular_power=15, smooth_shading=True,
     )
 
-    # Reference marker
-    ref_sphere = pv.Sphere(radius=0.055, center=(0, 0, 1.5))
+    ref_sphere = pv.Sphere(radius=0.055, center=(0, 0, cfg.z_hover))
     actors["ref_actor"]  = pl.add_mesh(ref_sphere, color="#4ade80", opacity=0.85)
     actors["ref_sphere"] = ref_sphere
 
-    # HUD text — use tuple position to get vtkTextActor (has SetInput)
     actors["hud"] = pl.add_text(
         "Initialising…",
         position=(0.01, 0.90), font_size=9, color="#e2e8f0", font="courier",
@@ -247,26 +440,22 @@ def _update_pv(actors: dict, states: list, times: list, refs: list) -> None:
     x = states[-1]
     t = times[-1] if times else 0.0
 
-    # Drone transform
     rot       = Rotation.from_euler("xyz", x[3:6]).as_matrix()
     T         = np.eye(4)
     T[:3, :3] = rot
     T[:3, 3]  = x[:3]
     actors["drone"].user_matrix = T
 
-    # Trail
     pts = np.array([s[:3] for s in states], dtype=float)
     n   = len(pts)
     if n < TRAIL_LEN:
         pts = np.vstack([np.tile(pts[0:1], (TRAIL_LEN - n, 1)), pts])
     actors["trail_poly"].points = pts
 
-    # Reference marker
     if refs:
         xr = refs[-1]
         actors["ref_actor"].SetPosition(xr[0], xr[1], xr[2])
 
-    # HUD
     phi_d, theta_d, psi_d = np.degrees(x[3:6])
     mode = "Neural-LQR" if HAS_TORCH else "LQR"
     actors["hud"].SetInput(
@@ -277,44 +466,43 @@ def _update_pv(actors: dict, states: list, times: list, refs: list) -> None:
     )
 
 
-# ── Matplotlib telemetry window ───────────────────────────────────────────────
+# ── Matplotlib telemetry ──────────────────────────────────────────────────────
 
-DARK_BG   = "#0f172a"
-PANEL_BG  = "#1e293b"
-GRID_COL  = "#334155"
-TEXT_COL  = "#94a3b8"
-
-CYAN    = "#38bdf8"
-PINK    = "#f472b6"
-YELLOW  = "#facc15"
-VIOLET  = "#a78bfa"
-ORANGE  = "#fb923c"
-TEAL    = "#34d399"
-RED     = "#ef4444"
-BLUE    = "#3b82f6"
-GREEN   = "#22c55e"
-AMBER   = "#f59e0b"
+_DARK   = "#0f172a"
+_PANEL  = "#1e293b"
+_GRID   = "#334155"
+_TEXT   = "#94a3b8"
+_CYAN   = "#38bdf8"
+_YELLOW = "#facc15"
+_VIOLET = "#a78bfa"
+_ORANGE = "#fb923c"
+_TEAL   = "#34d399"
+_RED    = "#ef4444"
+_BLUE   = "#3b82f6"
+_GREEN  = "#22c55e"
+_AMBER  = "#f59e0b"
 
 
-def _build_mpl_figure() -> tuple:
-    fig = plt.figure(figsize=(13, 9), facecolor=DARK_BG)
+def _build_mpl_figure(cfg: SimConfig) -> tuple:
+    fig = plt.figure(figsize=(13, 9), facecolor=_DARK)
+    lbl = {"figure8": "Figure-8", "circle": "Circle", "hover": "Hover"}
     fig.suptitle(
-        "Quadcopter MIMO  —  Neural-LQR Telemetry",
+        f"Quadcopter MIMO  —  Neural-LQR Telemetry  |  {lbl[cfg.ref_type]}  "
+        f"  t={cfg.t_total:.0f} s",
         color="white", fontsize=13, fontweight="bold", y=0.98,
     )
-
     gs = gridspec.GridSpec(3, 2, figure=fig,
                            hspace=0.50, wspace=0.35,
                            left=0.07, right=0.97, top=0.93, bottom=0.07)
 
-    def _ax(row, col, colspan=1):
+    def _ax(row: int, col: int, colspan: int = 1) -> plt.Axes:
         ax = fig.add_subplot(gs[row, col] if colspan == 1
                              else gs[row, slice(col, col + colspan)])
-        ax.set_facecolor(PANEL_BG)
-        ax.tick_params(colors=TEXT_COL, labelsize=8)
+        ax.set_facecolor(_PANEL)
+        ax.tick_params(colors=_TEXT, labelsize=8)
         for sp in ax.spines.values():
-            sp.set_edgecolor(GRID_COL)
-        ax.grid(True, color=GRID_COL, linewidth=0.5, alpha=0.7)
+            sp.set_edgecolor(_GRID)
+        ax.grid(True, color=_GRID, linewidth=0.5, alpha=0.7)
         return ax
 
     ax_xy  = _ax(0, 0)
@@ -323,51 +511,59 @@ def _build_mpl_figure() -> tuple:
     ax_u   = _ax(2, 0, colspan=2)
 
     ax_xy.set_title("Top-down  x-y  trajectory", color="#e2e8f0", fontsize=10, pad=5)
-    ax_xy.set_xlabel("x  (m)", color=TEXT_COL, fontsize=9)
-    ax_xy.set_ylabel("y  (m)", color=TEXT_COL, fontsize=9)
+    ax_xy.set_xlabel("x  (m)", color=_TEXT, fontsize=9)
+    ax_xy.set_ylabel("y  (m)", color=_TEXT, fontsize=9)
     ax_xy.set_aspect("equal")
-    ts_ref   = np.linspace(0, 2 * np.pi / 0.35, 300)
-    dn_ref   = 1.0 + np.sin(0.35 * ts_ref) ** 2
-    x8 = 0.80 * np.cos(0.35 * ts_ref) / dn_ref
-    y8 = 0.80 * np.sin(0.35 * ts_ref) * np.cos(0.35 * ts_ref) / dn_ref
-    ax_xy.plot(x8, y8, color=GREEN, lw=1.0, ls="--", alpha=0.5, label="ref figure-8")
-    l_traj,   = ax_xy.plot([], [], color=BLUE,  lw=1.5, label="trajectory")
-    l_dot_xy, = ax_xy.plot([], [], "o", color=CYAN, ms=7, zorder=5)
-    ax_xy.legend(fontsize=7, facecolor=PANEL_BG, edgecolor=GRID_COL,
+
+    # Static reference preview
+    ts_ref = np.linspace(0, 2 * np.pi / max(cfg.fig8_omega, cfg.circle_omega, 0.01), 300)
+    if cfg.ref_type == "figure8":
+        dn = 1.0 + np.sin(cfg.fig8_omega * ts_ref) ** 2
+        x8 = cfg.fig8_amp * np.cos(cfg.fig8_omega * ts_ref) / dn
+        y8 = cfg.fig8_amp * np.sin(cfg.fig8_omega * ts_ref) * np.cos(cfg.fig8_omega * ts_ref) / dn
+    elif cfg.ref_type == "circle":
+        x8 = cfg.circle_radius * np.cos(cfg.circle_omega * ts_ref)
+        y8 = cfg.circle_radius * np.sin(cfg.circle_omega * ts_ref)
+    else:
+        x8 = np.zeros_like(ts_ref)
+        y8 = np.zeros_like(ts_ref)
+    ax_xy.plot(x8, y8, color=_GREEN, lw=1.0, ls="--", alpha=0.5, label="ref")
+    l_traj,   = ax_xy.plot([], [], color=_BLUE,  lw=1.5, label="trajectory")
+    l_dot_xy, = ax_xy.plot([], [], "o", color=_CYAN, ms=7, zorder=5)
+    ax_xy.legend(fontsize=7, facecolor=_PANEL, edgecolor=_GRID,
                  labelcolor="#e2e8f0", loc="upper right")
 
     ax_z.set_title("Altitude  z(t)", color="#e2e8f0", fontsize=10, pad=5)
-    ax_z.set_xlabel("t  (s)", color=TEXT_COL, fontsize=9)
-    ax_z.set_ylabel("z  (m)", color=TEXT_COL, fontsize=9)
-    ax_z.axhline(1.5, color=GREEN, ls="--", lw=1.0, alpha=0.5, label="z_ref = 1.5 m")
-    l_z,      = ax_z.plot([], [], color=YELLOW, lw=1.8, label="z(t)")
-    ax_z.legend(fontsize=7, facecolor=PANEL_BG, edgecolor=GRID_COL,
-                labelcolor="#e2e8f0")
+    ax_z.set_xlabel("t  (s)", color=_TEXT, fontsize=9)
+    ax_z.set_ylabel("z  (m)", color=_TEXT, fontsize=9)
+    ax_z.axhline(cfg.z_hover, color=_GREEN, ls="--", lw=1.0, alpha=0.5,
+                 label=f"z_ref = {cfg.z_hover:.1f} m")
+    l_z, = ax_z.plot([], [], color=_YELLOW, lw=1.8, label="z(t)")
+    ax_z.legend(fontsize=7, facecolor=_PANEL, edgecolor=_GRID, labelcolor="#e2e8f0")
 
     ax_ang.set_title("Euler angles  phi, theta, psi", color="#e2e8f0", fontsize=10, pad=5)
-    ax_ang.set_xlabel("t  (s)", color=TEXT_COL, fontsize=9)
-    ax_ang.set_ylabel("deg", color=TEXT_COL, fontsize=9)
-    ax_ang.axhline(0, color=GRID_COL, ls=":", lw=0.7, alpha=0.6)
-    l_phi,    = ax_ang.plot([], [], color=VIOLET, lw=1.5, label="phi  roll")
-    l_theta,  = ax_ang.plot([], [], color=ORANGE, lw=1.5, label="theta  pitch")
-    l_psi,    = ax_ang.plot([], [], color=TEAL,   lw=1.5, label="psi  yaw")
-    ax_ang.legend(fontsize=8, ncol=3, facecolor=PANEL_BG, edgecolor=GRID_COL,
+    ax_ang.set_xlabel("t  (s)", color=_TEXT, fontsize=9)
+    ax_ang.set_ylabel("deg", color=_TEXT, fontsize=9)
+    ax_ang.axhline(0, color=_GRID, ls=":", lw=0.7, alpha=0.6)
+    l_phi,   = ax_ang.plot([], [], color=_VIOLET, lw=1.5, label="phi  roll")
+    l_theta, = ax_ang.plot([], [], color=_ORANGE, lw=1.5, label="theta  pitch")
+    l_psi,   = ax_ang.plot([], [], color=_TEAL,   lw=1.5, label="psi  yaw")
+    ax_ang.legend(fontsize=8, ncol=3, facecolor=_PANEL, edgecolor=_GRID,
                   labelcolor="#e2e8f0", loc="upper right")
 
     ax_u.set_title("Control deviations  delta_u", color="#e2e8f0", fontsize=10, pad=5)
-    ax_u.set_xlabel("t  (s)", color=TEXT_COL, fontsize=9)
-    ax_u.set_ylabel("N  /  Nm", color=TEXT_COL, fontsize=9)
-    ax_u.axhline(0, color=GRID_COL, ls=":", lw=0.7, alpha=0.6)
-    l_dF,     = ax_u.plot([], [], color=RED,   lw=1.5, label="dF  (N)")
-    l_tau_p,  = ax_u.plot([], [], color=BLUE,  lw=1.5, label="tau_phi  (Nm)")
-    l_tau_q,  = ax_u.plot([], [], color=GREEN, lw=1.5, label="tau_theta  (Nm)")
-    l_tau_r,  = ax_u.plot([], [], color=AMBER, lw=1.5, label="tau_psi  (Nm)")
-    ax_u.legend(fontsize=8, ncol=4, facecolor=PANEL_BG, edgecolor=GRID_COL,
+    ax_u.set_xlabel("t  (s)", color=_TEXT, fontsize=9)
+    ax_u.set_ylabel("N  /  Nm", color=_TEXT, fontsize=9)
+    ax_u.axhline(0, color=_GRID, ls=":", lw=0.7, alpha=0.6)
+    l_dF,    = ax_u.plot([], [], color=_RED,   lw=1.5, label="dF  (N)")
+    l_tau_p, = ax_u.plot([], [], color=_BLUE,  lw=1.5, label="tau_phi  (Nm)")
+    l_tau_q, = ax_u.plot([], [], color=_GREEN, lw=1.5, label="tau_theta  (Nm)")
+    l_tau_r, = ax_u.plot([], [], color=_AMBER, lw=1.5, label="tau_psi  (Nm)")
+    ax_u.legend(fontsize=8, ncol=4, facecolor=_PANEL, edgecolor=_GRID,
                 labelcolor="#e2e8f0", loc="upper right")
 
     lines = dict(
-        traj=l_traj, dot_xy=l_dot_xy,
-        z=l_z,
+        traj=l_traj, dot_xy=l_dot_xy, z=l_z,
         phi=l_phi, theta=l_theta, psi=l_psi,
         dF=l_dF, tau_p=l_tau_p, tau_q=l_tau_q, tau_r=l_tau_r,
     )
@@ -380,7 +576,6 @@ def _update_mpl(axes: dict, lines: dict,
     n = min(len(times), len(states), len(refs), len(inputs))
     if n < 3:
         return
-
     t_arr = np.asarray(times[-n:],  dtype=float)
     s_arr = np.asarray(states[-n:], dtype=float)
     u_arr = np.asarray(inputs[-n:], dtype=float)
@@ -399,11 +594,8 @@ def _update_mpl(axes: dict, lines: dict,
     for key, ax in axes.items():
         ax.relim()
         ax.autoscale_view()
-        if key == "xy":
-            ax.set_xlim(-1.1, 1.1)
-            ax.set_ylim(-1.1, 1.1)
         if key == "z":
-            ax.set_ylim(-0.1, 2.0)
+            ax.set_ylim(-0.1, 2.5)
 
 
 # ── Main ──────────────────────────────────────────────────────────────────────
@@ -413,57 +605,63 @@ def main() -> None:
     print("  Quadcopter MIMO  —  Neural-LQR + PyVista 3D")
     print("=" * 60)
 
+    # Config dialog
+    cfg = _show_config_dialog()
+    if cfg is None:
+        print("Cancelled.")
+        return
+
+    print(f"\nConfig: t={cfg.t_total:.0f}s  hover={cfg.t_hover:.1f}s  "
+          f"z={cfg.z_hover:.1f}m  ref={cfg.ref_type}")
+
+    # Build model
     A, B, C, D = build_matrices()
     sys_c = ss(A, B, C, D)
     sys_d = c2d(sys_c, DT)
-    print(f"\nPlant: {sys_c.n_states} states · {sys_c.n_inputs} inputs "
+    print(f"Plant: {sys_c.n_states} states · {sys_c.n_inputs} inputs "
           f"· {sys_c.n_outputs} outputs")
-    print(f"Open-loop: max Re(poles) = {max(np.real(sys_c.poles())):.4f}")
 
-    print("\nSolving LQR…")
+    print("Solving LQR…")
     K, _ = lqr(A, B, Q_LQR, R_LQR)
     cl   = np.linalg.eigvals(A - B @ K)
     print(f"  K : {K.shape}    CL max Re = {max(np.real(cl)):.4f}  (< 0 ok)")
 
     net = None
     if HAS_TORCH:
-        print("\nBuilding Neural-LQR (residual MLP 12->64->32->4)…")
+        print("Building Neural-LQR (12->64->32->4)…")
         net = build_neural_lqr(K)
-        n_p = sum(p.numel() for p in net.parameters())
-        print(f"  {n_p:,} parameters   |   residual init to 0 -> starts at LQR")
 
-    print(f"\nSimulation: {T_TOTAL:.0f} s @ {int(1/DT)} Hz…")
-    sim = threading.Thread(target=_sim_thread, args=(sys_d, K, net), daemon=True)
+    # Simulation thread
+    sim = threading.Thread(target=_sim_thread, args=(sys_d, K, net, cfg), daemon=True)
     sim.start()
     time.sleep(0.12)
 
-    # ── Matplotlib (non-blocking) ─────────────────────────────────────────────
+    # Matplotlib (non-blocking)
     plt.ion()
-    fig, axes, lines = _build_mpl_figure()
+    fig, axes, lines = _build_mpl_figure(cfg)
     plt.show(block=False)
     fig.canvas.draw()
     fig.canvas.flush_events()
 
-    # ── PyVista (non-blocking interactive_update) ─────────────────────────────
+    # PyVista (non-blocking)
     print("Opening PyVista 3D window…  (close window or Ctrl+C to exit)\n")
     drone_mesh = _build_drone()
     pl = pv.Plotter(
         window_size=(900, 820),
         title="Quadcopter MIMO — Neural-LQR  |  synapsys",
     )
-    actors = _setup_3d(pl, drone_mesh)
+    actors = _setup_3d(pl, drone_mesh, cfg)
     pl.show(auto_close=False, interactive_update=True)
 
-    # ── Main update loop ──────────────────────────────────────────────────────
-    pv_dt   = 1.0 / VIZ_HZ
-    mpl_dt  = 1.0 / MPL_HZ
+    # Main update loop
+    pv_dt    = 1.0 / VIZ_HZ
+    mpl_dt   = 1.0 / MPL_HZ
     last_pv  = time.perf_counter()
     last_mpl = time.perf_counter()
 
     try:
         while not _done[0]:
             now = time.perf_counter()
-
             if now - last_pv >= pv_dt:
                 with _lock:
                     states = list(_states)
@@ -472,7 +670,6 @@ def main() -> None:
                 _update_pv(actors, states, times, refs)
                 pl.update()
                 last_pv = now
-
             if now - last_mpl >= mpl_dt:
                 with _lock:
                     states = list(_states)
@@ -483,9 +680,7 @@ def main() -> None:
                 fig.canvas.draw()
                 fig.canvas.flush_events()
                 last_mpl = now
-
             time.sleep(0.004)
-
     except KeyboardInterrupt:
         print("\nInterrupted.")
     finally:

--- a/examples/advanced/06_quadcopter_mimo/06b_neural_lqr_3d.py
+++ b/examples/advanced/06_quadcopter_mimo/06b_neural_lqr_3d.py
@@ -1,0 +1,509 @@
+"""Quadcopter MIMO — Neural-LQR controller + PyVista real-time 3D animation.
+
+Demonstrates
+------------
+* MIMO LTI modelling with synapsys  (12 states, 4 inputs, 4 outputs)
+* LQR design via synapsys.algorithms.lqr() on the MIMO plant
+* Residual Neural-LQR: δu = −K·e + MLP(e), residual zeroed at init so
+  the network starts at the optimal linear policy and can be fine-tuned
+* Real-time 3D animation of drone pose + trajectory (PyVista, 50 Hz)
+* Real-time 2D telemetry panels (matplotlib, 10 Hz, same main thread)
+
+Architecture
+------------
+  sim_thread  : StateSpace.evolve() at 100 Hz (real-time paced)
+  main thread : manual update loop — PyVista 3D + matplotlib telemetry
+
+Run
+---
+  pip install synapsys[viz] torch matplotlib
+  python 06b_neural_lqr_3d.py
+"""
+from __future__ import annotations
+
+import collections
+import sys
+import threading
+import time
+from pathlib import Path
+
+import matplotlib
+matplotlib.use("TkAgg")
+import matplotlib.gridspec as gridspec
+import matplotlib.pyplot as plt
+import numpy as np
+from scipy.spatial.transform import Rotation
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+try:
+    import pyvista as pv
+except ImportError:
+    print("PyVista not found.  Install with:  pip install synapsys[viz]")
+    sys.exit(1)
+
+try:
+    import torch
+    import torch.nn as nn
+    HAS_TORCH = True
+except ImportError:
+    HAS_TORCH = False
+    print("[warn] PyTorch not found — running plain LQR.")
+
+from synapsys.algorithms import lqr
+from synapsys.api import c2d, ss
+
+from quadcopter_dynamics import (
+    ARM, Q_LQR, R_LQR, U_MAX, U_MIN,
+    build_matrices, figure8_ref,
+)
+
+# ── Simulation parameters ─────────────────────────────────────────────────────
+DT        = 0.01    # 100 Hz
+T_TOTAL   = 45.0    # s
+T_HOVER   = 3.0     # takeoff hover phase
+N_STEPS   = int(T_TOTAL / DT)
+VIZ_HZ    = 50      # PyVista 3D refresh rate
+MPL_HZ    = 10      # matplotlib panels refresh rate
+TRAIL_LEN = 500     # past positions kept for trail
+
+# ── Thread-safe circular buffers ──────────────────────────────────────────────
+_lock    = threading.Lock()
+_states: collections.deque = collections.deque(maxlen=TRAIL_LEN)
+_refs:   collections.deque = collections.deque(maxlen=N_STEPS)
+_inputs: collections.deque = collections.deque(maxlen=N_STEPS)
+_times:  collections.deque = collections.deque(maxlen=N_STEPS)
+_done    = [False]
+
+
+# ── Neural-LQR ────────────────────────────────────────────────────────────────
+
+def build_neural_lqr(K: np.ndarray) -> "nn.Module":
+    """Residual MLP: δu = −K·e + net(e),  net initialised to zero.
+
+    At t=0 the residual is zero → network == optimal LQR.
+    Fine-tune via RL / imitation learning without API changes.
+    """
+
+    class NeuralLQR(nn.Module):
+        def __init__(self, K_np: np.ndarray) -> None:
+            super().__init__()
+            self.register_buffer("K", torch.tensor(K_np, dtype=torch.float32))
+            self.residual = nn.Sequential(
+                nn.Linear(12, 64), nn.Tanh(),
+                nn.Linear(64, 32), nn.Tanh(),
+                nn.Linear(32,  4),
+            )
+            with torch.no_grad():
+                nn.init.xavier_uniform_(self.residual[0].weight)
+                nn.init.zeros_(self.residual[0].bias)
+                nn.init.xavier_uniform_(self.residual[2].weight)
+                nn.init.zeros_(self.residual[2].bias)
+                nn.init.zeros_(self.residual[4].weight)   # residual starts at 0
+                nn.init.zeros_(self.residual[4].bias)
+
+        def forward(self, e: "torch.Tensor") -> "torch.Tensor":
+            return -(e @ self.K.T) + self.residual(e)
+
+    return NeuralLQR(K).eval()
+
+
+# ── Simulation thread ─────────────────────────────────────────────────────────
+
+def _sim_thread(sys_d: object, K: np.ndarray, net: object | None) -> None:
+    x = np.zeros(12)
+
+    for step in range(N_STEPS):
+        t    = step * DT
+        t0   = time.perf_counter()
+
+        x_ref = np.zeros(12)
+        if t < T_HOVER:
+            x_ref[2] = 1.50
+        else:
+            x_ref = figure8_ref(t - T_HOVER)
+
+        e = x - x_ref
+        if net is not None and HAS_TORCH:
+            with torch.no_grad():
+                t_in    = torch.tensor(e, dtype=torch.float32).unsqueeze(0)
+                delta_u: np.ndarray = net(t_in).squeeze(0).numpy()
+        else:
+            delta_u = -(K @ e)
+
+        delta_u = np.clip(delta_u, U_MIN, U_MAX)
+        x_next, _ = sys_d.evolve(x, delta_u)  # type: ignore[union-attr]
+        x = x_next
+
+        with _lock:
+            _states.append(x.copy())
+            _refs.append(x_ref.copy())
+            _inputs.append(delta_u.copy())
+            _times.append(t)
+
+        elapsed = time.perf_counter() - t0
+        if elapsed < DT:
+            time.sleep(DT - elapsed)
+
+    _done[0] = True
+
+
+# ── PyVista 3-D drone mesh ────────────────────────────────────────────────────
+
+def _build_drone() -> pv.PolyData:
+    """X-configuration quadcopter mesh centred at origin."""
+    L = ARM / np.sqrt(2.0)
+    motor_xy = [(L, L), (-L, L), (-L, -L), (L, -L)]
+
+    body  = pv.Box(bounds=[-0.065, 0.065, -0.065, 0.065, -0.022, 0.022])
+    parts: list[pv.PolyData] = [body]
+
+    for mx, my in motor_xy:
+        arm = pv.Cylinder(
+            center=(mx / 2, my / 2, 0.0),
+            direction=(mx, my, 0.0),
+            radius=0.007, height=ARM, resolution=8, capping=True,
+        )
+        rotor = pv.Disc(
+            center=(mx, my, 0.014), normal=(0, 0, 1),
+            inner=0.0, outer=0.058, r_res=1, c_res=24,
+        )
+        parts += [arm, rotor]
+
+    mesh: pv.PolyData = parts[0]
+    for p in parts[1:]:
+        mesh = mesh.merge(p)
+    return mesh
+
+
+# ── PyVista scene ─────────────────────────────────────────────────────────────
+
+def _setup_3d(pl: pv.Plotter, drone_base: pv.PolyData) -> dict:
+    actors: dict = {}
+
+    # Ground grid
+    ground = pv.Plane(center=(0, 0, 0), direction=(0, 0, 1),
+                      i_size=8, j_size=8, i_resolution=16, j_resolution=16)
+    pl.add_mesh(ground, color="#1e293b", style="wireframe",
+                line_width=0.6, opacity=0.5)
+
+    # Hover altitude reference plane
+    hover_plane = pv.Plane(center=(0, 0, 1.5), direction=(0, 0, 1),
+                           i_size=3, j_size=3, i_resolution=6, j_resolution=6)
+    pl.add_mesh(hover_plane, color="#0ea5e9", style="wireframe",
+                line_width=0.4, opacity=0.22)
+
+    # Figure-8 reference curve (static)
+    ts    = np.linspace(0, 2 * np.pi / 0.35, 400)
+    denom = 1.0 + np.sin(0.35 * ts) ** 2
+    ref_pts = np.column_stack([
+        0.80 * np.cos(0.35 * ts) / denom,
+        0.80 * np.sin(0.35 * ts) * np.cos(0.35 * ts) / denom,
+        np.full(400, 1.50),
+    ])
+    ref_poly        = pv.PolyData(ref_pts)
+    ref_poly.lines  = np.hstack([[400], np.arange(400)])
+    pl.add_mesh(ref_poly, color="#22c55e", line_width=1.5, opacity=0.65)
+
+    # Trajectory trail
+    trail_pts        = np.zeros((TRAIL_LEN, 3))
+    trail_poly       = pv.PolyData(trail_pts)
+    trail_poly.lines = np.hstack([[TRAIL_LEN], np.arange(TRAIL_LEN)])
+    actors["trail_actor"] = pl.add_mesh(
+        trail_poly, color="#3b82f6", line_width=2.5, opacity=0.85,
+    )
+    actors["trail_poly"] = trail_poly
+
+    # Drone
+    actors["drone"] = pl.add_mesh(
+        drone_base.copy(),
+        color="#e11d48", specular=0.7, specular_power=15, smooth_shading=True,
+    )
+
+    # Reference marker
+    ref_sphere = pv.Sphere(radius=0.055, center=(0, 0, 1.5))
+    actors["ref_actor"]  = pl.add_mesh(ref_sphere, color="#4ade80", opacity=0.85)
+    actors["ref_sphere"] = ref_sphere
+
+    # HUD text — use tuple position to get vtkTextActor (has SetInput)
+    actors["hud"] = pl.add_text(
+        "Initialising…",
+        position=(0.01, 0.90), font_size=9, color="#e2e8f0", font="courier",
+    )
+
+    pl.set_background("#0f172a")
+    pl.add_light(pv.Light(position=(2, -2, 4), color="white", intensity=0.8))
+    pl.camera.position    = (4.5, -4.0, 3.5)
+    pl.camera.focal_point = (0.0,  0.0, 1.0)
+    pl.camera.up          = (0.0,  0.0, 1.0)
+    return actors
+
+
+# ── PyVista actor update ──────────────────────────────────────────────────────
+
+def _update_pv(actors: dict, states: list, times: list, refs: list) -> None:
+    if not states:
+        return
+    x = states[-1]
+    t = times[-1] if times else 0.0
+
+    # Drone transform
+    rot       = Rotation.from_euler("xyz", x[3:6]).as_matrix()
+    T         = np.eye(4)
+    T[:3, :3] = rot
+    T[:3, 3]  = x[:3]
+    actors["drone"].user_matrix = T
+
+    # Trail
+    pts = np.array([s[:3] for s in states], dtype=float)
+    n   = len(pts)
+    if n < TRAIL_LEN:
+        pts = np.vstack([np.tile(pts[0:1], (TRAIL_LEN - n, 1)), pts])
+    actors["trail_poly"].points = pts
+
+    # Reference marker
+    if refs:
+        xr = refs[-1]
+        actors["ref_actor"].SetPosition(xr[0], xr[1], xr[2])
+
+    # HUD
+    phi_d, theta_d, psi_d = np.degrees(x[3:6])
+    mode = "Neural-LQR" if HAS_TORCH else "LQR"
+    actors["hud"].SetInput(
+        f"  {mode}  |  t = {t:6.2f} s\n"
+        f"  x={x[0]:+.3f}  y={x[1]:+.3f}  z={x[2]:+.3f}  m\n"
+        f"  phi={phi_d:+.1f}  theta={theta_d:+.1f}  psi={psi_d:+.1f}  deg\n"
+        f"  xd={x[6]:+.3f}  yd={x[7]:+.3f}  zd={x[8]:+.3f}  m/s"
+    )
+
+
+# ── Matplotlib telemetry window ───────────────────────────────────────────────
+
+DARK_BG   = "#0f172a"
+PANEL_BG  = "#1e293b"
+GRID_COL  = "#334155"
+TEXT_COL  = "#94a3b8"
+
+CYAN    = "#38bdf8"
+PINK    = "#f472b6"
+YELLOW  = "#facc15"
+VIOLET  = "#a78bfa"
+ORANGE  = "#fb923c"
+TEAL    = "#34d399"
+RED     = "#ef4444"
+BLUE    = "#3b82f6"
+GREEN   = "#22c55e"
+AMBER   = "#f59e0b"
+
+
+def _build_mpl_figure() -> tuple:
+    fig = plt.figure(figsize=(13, 9), facecolor=DARK_BG)
+    fig.suptitle(
+        "Quadcopter MIMO  —  Neural-LQR Telemetry",
+        color="white", fontsize=13, fontweight="bold", y=0.98,
+    )
+
+    gs = gridspec.GridSpec(3, 2, figure=fig,
+                           hspace=0.50, wspace=0.35,
+                           left=0.07, right=0.97, top=0.93, bottom=0.07)
+
+    def _ax(row, col, colspan=1):
+        ax = fig.add_subplot(gs[row, col] if colspan == 1
+                             else gs[row, slice(col, col + colspan)])
+        ax.set_facecolor(PANEL_BG)
+        ax.tick_params(colors=TEXT_COL, labelsize=8)
+        for sp in ax.spines.values():
+            sp.set_edgecolor(GRID_COL)
+        ax.grid(True, color=GRID_COL, linewidth=0.5, alpha=0.7)
+        return ax
+
+    ax_xy  = _ax(0, 0)
+    ax_z   = _ax(0, 1)
+    ax_ang = _ax(1, 0, colspan=2)
+    ax_u   = _ax(2, 0, colspan=2)
+
+    ax_xy.set_title("Top-down  x-y  trajectory", color="#e2e8f0", fontsize=10, pad=5)
+    ax_xy.set_xlabel("x  (m)", color=TEXT_COL, fontsize=9)
+    ax_xy.set_ylabel("y  (m)", color=TEXT_COL, fontsize=9)
+    ax_xy.set_aspect("equal")
+    ts_ref   = np.linspace(0, 2 * np.pi / 0.35, 300)
+    dn_ref   = 1.0 + np.sin(0.35 * ts_ref) ** 2
+    x8 = 0.80 * np.cos(0.35 * ts_ref) / dn_ref
+    y8 = 0.80 * np.sin(0.35 * ts_ref) * np.cos(0.35 * ts_ref) / dn_ref
+    ax_xy.plot(x8, y8, color=GREEN, lw=1.0, ls="--", alpha=0.5, label="ref figure-8")
+    l_traj,   = ax_xy.plot([], [], color=BLUE,  lw=1.5, label="trajectory")
+    l_dot_xy, = ax_xy.plot([], [], "o", color=CYAN, ms=7, zorder=5)
+    ax_xy.legend(fontsize=7, facecolor=PANEL_BG, edgecolor=GRID_COL,
+                 labelcolor="#e2e8f0", loc="upper right")
+
+    ax_z.set_title("Altitude  z(t)", color="#e2e8f0", fontsize=10, pad=5)
+    ax_z.set_xlabel("t  (s)", color=TEXT_COL, fontsize=9)
+    ax_z.set_ylabel("z  (m)", color=TEXT_COL, fontsize=9)
+    ax_z.axhline(1.5, color=GREEN, ls="--", lw=1.0, alpha=0.5, label="z_ref = 1.5 m")
+    l_z,      = ax_z.plot([], [], color=YELLOW, lw=1.8, label="z(t)")
+    ax_z.legend(fontsize=7, facecolor=PANEL_BG, edgecolor=GRID_COL,
+                labelcolor="#e2e8f0")
+
+    ax_ang.set_title("Euler angles  phi, theta, psi", color="#e2e8f0", fontsize=10, pad=5)
+    ax_ang.set_xlabel("t  (s)", color=TEXT_COL, fontsize=9)
+    ax_ang.set_ylabel("deg", color=TEXT_COL, fontsize=9)
+    ax_ang.axhline(0, color=GRID_COL, ls=":", lw=0.7, alpha=0.6)
+    l_phi,    = ax_ang.plot([], [], color=VIOLET, lw=1.5, label="phi  roll")
+    l_theta,  = ax_ang.plot([], [], color=ORANGE, lw=1.5, label="theta  pitch")
+    l_psi,    = ax_ang.plot([], [], color=TEAL,   lw=1.5, label="psi  yaw")
+    ax_ang.legend(fontsize=8, ncol=3, facecolor=PANEL_BG, edgecolor=GRID_COL,
+                  labelcolor="#e2e8f0", loc="upper right")
+
+    ax_u.set_title("Control deviations  delta_u", color="#e2e8f0", fontsize=10, pad=5)
+    ax_u.set_xlabel("t  (s)", color=TEXT_COL, fontsize=9)
+    ax_u.set_ylabel("N  /  Nm", color=TEXT_COL, fontsize=9)
+    ax_u.axhline(0, color=GRID_COL, ls=":", lw=0.7, alpha=0.6)
+    l_dF,     = ax_u.plot([], [], color=RED,   lw=1.5, label="dF  (N)")
+    l_tau_p,  = ax_u.plot([], [], color=BLUE,  lw=1.5, label="tau_phi  (Nm)")
+    l_tau_q,  = ax_u.plot([], [], color=GREEN, lw=1.5, label="tau_theta  (Nm)")
+    l_tau_r,  = ax_u.plot([], [], color=AMBER, lw=1.5, label="tau_psi  (Nm)")
+    ax_u.legend(fontsize=8, ncol=4, facecolor=PANEL_BG, edgecolor=GRID_COL,
+                labelcolor="#e2e8f0", loc="upper right")
+
+    lines = dict(
+        traj=l_traj, dot_xy=l_dot_xy,
+        z=l_z,
+        phi=l_phi, theta=l_theta, psi=l_psi,
+        dF=l_dF, tau_p=l_tau_p, tau_q=l_tau_q, tau_r=l_tau_r,
+    )
+    axes = dict(xy=ax_xy, z=ax_z, ang=ax_ang, u=ax_u)
+    return fig, axes, lines
+
+
+def _update_mpl(axes: dict, lines: dict,
+                states: list, times: list, refs: list, inputs: list) -> None:
+    n = min(len(times), len(states), len(refs), len(inputs))
+    if n < 3:
+        return
+
+    t_arr = np.asarray(times[-n:],  dtype=float)
+    s_arr = np.asarray(states[-n:], dtype=float)
+    u_arr = np.asarray(inputs[-n:], dtype=float)
+
+    lines["traj"].set_data(s_arr[:, 0], s_arr[:, 1])
+    lines["dot_xy"].set_data([s_arr[-1, 0]], [s_arr[-1, 1]])
+    lines["z"].set_data(t_arr, s_arr[:, 2])
+    lines["phi"].set_data(t_arr,   np.degrees(s_arr[:, 3]))
+    lines["theta"].set_data(t_arr, np.degrees(s_arr[:, 4]))
+    lines["psi"].set_data(t_arr,   np.degrees(s_arr[:, 5]))
+    lines["dF"].set_data(t_arr,    u_arr[:, 0])
+    lines["tau_p"].set_data(t_arr, u_arr[:, 1])
+    lines["tau_q"].set_data(t_arr, u_arr[:, 2])
+    lines["tau_r"].set_data(t_arr, u_arr[:, 3])
+
+    for key, ax in axes.items():
+        ax.relim()
+        ax.autoscale_view()
+        if key == "xy":
+            ax.set_xlim(-1.1, 1.1)
+            ax.set_ylim(-1.1, 1.1)
+        if key == "z":
+            ax.set_ylim(-0.1, 2.0)
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    print("=" * 60)
+    print("  Quadcopter MIMO  —  Neural-LQR + PyVista 3D")
+    print("=" * 60)
+
+    A, B, C, D = build_matrices()
+    sys_c = ss(A, B, C, D)
+    sys_d = c2d(sys_c, DT)
+    print(f"\nPlant: {sys_c.n_states} states · {sys_c.n_inputs} inputs "
+          f"· {sys_c.n_outputs} outputs")
+    print(f"Open-loop: max Re(poles) = {max(np.real(sys_c.poles())):.4f}")
+
+    print("\nSolving LQR…")
+    K, _ = lqr(A, B, Q_LQR, R_LQR)
+    cl   = np.linalg.eigvals(A - B @ K)
+    print(f"  K : {K.shape}    CL max Re = {max(np.real(cl)):.4f}  (< 0 ok)")
+
+    net = None
+    if HAS_TORCH:
+        print("\nBuilding Neural-LQR (residual MLP 12->64->32->4)…")
+        net = build_neural_lqr(K)
+        n_p = sum(p.numel() for p in net.parameters())
+        print(f"  {n_p:,} parameters   |   residual init to 0 -> starts at LQR")
+
+    print(f"\nSimulation: {T_TOTAL:.0f} s @ {int(1/DT)} Hz…")
+    sim = threading.Thread(target=_sim_thread, args=(sys_d, K, net), daemon=True)
+    sim.start()
+    time.sleep(0.12)
+
+    # ── Matplotlib (non-blocking) ─────────────────────────────────────────────
+    plt.ion()
+    fig, axes, lines = _build_mpl_figure()
+    plt.show(block=False)
+    fig.canvas.draw()
+    fig.canvas.flush_events()
+
+    # ── PyVista (non-blocking interactive_update) ─────────────────────────────
+    print("Opening PyVista 3D window…  (close window or Ctrl+C to exit)\n")
+    drone_mesh = _build_drone()
+    pl = pv.Plotter(
+        window_size=(900, 820),
+        title="Quadcopter MIMO — Neural-LQR  |  synapsys",
+    )
+    actors = _setup_3d(pl, drone_mesh)
+    pl.show(auto_close=False, interactive_update=True)
+
+    # ── Main update loop ──────────────────────────────────────────────────────
+    pv_dt   = 1.0 / VIZ_HZ
+    mpl_dt  = 1.0 / MPL_HZ
+    last_pv  = time.perf_counter()
+    last_mpl = time.perf_counter()
+
+    try:
+        while not _done[0]:
+            now = time.perf_counter()
+
+            if now - last_pv >= pv_dt:
+                with _lock:
+                    states = list(_states)
+                    times  = list(_times)
+                    refs   = list(_refs)
+                _update_pv(actors, states, times, refs)
+                pl.update()
+                last_pv = now
+
+            if now - last_mpl >= mpl_dt:
+                with _lock:
+                    states = list(_states)
+                    times  = list(_times)
+                    refs   = list(_refs)
+                    inputs = list(_inputs)
+                _update_mpl(axes, lines, states, times, refs, inputs)
+                fig.canvas.draw()
+                fig.canvas.flush_events()
+                last_mpl = now
+
+            time.sleep(0.004)
+
+    except KeyboardInterrupt:
+        print("\nInterrupted.")
+    finally:
+        pl.close()
+        plt.close("all")
+
+    sim.join(timeout=2.0)
+    if _done[0]:
+        with _lock:
+            states = list(_states)
+        if states:
+            f = states[-1]
+            print(f"\nFinal:  x={f[0]:+.3f}  y={f[1]:+.3f}  z={f[2]:+.3f} m  "
+                  f"| phi={np.degrees(f[3]):+.1f} theta={np.degrees(f[4]):+.1f} "
+                  f"psi={np.degrees(f[5]):+.1f} deg")
+    else:
+        print("\nWindow closed early.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/advanced/06_quadcopter_mimo/README.md
+++ b/examples/advanced/06_quadcopter_mimo/README.md
@@ -1,0 +1,82 @@
+# Example 06 — Quadcopter MIMO Neural-LQR with PyVista 3D
+
+Real-time simulation and animation of a quadcopter controlled by a
+physics-informed Neural-LQR controller, built entirely with synapsys.
+
+## What this example demonstrates
+
+| Concept | Detail |
+|---------|--------|
+| **MIMO LTI modelling** | 12-state linearised hover model (x, y, z, φ, θ, ψ + velocities) |
+| **MIMO LQR** | `synapsys.algorithms.lqr()` on a 12-state / 4-input plant |
+| **Neural-LQR** | Residual MLP δu = −K·e + net(e), output layer zeroed → starts at LQR |
+| **synapsys API** | `ss()`, `c2d()`, `StateSpace.evolve()`, `lqr()` |
+| **PyVista 3D** | Real-time drone pose animation + trajectory trail at 50 Hz |
+| **PyVista charts** | Position tracking, Euler angles, control inputs — all in one window |
+
+## Plant model
+
+```
+State  x  = [x, y, z, φ, θ, ψ, ẋ, ẏ, ż, p, q, r]   (12 × 1)
+Input  δu = [δF, τφ, τθ, τψ]                           (4 × 1)
+Output y  = [x, y, z, ψ]                               (4 × 1)
+
+Linearised at hover.  Valid for |φ|, |θ| ≤ 15°.
+```
+
+## Neural-LQR architecture
+
+```
+δu = −K·e  +  MLP(e)
+     ^^^^^^     ^^^^^^
+   LQR term   residual (12→64→32→4, init to zero)
+```
+
+At t=0 the residual is zero → network == optimal LQR.  
+Hidden layers can be fine-tuned via RL/imitation learning without  
+changing the synapsys API.
+
+## Installation
+
+```bash
+pip install synapsys[viz]   # pyvista
+pip install torch            # optional — for Neural-LQR
+```
+
+## Running
+
+### Option A — standalone (recommended)
+
+```bash
+cd examples/advanced/06_quadcopter_mimo
+python 06b_neural_lqr_3d.py
+```
+
+A 1500×860 PyVista window opens with:
+- **Left pane**: 3-D drone animation with trajectory trail and figure-8 reference
+- **Right pane**: position tracking · Euler angles · control inputs (live charts)
+
+### Option B — two-process SIL
+
+```bash
+# Terminal 1
+python 06a_quadcopter_plant.py
+
+# Terminal 2 (while plant is running)
+# (adapt 06b to read from SharedMemoryTransport instead of running its own sim)
+```
+
+## Reference trajectory
+
+- **0 – 3 s** : takeoff to hover at z = 1.5 m
+- **3 – 45 s** : lemniscate of Bernoulli (figure-8) at z = 1.5 m, A = 0.8 m, ω = 0.35 rad/s
+
+## Window controls
+
+| Action | Key / Mouse |
+|--------|-------------|
+| Rotate | Left-drag |
+| Zoom | Scroll |
+| Pan | Right-drag |
+| Reset camera | `r` |
+| Close | `q` or close button |

--- a/examples/advanced/06_quadcopter_mimo/quadcopter_dynamics.py
+++ b/examples/advanced/06_quadcopter_mimo/quadcopter_dynamics.py
@@ -1,0 +1,82 @@
+"""
+Linearised quadcopter hover model — 12-state MIMO.
+
+State  x  = [x, y, z, φ, θ, ψ, ẋ, ẏ, ż, p, q, r]   (12 × 1)
+Input  δu = [δF, τφ, τθ, τψ]                           (4 × 1, deviations from hover)
+Output y  = [x, y, z, ψ]                               (4 × 1)
+
+Linearised at hover: φ = θ = ψ = 0, all velocities zero.
+Full derivation in docs/examples/quadcopter-mimo.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+# ── Physical parameters (500 mm racing quad) ──────────────────────────────────
+MASS: float = 0.500        # kg
+G:    float = 9.81         # m/s²
+IXX:  float = 4.856e-3     # kg·m²  (roll)
+IYY:  float = 4.856e-3     # kg·m²  (pitch)
+IZZ:  float = 8.801e-3     # kg·m²  (yaw)
+ARM:  float = 0.175        # m  (centre → motor)
+
+F_HOVER: float = MASS * G  # N — equilibrium total thrust
+
+# ── Input deviation limits ────────────────────────────────────────────────────
+U_MIN = np.array([-0.90 * F_HOVER, -0.50, -0.50, -0.30])  # [N, Nm, Nm, Nm]
+U_MAX = np.array([ 3.00 * F_HOVER,  0.50,  0.50,  0.30])
+
+# ── LQR weight matrices ───────────────────────────────────────────────────────
+Q_LQR = np.diag([
+    20.0, 20.0, 30.0,   # x, y, z    — position
+     3.0,  3.0,  8.0,   # φ, θ, ψ   — attitude (yaw weighted more)
+     2.0,  2.0,  4.0,   # ẋ, ẏ, ż   — linear velocity
+     0.5,  0.5,  1.0,   # p, q, r   — angular rates
+])
+R_LQR = np.diag([0.5, 3.0, 3.0, 5.0])   # δF, τφ, τθ, τψ
+
+
+def build_matrices() -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Return (A, B, C, D) for the linearised hover model."""
+    A = np.zeros((12, 12))
+    # Kinematics: ṗos = vel
+    A[0, 6] = A[1, 7] = A[2, 8] = 1.0
+    # Small-angle attitude kinematics: angle_rate = body_rate
+    A[3, 9] = A[4, 10] = A[5, 11] = 1.0
+    # Gravity coupling (linearised): ẍ = g·θ,  ÿ = −g·φ
+    A[6, 4] =  G
+    A[7, 3] = -G
+
+    B = np.zeros((12, 4))
+    B[8,  0] = 1.0 / MASS   # z̈  ← δF / m
+    B[9,  1] = 1.0 / IXX    # φ̈  ← τφ / Ixx
+    B[10, 2] = 1.0 / IYY    # θ̈  ← τθ / Iyy
+    B[11, 3] = 1.0 / IZZ    # ψ̈  ← τψ / Izz
+
+    C = np.zeros((4, 12))
+    C[0, 0] = C[1, 1] = C[2, 2] = 1.0   # x, y, z
+    C[3, 5] = 1.0                         # ψ
+
+    D = np.zeros((4, 4))
+    return A, B, C, D
+
+
+def figure8_ref(
+    t: float,
+    amp: float = 0.80,
+    omega: float = 0.35,
+    z_hover: float = 1.50,
+) -> np.ndarray:
+    """Lemniscate of Bernoulli reference trajectory.
+
+    Returns a 12-state reference with kinematically consistent
+    position only (velocity feedforward omitted — suitable for ω ≤ 0.5 rad/s).
+    """
+    s = np.sin(omega * t)
+    c = np.cos(omega * t)
+    denom = 1.0 + s ** 2
+    ref = np.zeros(12)
+    ref[0] = amp * c / denom            # x
+    ref[1] = amp * s * c / denom        # y
+    ref[2] = z_hover                    # z (constant altitude)
+    return ref

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,9 @@ Documentation = "https://synapsys-lab.github.io/synapsys/"
 Changelog     = "https://github.com/synapsys-lab/synapsys/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
+viz = [
+    "pyvista>=0.43",
+]
 dev = [
     "pytest>=7.4",
     "pytest-cov>=4.0",

--- a/uv.lock
+++ b/uv.lock
@@ -3156,7 +3156,7 @@ wheels = [
 
 [[package]]
 name = "synapsys"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },

--- a/website/docs/examples/advanced/quadcopter-mimo.md
+++ b/website/docs/examples/advanced/quadcopter-mimo.md
@@ -1,0 +1,353 @@
+---
+id: quadcopter-mimo
+title: Quadcopter MIMO Neural-LQR 3D
+sidebar_position: 6
+---
+
+# Quadcopter MIMO — Neural-LQR Controller with Real-Time 3D Animation
+
+**Files:** `examples/advanced/06_quadcopter_mimo/`
+
+---
+
+## What this example shows
+
+A complete real-time simulation of a **12-state quadcopter** controlled by a **physics-informed Neural-LQR** — and visualised simultaneously in a 3D PyVista scene and a live matplotlib telemetry window. Before the simulation starts, a **tkinter configuration GUI** lets you choose the reference trajectory, tune its parameters, and set the simulation duration.
+
+| Concept | Detail |
+|---|---|
+| **MIMO LTI modelling** | 12-state linearised hover model built with `synapsys.api.ss()` |
+| **MIMO LQR** | `synapsys.algorithms.lqr()` on a 12-state / 4-input plant |
+| **Residual Neural-LQR** | `δu = −K·e + MLP(e)` — residual zeroed at init → starts at optimal LQR |
+| **Config GUI** | tkinter dialog: simulation time, altitude, reference trajectory & its parameters |
+| **PyVista 3D** | Real-time drone pose animation + trajectory trail at 50 Hz |
+| **matplotlib telemetry** | Position tracking, Euler angles, control inputs — live at 10 Hz |
+
+---
+
+## Physical model — linearised hover
+
+A quadcopter has highly non-linear dynamics, but in the neighbourhood of **hover** (zero velocity, level attitude) a first-order Taylor expansion yields a useful **linear time-invariant (LTI)** model valid for small perturbations (|φ|, |θ| ≤ 15°).
+
+### State and input vectors
+
+$$
+\mathbf{x} =
+\begin{bmatrix}
+x & y & z & \varphi & \theta & \psi &
+\dot{x} & \dot{y} & \dot{z} & p & q & r
+\end{bmatrix}^\top \in \mathbb{R}^{12}
+$$
+
+$$
+\delta\mathbf{u} =
+\begin{bmatrix}
+\delta F & \tau_\varphi & \tau_\theta & \tau_\psi
+\end{bmatrix}^\top \in \mathbb{R}^{4}
+$$
+
+where $(\varphi, \theta, \psi)$ are roll, pitch, yaw; $(p, q, r)$ are body angular rates; and $\delta\mathbf{u}$ represents **deviations from hover equilibrium** (hovering at $F = mg$).
+
+### Linearised A and B matrices
+
+The state equation $\dot{\mathbf{x}} = A\mathbf{x} + B\,\delta\mathbf{u}$ at hover is:
+
+$$
+A =
+\begin{bmatrix}
+0_{3\times 3} & 0_{3\times 3} & I_{3\times 3} & 0_{3\times 3} \\
+0_{3\times 3} & 0_{3\times 3} & 0_{3\times 3} & I_{3\times 3} \\
+0 & 0 & 0 & g & 0 & 0 & 0_{3\times 6} \\
+0 & 0 & 0 & -g & 0 & 0 & 0_{3\times 6} \\
+0_{6\times 12}
+\end{bmatrix}
+$$
+
+The key gravity-coupling terms are $A_{6,4} = +g$ (forward acceleration from pitch $\theta$) and $A_{7,3} = -g$ (lateral acceleration from roll $\varphi$):
+
+```
+ẍ = +g·θ     (pitch forward → accelerate in x)
+ÿ = −g·φ     (roll right → accelerate in −y)
+```
+
+The input matrix maps each control channel to its dynamical effect:
+
+$$
+B =
+\begin{bmatrix}
+0_{8 \times 4} \\
+1/m & 0 & 0 & 0 \\
+0 & 1/I_{xx} & 0 & 0 \\
+0 & 0 & 1/I_{yy} & 0 \\
+0 & 0 & 0 & 1/I_{zz}
+\end{bmatrix}
+$$
+
+Physical parameters (500 mm racing quad):
+
+| Symbol | Value | Meaning |
+|---|---|---|
+| $m$ | 0.500 kg | Total mass |
+| $I_{xx} = I_{yy}$ | 4.856 × 10⁻³ kg·m² | Roll / pitch inertia |
+| $I_{zz}$ | 8.801 × 10⁻³ kg·m² | Yaw inertia |
+| $\ell$ | 0.175 m | Centre-to-motor arm |
+
+The continuous-time model is built with `synapsys.api.ss()` and discretised at 100 Hz with `synapsys.api.c2d()` using the zero-order-hold (ZOH) method:
+
+```python
+from synapsys.api import ss, c2d
+
+A, B, C, D = build_matrices()   # from quadcopter_dynamics.py
+sys_c = ss(A, B, C, D)          # continuous-time LTI
+sys_d = c2d(sys_c, dt=0.01)     # ZOH discretisation at 100 Hz
+```
+
+---
+
+## LQR design
+
+The **Linear Quadratic Regulator** minimises the infinite-horizon cost:
+
+$$
+J = \int_0^\infty \bigl(\mathbf{e}^\top Q\,\mathbf{e} + \delta\mathbf{u}^\top R\,\delta\mathbf{u}\bigr)\,dt
+$$
+
+where $\mathbf{e} = \mathbf{x} - \mathbf{x}_\text{ref}$ is the tracking error. The optimal gain matrix $K$ is found by solving the **Algebraic Riccati Equation** (ARE):
+
+$$
+A^\top P + PA - PBR^{-1}B^\top P + Q = 0
+\quad\Rightarrow\quad K = R^{-1}B^\top P
+$$
+
+Weight matrices used in this example:
+
+```python
+Q = diag([20, 20, 30,    # x, y, z       — position errors
+           3,  3,  8,    # φ, θ, ψ       — attitude (yaw weighted more)
+           2,  2,  4,    # ẋ, ẏ, ż       — linear velocity
+          0.5, 0.5, 1])  # p, q, r       — angular rates
+
+R = diag([0.5, 3.0, 3.0, 5.0])   # δF, τφ, τθ, τψ
+```
+
+```python
+from synapsys.algorithms import lqr
+
+K, P = lqr(A, B, Q, R)
+# K.shape == (4, 12)
+# All closed-loop eigenvalues have Re < 0  ✓
+```
+
+The resulting $K \in \mathbb{R}^{4 \times 12}$ yields a **closed-loop** system $A - BK$ with all eigenvalues in the left half-plane (Re < 0), confirming asymptotic stability.
+
+---
+
+## Neural-LQR controller
+
+### Residual architecture
+
+The controller extends LQR with a learnable residual term:
+
+$$
+\delta\mathbf{u} = \underbrace{-K\,\mathbf{e}}_{\text{LQR baseline}} + \underbrace{\text{MLP}(\mathbf{e})}_{\text{residual}}
+$$
+
+The MLP has architecture **12 → 64 → 32 → 4** with Tanh activations. At initialisation the **output layer weights and biases are zeroed**, so the network starts as pure LQR and the residual can be trained later via RL or imitation learning without changing any API.
+
+```python
+class NeuralLQR(nn.Module):
+    def __init__(self, K_np):
+        super().__init__()
+        self.register_buffer("K", torch.tensor(K_np, dtype=torch.float32))
+        self.residual = nn.Sequential(
+            nn.Linear(12, 64), nn.Tanh(),
+            nn.Linear(64, 32), nn.Tanh(),
+            nn.Linear(32,  4),            # ← zeroed at init
+        )
+        with torch.no_grad():
+            nn.init.zeros_(self.residual[4].weight)
+            nn.init.zeros_(self.residual[4].bias)
+
+    def forward(self, e):
+        return -(e @ self.K.T) + self.residual(e)
+```
+
+### Why this design?
+
+| Property | Benefit |
+|---|---|
+| **Stability at t = 0** | LQR baseline is provably stable; residual adds nothing until trained |
+| **Smooth fine-tuning** | RL or IL can adjust the residual without destabilising the loop |
+| **Interpretable fallback** | Remove/zero the MLP → revert to known-optimal LQR at any time |
+
+---
+
+## Reference trajectories
+
+Three reference trajectories are available via the config GUI:
+
+### Figure-8 — Lemniscate of Bernoulli
+
+$$
+x_\text{ref}(t) = \frac{A\cos(\omega t)}{1 + \sin^2(\omega t)}, \qquad
+y_\text{ref}(t) = \frac{A\sin(\omega t)\cos(\omega t)}{1 + \sin^2(\omega t)}, \qquad
+z_\text{ref} = z_h
+$$
+
+Default: $A = 0.8$ m, $\omega = 0.35$ rad/s.
+
+### Circle
+
+$$
+x_\text{ref}(t) = R\cos(\omega t), \qquad
+y_\text{ref}(t) = R\sin(\omega t), \qquad
+z_\text{ref} = z_h
+$$
+
+Default: $R = 1.0$ m, $\omega = 0.30$ rad/s.
+
+### Hover (static)
+
+$$
+\mathbf{x}_\text{ref} = [0,\; 0,\; z_h,\; 0, \ldots, 0]^\top
+$$
+
+All three trajectories share the takeoff phase: the drone climbs from the ground to hover altitude $z_h$ during the first $t_\text{hover}$ seconds before tracking begins.
+
+---
+
+## Architecture
+
+```mermaid
+%%{init: {'theme': 'dark'}}%%
+flowchart TD
+    GUI["tkinter Config GUI\ntime / altitude / trajectory\nparams"]
+    GUI -->|SimConfig| MAIN
+
+    subgraph SIM["sim_thread  (100 Hz)"]
+        PLANT["sys_d.evolve(x, δu)\nZOH discretised model"]
+        CTRL["NeuralLQR\n−K·e + MLP(e)"]
+        REF["get_ref(t, cfg)\nfig8 / circle / hover"]
+        CTRL -->|δu| PLANT
+        PLANT -->|x| CTRL
+        REF -->|x_ref| CTRL
+    end
+
+    subgraph BUFS["Thread-safe deques"]
+        S["_states  TRAIL_LEN"]
+        R["_refs    N_steps"]
+        U["_inputs  N_steps"]
+        T["_times   N_steps"]
+    end
+
+    SIM -->|append| BUFS
+
+    subgraph MAIN["main thread  (update loop)"]
+        PV["PyVista  50 Hz\ndrone pose + trail + HUD"]
+        MPL["matplotlib  10 Hz\nxy / z / angles / δu"]
+    end
+
+    BUFS -->|read snapshot| MAIN
+```
+
+All data flows from `sim_thread` into **thread-safe `collections.deque` buffers** protected by a single `threading.Lock`. The main thread reads snapshots without blocking the simulation.
+
+---
+
+## Config GUI
+
+When the script is launched a **tkinter dialog** appears before any simulation window opens:
+
+| Section | Controls |
+|---|---|
+| **Simulation Time** | Total duration (s), takeoff hover phase (s), hover altitude (m) |
+| **Reference Trajectory** | Radio buttons: Figure-8 / Circle / Hover |
+| **Figure-8 Parameters** | Amplitude slider (0.2–2.0 m), angular speed (0.1–0.8 rad/s) |
+| **Circle Parameters** | Radius slider (0.2–3.0 m), angular speed (0.1–0.8 rad/s) |
+
+Clicking **Run Simulation** closes the dialog, validates the configuration, and starts the simulation and visualisation windows. **Cancel** exits without running.
+
+---
+
+## Visualisation
+
+### PyVista 3D window (50 Hz)
+
+- **Drone mesh** — X-configuration body (box), 4 arms (cylinders) and 4 rotors (discs); pose updated via `actor.user_matrix` from the rotation matrix $R = R_z R_y R_x$ computed with `scipy.spatial.transform.Rotation`
+- **Trajectory trail** — last `TRAIL_LEN = 500` positions as a `pv.PolyData` polyline, updated in place
+- **Reference curve** — static preview of the chosen trajectory rendered at the start
+- **HUD overlay** — live text showing mode, time, position, Euler angles, velocities
+
+### matplotlib telemetry window (10 Hz)
+
+| Panel | Content |
+|---|---|
+| **Top-left** | Top-down $x$–$y$ trajectory vs. reference curve |
+| **Top-right** | Altitude $z(t)$ vs. reference line |
+| **Middle** | Euler angles $\varphi$, $\theta$, $\psi$ in degrees |
+| **Bottom** | Control deviations $\delta F$, $\tau_\varphi$, $\tau_\theta$, $\tau_\psi$ |
+
+Both windows run in the **same main thread** using `pv.Plotter(interactive_update=True)` and `plt.ion()`, avoiding cross-thread GUI crashes. The simulation runs in a dedicated daemon thread.
+
+---
+
+## How to run
+
+**Install dependencies:**
+
+```bash
+pip install synapsys[viz] torch matplotlib
+```
+
+**Run the standalone simulation:**
+
+```bash
+cd examples/advanced/06_quadcopter_mimo
+python 06b_neural_lqr_3d.py
+```
+
+1. The tkinter config GUI opens — adjust parameters and click **Run Simulation**
+2. A matplotlib telemetry window opens with 4 live panels
+3. A PyVista 3D window opens with the drone animation
+4. Close either window or press **Ctrl+C** to stop
+
+**Two-process SIL variant (optional):**
+
+```bash
+# Terminal 1 — start the linearised plant on shared memory
+python 06a_quadcopter_plant.py
+
+# Terminal 2 — connect an external controller via SharedMemoryTransport
+# (adapt 06b to read from bus instead of running its own simulation)
+```
+
+:::tip[Extending the Neural-LQR]
+The `NeuralLQR.residual` sub-network (12→64→32→4, Tanh) starts at zero — it does nothing until trained. Replace the zero-initialised weights with one trained via PPO, SAC, or DDPG and the rest of the example stays identical. The `synapsys` API calls (`ss()`, `c2d()`, `lqr()`, `evolve()`) do not change.
+:::
+
+:::tip[Adding velocity feedforward]
+The current reference only prescribes position. For aggressive manoeuvres, add a kinematically consistent velocity feedforward ($\dot{x}_\text{ref}$, $\dot{y}_\text{ref}$) to the reference state — this reduces tracking error during the figure-8 phase significantly.
+:::
+
+:::warning[Linearisation limits]
+The hover model is valid only for $|\varphi|, |\theta| \leq 15°$. Aggressive manoeuvres that exceed this envelope will cause divergence. For full-envelope flight, replace the LTI model with a non-linear model (e.g., Euler-Lagrange equations) and use feedback linearisation or NMPC.
+:::
+
+---
+
+## File reference
+
+| File | Purpose |
+|---|---|
+| `quadcopter_dynamics.py` | Physical constants, `build_matrices()`, `figure8_ref()`, LQR weights |
+| `06a_quadcopter_plant.py` | Two-process SIL plant via `PlantAgent` + `SharedMemoryTransport` |
+| `06b_neural_lqr_3d.py` | Standalone simulation: config GUI, Neural-LQR, PyVista 3D, matplotlib |
+
+### Key synapsys API calls
+
+| Call | What it does |
+|---|---|
+| `ss(A, B, C, D)` | Builds a continuous-time `StateSpace` object |
+| `c2d(sys_c, dt)` | Discretises to ZOH discrete-time `StateSpace` |
+| `sys_d.evolve(x, u)` | One-step state update: returns $(x_{k+1},\, y_k)$ |
+| `lqr(A, B, Q, R)` | Solves ARE, returns gain matrix $K$ and cost matrix $P$ |

--- a/website/docs/examples/index.md
+++ b/website/docs/examples/index.md
@@ -27,6 +27,7 @@ Each example lives in its own subfolder under `examples/` and includes a detaile
 | [Real-Time Scope (Terminal)](./advanced/realtime-scope.md) | Read-only bus monitor, headless display |
 | [Real-Time Oscilloscope](./advanced/realtime-oscilloscope.md) | Three-role architecture, PID, sinusoidal reference, `FuncAnimation` |
 | [Digital Twin](./advanced/digital-twin.md) | Virtual twin, wear injection, divergence metric, anomaly detection |
+| [Quadcopter MIMO Neural-LQR 3D](./advanced/quadcopter-mimo.md) | MIMO LTI, 12-state quadcopter, `lqr()`, Neural-LQR residual MLP, PyVista 3D, config GUI |
 
 ## Distributed
 

--- a/website/i18n/pt/docusaurus-plugin-content-docs/current/examples/advanced/quadcopter-mimo.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/current/examples/advanced/quadcopter-mimo.md
@@ -1,0 +1,352 @@
+---
+id: quadcopter-mimo
+title: Quadricóptero MIMO Neural-LQR 3D
+sidebar_position: 6
+---
+
+# Quadricóptero MIMO — Controlador Neural-LQR com Animação 3D em Tempo Real
+
+**Arquivos:** `examples/advanced/06_quadcopter_mimo/`
+
+---
+
+## O que este exemplo demonstra
+
+Uma simulação em tempo real completa de um **quadricóptero com 12 estados** controlado por um **Neural-LQR informado pela física** — visualizado simultaneamente em uma cena 3D com PyVista e uma janela de telemetria matplotlib ao vivo. Antes da simulação começar, uma **GUI de configuração em tkinter** permite escolher a trajetória de referência, ajustar seus parâmetros e definir a duração da simulação.
+
+| Conceito | Detalhe |
+|---|---|
+| **Modelagem LTI MIMO** | Modelo hover linearizado com 12 estados, construído com `synapsys.api.ss()` |
+| **LQR MIMO** | `synapsys.algorithms.lqr()` em uma planta 12 estados / 4 entradas |
+| **Neural-LQR residual** | `δu = −K·e + MLP(e)` — resíduo zerado na inicialização → começa no LQR ótimo |
+| **GUI de configuração** | Dialog tkinter: tempo de simulação, altitude, trajetória de referência e seus parâmetros |
+| **PyVista 3D** | Animação da pose do drone + rastro de trajetória a 50 Hz |
+| **Telemetria matplotlib** | Rastreamento de posição, ângulos de Euler, entradas de controle — ao vivo a 10 Hz |
+
+---
+
+## Modelo físico — hover linearizado
+
+Um quadricóptero possui dinâmica altamente não-linear, mas na vizinhança do **hover** (velocidade zero, atitude nivelada) uma expansão de Taylor de primeira ordem fornece um modelo **LTI** útil válido para pequenas perturbações (|φ|, |θ| ≤ 15°).
+
+### Vetores de estado e entrada
+
+$$
+\mathbf{x} =
+\begin{bmatrix}
+x & y & z & \varphi & \theta & \psi &
+\dot{x} & \dot{y} & \dot{z} & p & q & r
+\end{bmatrix}^\top \in \mathbb{R}^{12}
+$$
+
+$$
+\delta\mathbf{u} =
+\begin{bmatrix}
+\delta F & \tau_\varphi & \tau_\theta & \tau_\psi
+\end{bmatrix}^\top \in \mathbb{R}^{4}
+$$
+
+onde $(\varphi, \theta, \psi)$ são rolagem, arfagem e guinada; $(p, q, r)$ são as taxas angulares no corpo; e $\delta\mathbf{u}$ representa **desvios do equilíbrio hover** (em hover $F = mg$).
+
+### Matrizes A e B linearizadas
+
+A equação de estado $\dot{\mathbf{x}} = A\mathbf{x} + B\,\delta\mathbf{u}$ no hover é:
+
+$$
+A =
+\begin{bmatrix}
+0_{3\times 3} & 0_{3\times 3} & I_{3\times 3} & 0_{3\times 3} \\
+0_{3\times 3} & 0_{3\times 3} & 0_{3\times 3} & I_{3\times 3} \\
+0 & 0 & 0 & g & 0 & 0 & 0_{3\times 6} \\
+0 & 0 & 0 & -g & 0 & 0 & 0_{3\times 6} \\
+0_{6\times 12}
+\end{bmatrix}
+$$
+
+Os termos de acoplamento gravitacional são $A_{6,4} = +g$ (aceleração frontal pela arfagem $\theta$) e $A_{7,3} = -g$ (aceleração lateral pela rolagem $\varphi$):
+
+```
+ẍ = +g·θ     (arfagem para frente → acelera em x)
+ÿ = −g·φ     (rolagem à direita → acelera em −y)
+```
+
+A matriz de entrada mapeia cada canal de controle para seu efeito dinâmico:
+
+$$
+B =
+\begin{bmatrix}
+0_{8 \times 4} \\
+1/m & 0 & 0 & 0 \\
+0 & 1/I_{xx} & 0 & 0 \\
+0 & 0 & 1/I_{yy} & 0 \\
+0 & 0 & 0 & 1/I_{zz}
+\end{bmatrix}
+$$
+
+Parâmetros físicos (quadricóptero racing de 500 mm):
+
+| Símbolo | Valor | Significado |
+|---|---|---|
+| $m$ | 0,500 kg | Massa total |
+| $I_{xx} = I_{yy}$ | 4,856 × 10⁻³ kg·m² | Inércia de rolagem / arfagem |
+| $I_{zz}$ | 8,801 × 10⁻³ kg·m² | Inércia de guinada |
+| $\ell$ | 0,175 m | Braço centro-motor |
+
+O modelo em tempo contínuo é construído com `synapsys.api.ss()` e discretizado a 100 Hz com `synapsys.api.c2d()` pelo método zero-order-hold (ZOH):
+
+```python
+from synapsys.api import ss, c2d
+
+A, B, C, D = build_matrices()   # de quadcopter_dynamics.py
+sys_c = ss(A, B, C, D)          # sistema LTI em tempo contínuo
+sys_d = c2d(sys_c, dt=0.01)     # discretização ZOH a 100 Hz
+```
+
+---
+
+## Projeto LQR
+
+O **Regulador Linear Quadrático** minimiza o custo de horizonte infinito:
+
+$$
+J = \int_0^\infty \bigl(\mathbf{e}^\top Q\,\mathbf{e} + \delta\mathbf{u}^\top R\,\delta\mathbf{u}\bigr)\,dt
+$$
+
+onde $\mathbf{e} = \mathbf{x} - \mathbf{x}_\text{ref}$ é o erro de rastreamento. A matriz de ganho ótima $K$ é encontrada resolvendo a **Equação de Riccati Algébrica** (ARE):
+
+$$
+A^\top P + PA - PBR^{-1}B^\top P + Q = 0
+\quad\Rightarrow\quad K = R^{-1}B^\top P
+$$
+
+Matrizes de peso usadas neste exemplo:
+
+```python
+Q = diag([20, 20, 30,    # x, y, z       — erros de posição
+           3,  3,  8,    # φ, θ, ψ       — atitude (guinada com mais peso)
+           2,  2,  4,    # ẋ, ẏ, ż       — velocidade linear
+          0.5, 0.5, 1])  # p, q, r       — taxas angulares
+
+R = diag([0.5, 3.0, 3.0, 5.0])   # δF, τφ, τθ, τψ
+```
+
+```python
+from synapsys.algorithms import lqr
+
+K, P = lqr(A, B, Q, R)
+# K.shape == (4, 12)
+# Todos os autovalores em malha fechada têm Re < 0  ✓
+```
+
+O $K \in \mathbb{R}^{4 \times 12}$ resultante produz um sistema em **malha fechada** $A - BK$ com todos os autovalores no semiplano esquerdo (Re < 0), confirmando estabilidade assintótica.
+
+---
+
+## Controlador Neural-LQR
+
+### Arquitetura residual
+
+O controlador estende o LQR com um termo residual aprendível:
+
+$$
+\delta\mathbf{u} = \underbrace{-K\,\mathbf{e}}_{\text{base LQR}} + \underbrace{\text{MLP}(\mathbf{e})}_{\text{resíduo}}
+$$
+
+A MLP tem arquitetura **12 → 64 → 32 → 4** com ativações Tanh. Na inicialização, os **pesos e vieses da camada de saída são zerados**, de modo que a rede começa como LQR puro — o resíduo pode ser treinado depois via RL ou imitação sem alterar nenhuma API.
+
+```python
+class NeuralLQR(nn.Module):
+    def __init__(self, K_np):
+        super().__init__()
+        self.register_buffer("K", torch.tensor(K_np, dtype=torch.float32))
+        self.residual = nn.Sequential(
+            nn.Linear(12, 64), nn.Tanh(),
+            nn.Linear(64, 32), nn.Tanh(),
+            nn.Linear(32,  4),            # ← zerado na inicialização
+        )
+        with torch.no_grad():
+            nn.init.zeros_(self.residual[4].weight)
+            nn.init.zeros_(self.residual[4].bias)
+
+    def forward(self, e):
+        return -(e @ self.K.T) + self.residual(e)
+```
+
+### Por que esse design?
+
+| Propriedade | Benefício |
+|---|---|
+| **Estabilidade em t = 0** | A base LQR é provadamente estável; o resíduo não acrescenta nada até ser treinado |
+| **Fine-tuning suave** | RL ou IL pode ajustar o resíduo sem desestabilizar o loop |
+| **Fallback interpretável** | Remova/zere a MLP → reverte ao LQR ótimo conhecido a qualquer momento |
+
+---
+
+## Trajetórias de referência
+
+Três trajetórias de referência estão disponíveis via GUI de configuração:
+
+### Figura-8 — Lemniscata de Bernoulli
+
+$$
+x_\text{ref}(t) = \frac{A\cos(\omega t)}{1 + \sin^2(\omega t)}, \qquad
+y_\text{ref}(t) = \frac{A\sin(\omega t)\cos(\omega t)}{1 + \sin^2(\omega t)}, \qquad
+z_\text{ref} = z_h
+$$
+
+Padrão: $A = 0,8$ m, $\omega = 0,35$ rad/s.
+
+### Círculo
+
+$$
+x_\text{ref}(t) = R\cos(\omega t), \qquad
+y_\text{ref}(t) = R\sin(\omega t), \qquad
+z_\text{ref} = z_h
+$$
+
+Padrão: $R = 1,0$ m, $\omega = 0,30$ rad/s.
+
+### Hover (estático)
+
+$$
+\mathbf{x}_\text{ref} = [0,\; 0,\; z_h,\; 0, \ldots, 0]^\top
+$$
+
+As três trajetórias compartilham a fase de decolagem: o drone sobe do chão até a altitude hover $z_h$ durante os primeiros $t_\text{hover}$ segundos antes de iniciar o rastreamento.
+
+---
+
+## Arquitetura
+
+```mermaid
+%%{init: {'theme': 'dark'}}%%
+flowchart TD
+    GUI["GUI tkinter de Configuração\ntempo / altitude / trajetória\nparâmetros"]
+    GUI -->|SimConfig| MAIN
+
+    subgraph SIM["sim_thread  (100 Hz)"]
+        PLANT["sys_d.evolve(x, δu)\nmodelo discretizado ZOH"]
+        CTRL["NeuralLQR\n−K·e + MLP(e)"]
+        REF["get_ref(t, cfg)\nfig8 / círculo / hover"]
+        CTRL -->|δu| PLANT
+        PLANT -->|x| CTRL
+        REF -->|x_ref| CTRL
+    end
+
+    subgraph BUFS["Deques thread-safe"]
+        S["_states  TRAIL_LEN"]
+        R["_refs    N_steps"]
+        U["_inputs  N_steps"]
+        T["_times   N_steps"]
+    end
+
+    SIM -->|append| BUFS
+
+    subgraph MAIN["thread principal  (loop de atualização)"]
+        PV["PyVista  50 Hz\npose do drone + rastro + HUD"]
+        MPL["matplotlib  10 Hz\nxy / z / ângulos / δu"]
+    end
+
+    BUFS -->|snapshot leitura| MAIN
+```
+
+Todos os dados fluem de `sim_thread` para **buffers `collections.deque` thread-safe** protegidos por um único `threading.Lock`. A thread principal lê snapshots sem bloquear a simulação.
+
+---
+
+## GUI de Configuração
+
+Ao iniciar o script, um **dialog tkinter** aparece antes de qualquer janela de simulação:
+
+| Seção | Controles |
+|---|---|
+| **Tempo de Simulação** | Duração total (s), fase hover de decolagem (s), altitude hover (m) |
+| **Trajetória de Referência** | Botões de rádio: Figura-8 / Círculo / Hover |
+| **Parâmetros Figura-8** | Slider de amplitude (0,2–2,0 m), velocidade angular (0,1–0,8 rad/s) |
+| **Parâmetros Círculo** | Slider de raio (0,2–3,0 m), velocidade angular (0,1–0,8 rad/s) |
+
+Clicar em **Run Simulation** fecha o dialog, valida a configuração e inicia as janelas de simulação e visualização. **Cancel** sai sem executar.
+
+---
+
+## Visualização
+
+### Janela PyVista 3D (50 Hz)
+
+- **Malha do drone** — corpo em configuração X (caixa), 4 braços (cilindros) e 4 rotores (discos); pose atualizada via `actor.user_matrix` a partir da matriz de rotação $R = R_z R_y R_x$ calculada com `scipy.spatial.transform.Rotation`
+- **Rastro da trajetória** — últimas `TRAIL_LEN = 500` posições como `pv.PolyData` polyline, atualizado in-place
+- **Curva de referência** — prévia estática da trajetória escolhida renderizada no início
+- **Overlay HUD** — texto ao vivo mostrando modo, tempo, posição, ângulos de Euler, velocidades
+
+### Janela de telemetria matplotlib (10 Hz)
+
+| Painel | Conteúdo |
+|---|---|
+| **Superior esquerdo** | Trajetória $x$–$y$ vista de cima vs. curva de referência |
+| **Superior direito** | Altitude $z(t)$ vs. linha de referência |
+| **Meio** | Ângulos de Euler $\varphi$, $\theta$, $\psi$ em graus |
+| **Inferior** | Desvios de controle $\delta F$, $\tau_\varphi$, $\tau_\theta$, $\tau_\psi$ |
+
+Ambas as janelas rodam na **mesma thread principal** usando `pv.Plotter(interactive_update=True)` e `plt.ion()`, evitando crashes de GUI entre threads. A simulação roda em uma thread daemon dedicada.
+
+---
+
+## Como executar
+
+**Instalar dependências:**
+
+```bash
+pip install synapsys[viz] torch matplotlib
+```
+
+**Executar a simulação standalone:**
+
+```bash
+cd examples/advanced/06_quadcopter_mimo
+python 06b_neural_lqr_3d.py
+```
+
+1. A GUI de configuração tkinter abre — ajuste os parâmetros e clique em **Run Simulation**
+2. Uma janela de telemetria matplotlib abre com 4 painéis ao vivo
+3. Uma janela PyVista 3D abre com a animação do drone
+4. Feche qualquer janela ou pressione **Ctrl+C** para parar
+
+**Variante SIL de dois processos (opcional):**
+
+```bash
+# Terminal 1 — iniciar a planta linearizada em memória compartilhada
+python 06a_quadcopter_plant.py
+
+# Terminal 2 — conectar um controlador externo via SharedMemoryTransport
+```
+
+:::tip[Estendendo o Neural-LQR]
+A sub-rede `NeuralLQR.residual` (12→64→32→4, Tanh) começa em zero — não faz nada até ser treinada. Substitua os pesos zerados por pesos treinados via PPO, SAC ou DDPG e o restante do exemplo permanece idêntico. As chamadas de API `synapsys` (`ss()`, `c2d()`, `lqr()`, `evolve()`) não mudam.
+:::
+
+:::tip[Adicionando feedforward de velocidade]
+A referência atual prescreve apenas posição. Para manobras agressivas, adicione um feedforward de velocidade cinematicamente consistente ($\dot{x}_\text{ref}$, $\dot{y}_\text{ref}$) ao estado de referência — isso reduz significativamente o erro de rastreamento durante a fase figura-8.
+:::
+
+:::warning[Limites da linearização]
+O modelo hover é válido apenas para $|\varphi|, |\theta| \leq 15°$. Manobras agressivas que ultrapassem esse envelope causarão divergência. Para voo em envelope completo, substitua o modelo LTI por um modelo não-linear (ex.: equações de Euler-Lagrange) e use linearização por realimentação ou NMPC.
+:::
+
+---
+
+## Referência de arquivos
+
+| Arquivo | Propósito |
+|---|---|
+| `quadcopter_dynamics.py` | Constantes físicas, `build_matrices()`, `figure8_ref()`, pesos LQR |
+| `06a_quadcopter_plant.py` | Planta SIL de dois processos via `PlantAgent` + `SharedMemoryTransport` |
+| `06b_neural_lqr_3d.py` | Simulação standalone: GUI de config, Neural-LQR, PyVista 3D, matplotlib |
+
+### Chamadas chave da API synapsys
+
+| Chamada | O que faz |
+|---|---|
+| `ss(A, B, C, D)` | Constrói um objeto `StateSpace` em tempo contínuo |
+| `c2d(sys_c, dt)` | Discretiza para `StateSpace` discreto ZOH |
+| `sys_d.evolve(x, u)` | Atualização de estado de um passo: retorna $(x_{k+1},\, y_k)$ |
+| `lqr(A, B, Q, R)` | Resolve a ARE, retorna matriz de ganho $K$ e matriz de custo $P$ |

--- a/website/i18n/pt/docusaurus-plugin-content-docs/current/examples/index.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/current/examples/index.md
@@ -27,6 +27,7 @@ Each example lives in its own subfolder under `examples/` and includes a detaile
 | [Real-Time Scope (Terminal)](./advanced/realtime-scope.md) | Read-only bus monitor, headless display |
 | [Real-Time Oscilloscope](./advanced/realtime-oscilloscope.md) | Three-role architecture, PID, sinusoidal reference, `FuncAnimation` |
 | [Digital Twin](./advanced/digital-twin.md) | Virtual twin, wear injection, divergence metric, anomaly detection |
+| [Quadricóptero MIMO Neural-LQR 3D](./advanced/quadcopter-mimo.md) | LTI MIMO, quadricóptero 12 estados, `lqr()`, MLP residual Neural-LQR, PyVista 3D, GUI de config |
 
 ## Distributed
 

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -89,6 +89,7 @@ const sidebars: SidebarsConfig = {
             'examples/advanced/realtime-scope',
             'examples/advanced/realtime-oscilloscope',
             'examples/advanced/digital-twin',
+            'examples/advanced/quadcopter-mimo',
           ],
         },
         {


### PR DESCRIPTION
## Summary

- Adds `examples/advanced/06_quadcopter_mimo/` with a complete, runnable quadcopter demo
- 12-state linearised hover model (x, y, z, φ, θ, ψ + velocities), 4 inputs (δF, τφ, τθ, τψ)
- Residual Neural-LQR controller: `δu = −K·e + MLP(e)`, residual zeroed at init → starts at optimal LQR policy
- Real-time 3D drone animation via PyVista (50 Hz) + live matplotlib telemetry panels (10 Hz)
- `pyvista>=0.43` added as `synapsys[viz]` optional dependency

## Test plan

- [ ] `pip install synapsys[viz] torch` then `python examples/advanced/06_quadcopter_mimo/06b_neural_lqr_3d.py`
- [ ] PyVista window opens with drone mesh, trajectory trail, figure-8 reference curve
- [ ] Matplotlib window opens with 4 live panels (x-y trajectory, altitude, Euler angles, control inputs)
- [ ] Drone converges to hover at z=1.5 m within ~3 s, then tracks figure-8
- [ ] Closed-loop max Re(poles) < 0 printed in console