### PR TITLE
docs(readme): update demo to quadcopter GIFs and add AI integration row

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![Coverage](https://img.shields.io/badge/coverage-90%25-brightgreen.svg)](#testing)
 [![Code style: ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
-[📖 Documentation](https://synapsys-lab.github.io/synapsys/) · [🚀 Quickstart](#quickstart) · [📦 PyPI](https://pypi.org/project/synapsys/) · [💡 Examples](examples/) · [📋 Changelog](CHANGELOG.md)
+[Documentation](https://synapsys-lab.github.io/synapsys/) · [Quickstart](#quickstart) · [PyPI](https://pypi.org/project/synapsys/) · [Examples](examples/) · [Changelog](CHANGELOG.md)
 
 </div>
 
@@ -24,21 +24,23 @@
 
 Synapsys is an open-source Python library for **modelling, simulating, and deploying control systems**. It provides a **MATLAB-compatible API** built on SciPy, a modern **multi-agent simulation framework**, and a pluggable **transport layer** (shared memory / ZeroMQ) that scales from a single laptop to distributed lab setups.
 
+Any PyTorch, Keras or JAX model plugs directly into a `ControllerAgent` via a plain `np.ndarray -> np.ndarray` callback, making it straightforward to combine classical control theory with deep learning or reinforcement learning.
+
 ```python
 from synapsys.api import tf, ss, feedback, step, c2d
 
 # SISO
-G    = tf([1], [1, 2, 1])    # G(s) = 1 / (s² + 2s + 1)
+G    = tf([1], [1, 2, 1])    # G(s) = 1 / (s^2 + 2s + 1)
 T    = feedback(G)            # closed-loop: T = G / (1 + G)
 t, y = step(T)                # step response
 Gd   = c2d(G, dt=0.02)       # ZOH discretisation at 50 Hz
 
 # MIMO
-G_mimo = tf([[[ 1], [0]],     # 2×2 transfer-function matrix
+G_mimo = tf([[[ 1], [0]],
              [[ 0], [1]]],
             [[[1,1],[1]],
              [[1],[1,2]]])
-T_mimo = feedback(G_mimo)     # state-space closed-loop
+T_mimo = feedback(G_mimo)     # returns StateSpace closed-loop
 ```
 
 ```bash
@@ -47,15 +49,28 @@ pip install synapsys
 
 ---
 
-## See it in action
+## Demo — Quadcopter MIMO Neural-LQR
 
-Neural-LQR controller on a 2-DOF mass-spring-damper — MLP initialized with LQR optimal gains tracking setpoint x₂ = 1 m:
+12-state linearised quadcopter controlled by a residual Neural-LQR (`du = -K*e + MLP(e)`).
+The MLP output layer is zeroed at initialisation, so the controller starts as provably stable LQR
+and the residual can be trained later via RL or imitation learning without destabilising the loop.
 
 <div align="center">
-<img src="https://raw.githubusercontent.com/synapsys-lab/synapsys/main/website/static/img/examples/03_sil_ai_controller.gif" alt="Neural-LQR 2-DOF simulation — position tracking, velocities, control force and phase portrait" width="720" />
+<table>
+<tr>
+<td align="center">
+<img src="https://raw.githubusercontent.com/synapsys-lab/synapsys/main/website/static/img/examples/06_quadcopter_3d.gif" alt="PyVista 3D window — drone tracking a figure-8 trajectory in real time" width="380" />
+<br><sub>PyVista 3D window — drone mesh, trajectory trail and live HUD at 50 Hz</sub>
+</td>
+<td align="center">
+<img src="https://raw.githubusercontent.com/synapsys-lab/synapsys/main/website/static/img/examples/06_quadcopter_telemetry.gif" alt="matplotlib telemetry — position, Euler angles and control inputs" width="480" />
+<br><sub>matplotlib telemetry — x-y position, altitude, Euler angles and control deviations</sub>
+</td>
+</tr>
+</table>
 </div>
 
-> Full walkthrough: [SIL + Neural-LQR example →](https://synapsys-lab.github.io/synapsys/docs/examples/advanced/sil-ai-controller)
+> Full walkthrough: [Quadcopter MIMO Neural-LQR example](https://synapsys-lab.github.io/synapsys/docs/examples/advanced/quadcopter-mimo)
 
 ---
 
@@ -63,14 +78,15 @@ Neural-LQR controller on a 2-DOF mass-spring-damper — MLP initialized with LQR
 
 | Feature | Description |
 |---------|-------------|
-| ⚡ **MATLAB-Compatible API** | `tf()`, `ss()`, `c2d()`, `step()`, `bode()`, `feedback()`, `lsim()` — same names, pure Python |
-| 📐 **LTI Core** | `TransferFunction`, `StateSpace`, and `TransferFunctionMatrix` with operator overloading, poles, zeros, stability |
-| 🔀 **MIMO Support** | `TransferFunctionMatrix` for multi-input multi-output plants · MIMO `feedback()` · transmission zeros via Rosenbrock pencil |
-| 🧮 **Control Algorithms** | Discrete PID with anti-windup · LQR via algebraic Riccati equation (Q/R validated) |
-| 🤖 **Multi-Agent Simulation** | `PlantAgent` and `ControllerAgent` with lock-step and wall-clock sync |
-| 🔗 **Pluggable Transport** | Zero-copy shared memory (single-host) · ZeroMQ PUB/SUB and REQ/REP (distributed) |
-| 🔌 **Hardware Abstraction** | `HardwareInterface` contract enables seamless MIL → SIL → HIL transitions |
-| 🧱 **Matrix Builders** | `StateEquations`, `mat()`, `col()`, `row()` — define state-space models from named equations |
+| MATLAB-Compatible API | `tf()`, `ss()`, `c2d()`, `step()`, `bode()`, `feedback()`, `lsim()` — same names, pure Python |
+| LTI Core | `TransferFunction`, `StateSpace`, and `TransferFunctionMatrix` with operator overloading, poles, zeros, stability |
+| MIMO Support | `TransferFunctionMatrix` for multi-input multi-output plants, MIMO `feedback()`, transmission zeros via Rosenbrock pencil |
+| Control Algorithms | Discrete PID with anti-windup, LQR via algebraic Riccati equation (Q/R validated) |
+| AI Integration | Any PyTorch, Keras or JAX model as a controller — plain callable interface, no wrappers |
+| Multi-Agent Simulation | `PlantAgent` and `ControllerAgent` with lock-step and wall-clock sync |
+| Distributed Transport | Zero-copy shared memory (single-host) and ZeroMQ PUB/SUB and REQ/REP (multi-process / multi-machine) |
+| Hardware Abstraction | `HardwareInterface` contract enables seamless MIL to SIL to HIL transitions |
+| Matrix Builders | `StateEquations`, `mat()`, `col()`, `row()` — define state-space models from named equations |
 
 ---
 
@@ -80,7 +96,13 @@ Neural-LQR controller on a 2-DOF mass-spring-damper — MLP initialized with LQR
 pip install synapsys
 ```
 
-**Requirements:** Python ≥ 3.10 · NumPy ≥ 1.24 · SciPy ≥ 1.10 · pyzmq ≥ 25.0
+**Requirements:** Python >= 3.10, NumPy >= 1.24, SciPy >= 1.10, pyzmq >= 25.0
+
+For 3D visualisation (quadcopter example):
+
+```bash
+pip install synapsys[viz] torch matplotlib
+```
 
 For development:
 
@@ -94,7 +116,7 @@ uv sync --extra dev
 
 ## Quickstart
 
-### 1 · LTI systems and frequency analysis
+### 1. LTI systems and frequency analysis
 
 ```python
 from synapsys.api import tf, ss, bode, feedback, c2d
@@ -111,15 +133,15 @@ w, mag, phase = bode(G)
 # ZOH discretisation at 50 Hz
 Gd = c2d(G, dt=0.02)
 
-# MIMO: 2×2 transfer-function matrix
+# MIMO: 2x2 transfer-function matrix
 G_mimo = tf(
-    [[[1], [0]], [[0], [1]]],           # numerators
-    [[[1, 1], [1]], [[1], [1, 2]]],     # denominators
+    [[[1], [0]], [[0], [1]]],
+    [[[1, 1], [1]], [[1], [1, 2]]],
 )
-T_mimo = feedback(G_mimo)               # returns StateSpace
+T_mimo = feedback(G_mimo)    # returns StateSpace
 ```
 
-### 2 · Control algorithms
+### 2. Control algorithms
 
 ```python
 from synapsys.algorithms import PID, lqr
@@ -133,10 +155,10 @@ u   = pid.compute(setpoint=5.0, measurement=y)
 A = np.array([[0., 1.], [-2., -3.]])
 B = np.array([[0.], [1.]])
 K, P = lqr(A, B, Q=np.eye(2), R=np.eye(1))
-# Control law: u = −K · x
+# Control law: u = -K * x
 ```
 
-### 3 · State-space from named equations
+### 3. State-space from named equations
 
 ```python
 from synapsys.utils import StateEquations
@@ -150,11 +172,11 @@ eqs = (
     .eq("v2", x1=k/m,  x2=-2*k/m, v2=-c/m, F=1/m)
 )
 
-print(eqs.A)   # 4×4 system matrix
-print(eqs.B)   # 4×1 input matrix
+print(eqs.A)   # 4x4 system matrix
+print(eqs.B)   # 4x1 input matrix
 ```
 
-### 4 · Multi-agent closed-loop simulation
+### 4. Multi-agent closed-loop simulation
 
 ```python
 from synapsys.api import ss, c2d
@@ -178,24 +200,24 @@ with SharedMemoryTransport("demo", {"y": 1, "u": 1}, create=True) as bus:
     ControllerAgent("ctrl",  law,  bus, sync).start(blocking=True)
 ```
 
-### 5 · MIL → SIL → HIL — swap transport, keep algorithm
+### 5. MIL to SIL to HIL — swap transport, keep algorithm
 
 ```python
 # MIL — shared memory, single host
 from synapsys.transport import SharedMemoryTransport
 bus = SharedMemoryTransport("demo", {"y": 1, "u": 1}, create=True)
 
-# SIL — ZeroMQ, cross-process / cross-machine
+# SIL — ZeroMQ, cross-process or cross-machine
 from synapsys.transport import ZMQTransport
 bus = ZMQTransport("tcp://localhost:5555", mode="pub")
 
 # HIL — real hardware
 from synapsys.agents import HardwareAgent
-from synapsys.hw import MockHardwareInterface   # replace with your driver
+from synapsys.hw import MockHardwareInterface
 hw    = MockHardwareInterface(n_inputs=1, n_outputs=1, plant_fn=my_hw)
 agent = HardwareAgent("hw", hw, bus, sync)
 
-# PlantAgent / ControllerAgent stay exactly the same in all three modes
+# PlantAgent and ControllerAgent stay exactly the same in all three modes
 ```
 
 ---
@@ -208,10 +230,11 @@ agent = HardwareAgent("hw", hw, bus, sync)
 | [`distributed/plant.py`](examples/distributed/plant.py) + [`controller.py`](examples/distributed/controller.py) | Two-process PID loop via shared memory |
 | [`distributed/plant_zmq.py`](examples/distributed/plant_zmq.py) | Same loop over ZeroMQ (cross-machine) |
 | [`advanced/01_custom_signals.py`](examples/advanced/01_custom_signals.py) | Custom reference signals with `lsim()` |
-| [`advanced/02a_sil_plant.py`](examples/advanced/02a_sil_plant.py) + [`02b_sil_ai_controller.py`](examples/advanced/02_sil_ai_controller/02b_sil_ai_controller.py) | SIL + Neural-LQR PyTorch controller |
+| [`advanced/02b_sil_ai_controller.py`](examples/advanced/02_sil_ai_controller/02b_sil_ai_controller.py) | SIL + Neural-LQR PyTorch controller on 2-DOF mass-spring-damper |
 | [`advanced/03_realtime_scope.py`](examples/advanced/03_realtime_scope.py) | Text-mode real-time oscilloscope |
 | [`advanced/04_realtime_matplotlib.py`](examples/advanced/04_realtime_matplotlib.py) | Live matplotlib oscilloscope |
 | [`advanced/05_digital_twin.py`](examples/advanced/05_digital_twin.py) | Digital twin with mechanical wear detection |
+| [`advanced/06_quadcopter_mimo/`](examples/advanced/06_quadcopter_mimo/) | 12-state quadcopter MIMO Neural-LQR with PyVista 3D and config GUI |
 | [`quickstart_en.ipynb`](examples/quickstart_en.ipynb) | Interactive Jupyter notebook walkthrough |
 
 ---
@@ -220,7 +243,7 @@ agent = HardwareAgent("hw", hw, bus, sync)
 
 ```
 synapsys/
-├── api/            # MATLAB-compatible façade  (tf, ss, c2d, step, bode, feedback, …)
+├── api/            # MATLAB-compatible facade  (tf, ss, c2d, step, bode, feedback, ...)
 ├── core/           # LTI math — TransferFunction, StateSpace, TransferFunctionMatrix, LTIModel
 ├── algorithms/     # PID (discrete, anti-windup), LQR (ARE solver)
 ├── agents/         # PlantAgent, ControllerAgent, HardwareAgent, SyncEngine
@@ -229,7 +252,7 @@ synapsys/
 └── utils/          # StateEquations, mat(), col(), row()
 ```
 
-The transport layer is the key abstraction: agents communicate exclusively through a `TransportStrategy` interface. Swapping the concrete transport (shared memory ↔ ZMQ ↔ real hardware) requires changing **one line** — algorithms and agents are untouched.
+The transport layer is the key abstraction: agents communicate exclusively through a `TransportStrategy` interface. Swapping the concrete transport (shared memory, ZMQ, or real hardware) requires changing one line — algorithms and agents are untouched.
 
 ---
 
@@ -245,9 +268,9 @@ uv run ruff check synapsys tests   # linting
 | Metric | Value |
 |--------|-------|
 | Test suite | 184 tests |
-| Coverage | 90 % |
+| Coverage | 90% |
 | Type checking | mypy strict — 0 errors |
-| Python versions | 3.10 · 3.11 · 3.12 |
+| Python versions | 3.10, 3.11, 3.12 |
 
 ---
 
@@ -255,10 +278,11 @@ uv run ruff check synapsys tests   # linting
 
 | Version | Status | Features |
 |---------|--------|---------|
-| **v0.1.0** | ✅ Released | SISO LTI, PID, LQR, multi-agent, shared memory, ZMQ, hardware abstraction, Neural-LQR example |
-| **v0.2.0** | ✅ Released | MIMO support — `TransferFunctionMatrix`, MIMO `feedback()`, transmission zeros (Rosenbrock pencil), LQR Q/R validation, covariant LTI type annotations |
-| **v0.3** | 🔜 Planned | `margin()`, `rlocus()`, `pole_placement()` · State estimation — Kalman filter, Luenberger observer |
-| **v0.5** | 🔜 Planned | Real hardware drivers (serial, CAN, FPGA via PYNQ) |
+| v0.1.0 | Released | SISO LTI, PID, LQR, multi-agent, shared memory, ZMQ, hardware abstraction, Neural-LQR example |
+| v0.2.0 | Released | MIMO support — `TransferFunctionMatrix`, MIMO `feedback()`, transmission zeros (Rosenbrock pencil), LQR Q/R validation, covariant type annotations |
+| v0.2.1 | Released | Quadcopter MIMO Neural-LQR example with PyVista 3D, config GUI, GIF export, version sync fix |
+| v0.3 | Planned | `margin()`, `rlocus()`, `pole_placement()`, Kalman filter, Luenberger observer |
+| v0.5 | Planned | Real hardware drivers (serial, CAN, FPGA via PYNQ) |
 
 See [CHANGELOG.md](CHANGELOG.md) for the full release history.
 
@@ -293,7 +317,7 @@ https://github.com/synapsys-lab/synapsys
 
 ## Contributing
 
-Contributions are welcome! Please open an issue to discuss what you'd like to change before submitting a pull request.
+Contributions are welcome. Please open an issue to discuss what you would like to change before submitting a pull request.
 
 ```bash
 git clone https://github.com/synapsys-lab/synapsys.git


### PR DESCRIPTION
## Summary

- Replace 2-DOF mass-spring-damper demo with quadcopter MIMO Neural-LQR GIFs (side-by-side HTML table)
- Remove all emojis from features table, nav links, and roadmap
- Add AI Integration feature row (PyTorch/Keras/JAX interop)
- Add `synapsys[viz] torch matplotlib` install variant
- Add quadcopter MIMO example to examples table
- Mark v0.2.1 as Released in roadmap

## Test plan

- [ ] README renders correctly on GitHub (check image dimensions and table layout)
- [ ] Drone GIFs load from `synapsys-lab/synapsys` raw URL