### PR TITLE
feat(broker): MessageBroker mediator layer for multi-agent communication

### DIFF
--- a/examples/advanced/02_sil_ai_controller/02a_sil_plant.py
+++ b/examples/advanced/02_sil_ai_controller/02a_sil_plant.py
@@ -8,22 +8,20 @@ Topology
 
 State:  x = [x1, x2, v1, v2]  (positions + velocities of m1, m2)
 Input:  F  (force on m2 via the coupling spring)
-Output: full state vector written to the shared-memory bus every 10 ms.
+Output: full state vector written to the broker bus every 10 ms.
 
 Run FIRST, then start 02b_sil_ai_controller.py in a second terminal.
 """
-import time
-
 import numpy as np
 
 from synapsys.agents import PlantAgent, SyncEngine, SyncMode
 from synapsys.api import c2d, ss
-from synapsys.transport import SharedMemoryTransport
+from synapsys.broker import MessageBroker, Topic, SharedMemoryBackend
 from synapsys.utils import StateEquations
 
 # ── System parameters ─────────────────────────────────────────────────────────
-M, C_DAMP, K_SPR = 1.0, 0.1, 2.0      # mass (kg), damping (N·s/m), stiffness (N/m)
-DT = 0.01                               # sample period — 100 Hz
+M, C_DAMP, K_SPR = 1.0, 0.1, 2.0
+DT = 0.01   # 100 Hz
 
 # ── 2-DOF model via named equations ──────────────────────────────────────────
 eqs = (
@@ -34,7 +32,6 @@ eqs = (
     .eq("v2", x1=K_SPR/M,  x2=-2*K_SPR/M, v2=-C_DAMP/M, F=K_SPR/M)
 )
 
-# Full-state output: y = [x1, x2, v1, v2]
 plant_c = ss(eqs.A, eqs.B, np.eye(4), np.zeros((4, 1)))
 plant_d = c2d(plant_c, dt=DT)
 
@@ -45,26 +42,33 @@ print(f"  m={M} kg   c={C_DAMP} N·s/m   k={K_SPR} N/m   Ts={DT*1000:.0f} ms")
 print(f"  n_states={plant_d.n_states}  stable={plant_d.is_stable()}")
 print("=" * 58)
 
+# ── Broker setup ──────────────────────────────────────────────────────────────
+topic_state = Topic("sil/state", shape=(4,))
+topic_u     = Topic("sil/u",     shape=(1,))
 
-def main() -> None:
-    print("\nAllocating shared-memory bus 'sil_2dof'…")
-    bus = SharedMemoryTransport("sil_2dof", {"state": 4, "u": 1}, create=True)
-    bus.write("state", np.zeros(4))
-    bus.write("u", np.zeros(1))
+broker = MessageBroker()
+broker.declare_topic(topic_state)
+broker.declare_topic(topic_u)
+broker.add_backend(
+    SharedMemoryBackend("sil_2dof", [topic_state, topic_u], create=True)
+)
+broker.publish("sil/state", np.zeros(4))
+broker.publish("sil/u",     np.zeros(1))
 
-    agent_bus = SharedMemoryTransport("sil_2dof", {"state": 4, "u": 1})
-    sync = SyncEngine(mode=SyncMode.WALL_CLOCK, dt=DT)
-    plant = PlantAgent("2dof_plant", plant_d, agent_bus, sync)
+# ── Agent ─────────────────────────────────────────────────────────────────────
+sync  = SyncEngine(mode=SyncMode.WALL_CLOCK, dt=DT)
+plant = PlantAgent(
+    "2dof_plant", plant_d, None, sync,
+    channel_y="sil/state", channel_u="sil/u",
+    broker=broker,
+)
 
-    print("Starting PlantAgent — waiting for AI controller…")
-    print("Press Ctrl+C to stop.\n")
-    try:
-        plant.start(blocking=True)
-    except KeyboardInterrupt:
-        print("\nStopping plant.")
-        plant.stop()
-        bus.close()
-
-
-if __name__ == "__main__":
-    main()
+print("\nStarting PlantAgent — waiting for AI controller…")
+print("Press Ctrl+C to stop.\n")
+try:
+    plant.start(blocking=True)
+except KeyboardInterrupt:
+    print("\nStopping plant.")
+    plant.stop()
+finally:
+    broker.close()

--- a/examples/advanced/02_sil_ai_controller/02b_sil_ai_controller.py
+++ b/examples/advanced/02_sil_ai_controller/02b_sil_ai_controller.py
@@ -21,7 +21,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from synapsys.agents import ControllerAgent, SyncEngine, SyncMode
-from synapsys.transport import SharedMemoryTransport
+from synapsys.broker import MessageBroker, Topic, SharedMemoryBackend
 
 # ── Optional PyTorch import ───────────────────────────────────────────────────
 try:
@@ -234,14 +234,25 @@ def _build_figure():
 def main() -> None:
     print("\nConnecting to 'sil_2dof' bus…")
     try:
-        transport = SharedMemoryTransport("sil_2dof", {"state": 4, "u": 1}, create=False)
+        topic_state = Topic("sil/state", shape=(4,))
+        topic_u     = Topic("sil/u",     shape=(1,))
+        broker = MessageBroker()
+        broker.declare_topic(topic_state)
+        broker.declare_topic(topic_u)
+        broker.add_backend(
+            SharedMemoryBackend("sil_2dof", [topic_state, topic_u], create=False)
+        )
     except Exception as exc:
         print(f"  Error: {exc}")
         print("  Is 02a_sil_plant.py running?")
         return
 
     sync = SyncEngine(mode=SyncMode.WALL_CLOCK, dt=DT)
-    agent = ControllerAgent("neural_lqr", control_law, transport, sync)
+    agent = ControllerAgent(
+        "neural_lqr", control_law, None, sync,
+        channel_y="sil/state", channel_u="sil/u",
+        broker=broker,
+    )
     agent.start(blocking=False)
     print("Neural-LQR controller running.")
     print(f"  Setpoint: x₂ → {X2_REF} m\n")
@@ -284,6 +295,7 @@ def main() -> None:
     finally:
         print("\nStopping Neural-LQR controller.")
         agent.stop()
+        broker.close()
 
 
 if __name__ == "__main__":

--- a/examples/advanced/03_realtime_scope/03_realtime_scope.py
+++ b/examples/advanced/03_realtime_scope/03_realtime_scope.py
@@ -1,33 +1,48 @@
 import time
 import sys
-from synapsys.transport import SharedMemoryTransport
+
+from synapsys.broker import MessageBroker, Topic, SharedMemoryBackend
+
 
 def main():
     print("==== Synapsys Real-Time Headless Monitor ====")
-    print("Connecting to 'sil_bus' to plot values in text...")
-    
+    print("Connecting to 'sil_2dof' bus to plot values in text...")
+
     try:
-        monitor = SharedMemoryTransport("sil_bus", {"y": 1, "u": 1}, create=False)
+        topic_state = Topic("sil/state", shape=(4,))
+        topic_u     = Topic("sil/u",     shape=(1,))
+        broker = MessageBroker()
+        broker.declare_topic(topic_state)
+        broker.declare_topic(topic_u)
+        broker.add_backend(
+            SharedMemoryBackend("sil_2dof", [topic_state, topic_u], create=False)
+        )
     except Exception as e:
         print(f"Error connecting to bus. Run 02a_sil_plant.py first! ({e})")
         return
-        
+
     start_time = time.time()
-    
+
     try:
-        # We run the loop much faster to 'sample' the bus
-        # A true GUI (like PyQtGraph) would run this in a QTimer or update loop.
         while True:
-            y = monitor.read("y")[0]
-            u = monitor.read("u")[0]
+            state = broker.read("sil/state")
+            u     = broker.read("sil/u")[0]
             elapsed = time.time() - start_time
-            
-            sys.stdout.write(f"\r[t={elapsed:6.2f}s] Sensor y(t): {y:8.4f} | Inference u(t): {u:8.4f}")
+
+            sys.stdout.write(
+                f"\r[t={elapsed:6.2f}s]  "
+                f"x1={state[0]:7.4f}  x2={state[1]:7.4f}  "
+                f"v1={state[2]:7.4f}  v2={state[3]:7.4f}  "
+                f"u={u:8.4f}"
+            )
             sys.stdout.flush()
-            time.sleep(0.05) 
-            
+            time.sleep(0.05)
+
     except KeyboardInterrupt:
         print("\n\nMonitor stopped.")
+    finally:
+        broker.close()
+
 
 if __name__ == "__main__":
     main()

--- a/examples/advanced/04_realtime_oscilloscope/04_realtime_matplotlib.py
+++ b/examples/advanced/04_realtime_oscilloscope/04_realtime_matplotlib.py
@@ -2,23 +2,18 @@
 Advanced example 04 — Real-time oscilloscope with matplotlib.animation
 ======================================================================
 
-Launches a PlantAgent + ControllerAgent on a shared-memory bus and opens a
-live-updating plot WITHOUT blocking the simulation loop.
+Launches a PlantAgent + ControllerAgent on a MessageBroker (shared memory)
+and opens a live-updating plot WITHOUT blocking the simulation loop.
 
 Architecture (three independent roles):
-    Process / Thread A  →  PlantAgent       (physics engine)
-    Process / Thread B  →  ControllerAgent  (PID law, sinusoidal reference)
-    Main thread         →  Oscilloscope     (read-only monitor + matplotlib)
+    PlantAgent      → publishes "scope/y" at 50 Hz
+    ControllerAgent → reads "scope/y", publishes "scope/u" at 50 Hz
+    Oscilloscope    → reads both topics as a read-only observer via broker.read()
 
-The oscilloscope attaches to the bus as a third read-only handle.  The two
-simulation agents never know it exists and are not slowed down by GUI rendering.
-
-The reference signal r(t) = SP_OFFSET + SP_AMP * sin(2π * SP_FREQ * t) is a
-sinusoid shared between the control law (via closure over time.monotonic) and
-the oscilloscope (recomputed each frame for the reference trace).
+The reference signal r(t) = SP_OFFSET + SP_AMP * sin(2π * SP_FREQ * t).
 
 Usage:
-    python examples/advanced/04_realtime_matplotlib.py
+    python examples/advanced/04_realtime_oscilloscope/04_realtime_matplotlib.py
 
 Dependencies:
     matplotlib (already in dev dependencies)
@@ -36,69 +31,68 @@ import numpy as np
 from synapsys.api import ss, c2d
 from synapsys.agents import PlantAgent, ControllerAgent, SyncEngine, SyncMode
 from synapsys.algorithms import PID
-from synapsys.transport import SharedMemoryTransport
+from synapsys.broker import MessageBroker, Topic, SharedMemoryBackend
 
 # ── Simulation parameters ─────────────────────────────────────────────────────
 BUS      = "scope_demo"
-CHANNELS = {"y": 1, "u": 1}
 DT       = 0.02       # 50 Hz
 WINDOW   = 200        # samples shown in the rolling window
 SCOPE_HZ = 30         # oscilloscope refresh rate (frames per second)
 
-# Sinusoidal reference:  r(t) = SP_OFFSET + SP_AMP * sin(2π * SP_FREQ * t)
-SP_AMP    = 2.0        # amplitude  [same units as y]
-SP_FREQ   = 0.2        # frequency  [Hz]  → 5 s period
-SP_OFFSET = 3.0        # DC offset  (keeps r(t) well above zero)
+SP_AMP    = 2.0
+SP_FREQ   = 0.2
+SP_OFFSET = 3.0
 
 # ── 1. Build plant ────────────────────────────────────────────────────────────
 plant_d = c2d(ss([[-1.0]], [[1.0]], [[1.0]], [[0.0]]), dt=DT)
 
-# ── 2. Create transport owner and initialise channels ─────────────────────────
-owner = SharedMemoryTransport(BUS, CHANNELS, create=True)
-owner.write("y", np.array([0.0]))
-owner.write("u", np.array([0.0]))
+# ── 2. Broker + topics ────────────────────────────────────────────────────────
+topic_y = Topic("scope/y", shape=(1,))
+topic_u = Topic("scope/u", shape=(1,))
 
-# ── 3. Per-agent transport handles ────────────────────────────────────────────
-t_plant = SharedMemoryTransport(BUS, CHANNELS)
-t_ctrl  = SharedMemoryTransport(BUS, CHANNELS)
+broker = MessageBroker()
+broker.declare_topic(topic_y)
+broker.declare_topic(topic_u)
+broker.add_backend(SharedMemoryBackend(BUS, [topic_y, topic_u], create=True))
 
-# ── 4. Reference + control law ────────────────────────────────────────────────
+broker.publish("scope/y", np.zeros(1))
+broker.publish("scope/u", np.zeros(1))
+
+# ── 3. Reference + control law ────────────────────────────────────────────────
 t_start = time.monotonic()
 
 def _setpoint(t: float) -> float:
-    """Sinusoidal reference evaluated at wall-clock time t (seconds)."""
     return SP_OFFSET + SP_AMP * np.sin(2.0 * np.pi * SP_FREQ * t)
 
 pid = PID(Kp=6.0, Ki=2.0, dt=DT, u_min=-15.0, u_max=15.0)
 
 def law(y: np.ndarray) -> np.ndarray:
-    """PID law with time-varying setpoint sampled at call time."""
     r = _setpoint(time.monotonic() - t_start)
     return np.array([pid.compute(setpoint=r, measurement=y[0])])
 
-# ── 5. Launch agents in background threads ────────────────────────────────────
-plant_agent = PlantAgent("plant", plant_d, t_plant,
-                         SyncEngine(SyncMode.WALL_CLOCK, dt=DT))
-ctrl_agent  = ControllerAgent("ctrl", law, t_ctrl,
-                              SyncEngine(SyncMode.WALL_CLOCK, dt=DT))
+# ── 4. Launch agents in background threads ────────────────────────────────────
+plant_agent = PlantAgent(
+    "plant", plant_d, None, SyncEngine(SyncMode.WALL_CLOCK, dt=DT),
+    channel_y="scope/y", channel_u="scope/u", broker=broker,
+)
+ctrl_agent = ControllerAgent(
+    "ctrl", law, None, SyncEngine(SyncMode.WALL_CLOCK, dt=DT),
+    channel_y="scope/y", channel_u="scope/u", broker=broker,
+)
 plant_agent.start(blocking=False)
 ctrl_agent.start(blocking=False)
 
-# ── 6. Read-only oscilloscope handle ─────────────────────────────────────────
-scope = SharedMemoryTransport(BUS, CHANNELS)
-
-# Rolling buffers
+# ── 5. Rolling buffers (oscilloscope reads directly from broker) ──────────────
 buf_t = deque([0.0] * WINDOW, maxlen=WINDOW)
 buf_y = deque([0.0] * WINDOW, maxlen=WINDOW)
-buf_r = deque([SP_OFFSET] * WINDOW, maxlen=WINDOW)   # reference trace
+buf_r = deque([SP_OFFSET] * WINDOW, maxlen=WINDOW)
 buf_u = deque([0.0] * WINDOW, maxlen=WINDOW)
 
-# ── 7. Matplotlib figure ──────────────────────────────────────────────────────
+# ── 6. Matplotlib figure ──────────────────────────────────────────────────────
 fig, (ax_y, ax_u) = plt.subplots(2, 1, figsize=(10, 6), sharex=True)
 fig.suptitle("Synapsys — Real-Time Oscilloscope (sinusoidal reference)", fontsize=13)
 
-line_y,  = ax_y.plot([], [], lw=1.6, color="steelblue",
-                     label="y(t) — output")
+line_y,  = ax_y.plot([], [], lw=1.6, color="steelblue",  label="y(t) — output")
 line_sp, = ax_y.plot([], [], lw=1.4, color="black", linestyle="--",
                      label=f"r(t) = {SP_OFFSET}+{SP_AMP}·sin(2π·{SP_FREQ}t)")
 ax_y.set_ylabel("y(t)")
@@ -118,10 +112,9 @@ fig.tight_layout()
 
 
 def _update(_frame: int) -> tuple:
-    """Called by FuncAnimation at SCOPE_HZ.  Reads bus, updates lines."""
     now   = time.monotonic() - t_start
-    y_val = scope.read("y")[0]
-    u_val = scope.read("u")[0]
+    y_val = broker.read("scope/y")[0]   # observer reads directly from broker
+    u_val = broker.read("scope/u")[0]
     r_val = _setpoint(now)
 
     buf_t.append(now)
@@ -134,7 +127,6 @@ def _update(_frame: int) -> tuple:
     line_sp.set_data(t_arr, list(buf_r))
     line_u.set_data(t_arr,  list(buf_u))
 
-    # Slide x-axis window
     x_min = max(0.0, now - WINDOW * DT)
     x_max = x_min + WINDOW * DT
     ax_y.set_xlim(x_min, x_max)
@@ -146,7 +138,7 @@ def _update(_frame: int) -> tuple:
 ani = animation.FuncAnimation(
     fig,
     _update,
-    interval=int(1000 / SCOPE_HZ),   # ms between frames
+    interval=int(1000 / SCOPE_HZ),
     blit=True,
     cache_frame_data=False,
 )
@@ -154,15 +146,11 @@ ani = animation.FuncAnimation(
 print("Oscilloscope running — close the window to stop.")
 
 try:
-    plt.show(block=True)              # blocks until window is closed by user
-    # Fallback: if show() returns immediately (headless CI), keep event loop alive
+    plt.show(block=True)
     while plt.get_fignums():
         plt.pause(0.1)
 finally:
     plant_agent.stop()
     ctrl_agent.stop()
-    scope.close()
-    t_plant.close()
-    t_ctrl.close()
-    owner.close()
+    broker.close()
     print("Simulation stopped.")

--- a/examples/advanced/05_digital_twin/05_digital_twin.py
+++ b/examples/advanced/05_digital_twin/05_digital_twin.py
@@ -17,24 +17,23 @@ Demonstrates the Digital Twin pattern:
 Architecture:
     ┌───────────────────────────────────────────────────────┐
     │  "Physical" plant  (drifting model, hidden from twin)  │
-    │  PlantAgent on bus  "physical_bus"                     │
-    └──────────────────────────┬────────────────────────────┘
-                               │  y_physical, u
-    ┌──────────────────────────▼────────────────────────────┐
-    │  ControllerAgent  (PID)  on bus  "physical_bus"        │
-    └──────────────────────────┬────────────────────────────┘
-                               │  (same u fed to twin)
-    ┌──────────────────────────▼────────────────────────────┐
-    │  Virtual twin  (nominal model, step-by-step in main)   │
-    │  Receives the same u each tick, evolves independently  │
+    │  PlantAgent publishes "twin/y", reads "twin/u"         │
     └──────────────────────────┬────────────────────────────┘
                                │
     ┌──────────────────────────▼────────────────────────────┐
-    │  Divergence monitor — plots both signals + error       │
+    │  ControllerAgent (PID) reads "twin/y", writes "twin/u" │
+    └──────────────────────────┬────────────────────────────┘
+                               │  same u fed to virtual twin
+    ┌──────────────────────────▼────────────────────────────┐
+    │  Virtual twin (main thread) — broker.read("twin/u")    │
+    └──────────────────────────┬────────────────────────────┘
+                               │
+    ┌──────────────────────────▼────────────────────────────┐
+    │  Divergence monitor — broker.read() for both signals   │
     └───────────────────────────────────────────────────────┘
 
 Usage:
-    python examples/advanced/05_digital_twin.py
+    python examples/advanced/05_digital_twin/05_digital_twin.py
 """
 
 from __future__ import annotations
@@ -47,69 +46,75 @@ import matplotlib.gridspec as gridspec
 from synapsys.api import ss, c2d
 from synapsys.agents import PlantAgent, ControllerAgent, SyncEngine, SyncMode
 from synapsys.algorithms import PID
-from synapsys.transport import SharedMemoryTransport
+from synapsys.broker import MessageBroker, Topic, SharedMemoryBackend
 
 # ── Parameters ────────────────────────────────────────────────────────────────
-DT        = 0.02      # 50 Hz
-SIM_TIME  = 8.0       # seconds
+DT        = 0.02
+SIM_TIME  = 8.0
 SETPOINT  = 3.0
-DRIFT_AT  = 3.0       # seconds at which mechanical wear begins
-ALERT_THR = 0.15      # divergence threshold that fires alert
+DRIFT_AT  = 3.0
+ALERT_THR = 0.15
 
-BUS      = "twin_demo"
-CHANNELS = {"y": 1, "u": 1}
+BUS = "twin_demo"
 
-# ── Nominal model (what engineers designed against) ───────────────────────────
-# G(s) = 1/(s + 1)
+# ── Nominal model ─────────────────────────────────────────────────────────────
 A_nom = np.array([[-1.0]])
 B_nom = np.array([[1.0]])
 C_nom = np.array([[1.0]])
 D_nom = np.array([[0.0]])
 plant_nominal = c2d(ss(A_nom, B_nom, C_nom, D_nom), dt=DT)
 
-# ── "Physical" plant (hidden from twin — adds damping drift after DRIFT_AT s) ─
-# Same structure, but A gradually drifts from -1 → -2 after 3 s
 def make_drifted_plant(extra_damping: float) -> object:
-    """Return a discretised plant with extra_damping added to pole."""
-    A_drift = np.array([[-1.0 - extra_damping]])
-    return c2d(ss(A_drift, B_nom, C_nom, D_nom), dt=DT)
+    return c2d(ss(np.array([[-1.0 - extra_damping]]), B_nom, C_nom, D_nom), dt=DT)
 
-# ── Transport & agents ────────────────────────────────────────────────────────
-owner = SharedMemoryTransport(BUS, CHANNELS, create=True)
-owner.write("y", np.array([0.0]))
-owner.write("u", np.array([0.0]))
+# ── Broker + topics ────────────────────────────────────────────────────────────
+topic_y = Topic("twin/y", shape=(1,))
+topic_u = Topic("twin/u", shape=(1,))
 
-t_plant = SharedMemoryTransport(BUS, CHANNELS)
-t_ctrl  = SharedMemoryTransport(BUS, CHANNELS)
-monitor = SharedMemoryTransport(BUS, CHANNELS)
+broker = MessageBroker()
+broker.declare_topic(topic_y)
+broker.declare_topic(topic_u)
+broker.add_backend(SharedMemoryBackend(BUS, [topic_y, topic_u], create=True))
 
+broker.publish("twin/y", np.zeros(1))
+broker.publish("twin/u", np.zeros(1))
+
+# ── Control law ───────────────────────────────────────────────────────────────
 pid = PID(Kp=4.0, Ki=1.2, dt=DT, u_min=-15.0, u_max=15.0)
 law = lambda y: np.array([pid.compute(setpoint=SETPOINT, measurement=y[0])])
 
-# Start with nominal plant
-plant_agent = PlantAgent(
-    "physical_plant",
-    make_drifted_plant(0.0),      # no drift initially
-    t_plant,
+# ── Agents ────────────────────────────────────────────────────────────────────
+def _make_plant_agent(extra_damping: float) -> PlantAgent:
+    return PlantAgent(
+        "physical_plant",
+        make_drifted_plant(extra_damping),
+        None,
+        SyncEngine(SyncMode.WALL_CLOCK, dt=DT),
+        channel_y="twin/y", channel_u="twin/u",
+        broker=broker,
+    )
+
+plant_agent = _make_plant_agent(0.0)
+ctrl_agent  = ControllerAgent(
+    "pid_ctrl", law, None,
     SyncEngine(SyncMode.WALL_CLOCK, dt=DT),
-)
-ctrl_agent = ControllerAgent(
-    "pid_ctrl", law, t_ctrl, SyncEngine(SyncMode.WALL_CLOCK, dt=DT)
+    channel_y="twin/y", channel_u="twin/u",
+    broker=broker,
 )
 
 plant_agent.start(blocking=False)
 ctrl_agent.start(blocking=False)
 
-# ── Virtual twin state (evolves in main thread) ───────────────────────────────
+# ── Virtual twin state ────────────────────────────────────────────────────────
 x_virtual = np.zeros(plant_nominal.n_states)
 
 # ── Data collection ───────────────────────────────────────────────────────────
-log_t:    list[float] = []
-log_yp:   list[float] = []   # physical y
-log_yv:   list[float] = []   # virtual twin y
-log_u:    list[float] = []
-log_div:  list[float] = []   # ||y_physical - y_virtual||
-alerts:   list[float] = []   # timestamps where divergence exceeded threshold
+log_t:   list[float] = []
+log_yp:  list[float] = []
+log_yv:  list[float] = []
+log_u:   list[float] = []
+log_div: list[float] = []
+alerts:  list[float] = []
 
 drift_applied = False
 t0 = time.monotonic()
@@ -119,45 +124,33 @@ print(f"  Nominal model: G(s) = 1/(s+1)")
 print(f"  Wear injection at t={DRIFT_AT}s (extra damping +1.0)")
 print(f"  Alert threshold: ||divergence|| > {ALERT_THR}\n")
 
-step = 0
 while True:
     elapsed = time.monotonic() - t0
     if elapsed >= SIM_TIME:
         break
 
-    # ── Inject wear at DRIFT_AT seconds ──────────────────────────────────
-    # In a real digital twin the physical plant changes by itself;
-    # here we simulate it by swapping the PlantAgent's internal model.
-    # We do this by stopping and restarting the agent (graceful swap).
     if not drift_applied and elapsed >= DRIFT_AT:
         plant_agent.stop()
-        plant_agent = PlantAgent(
-            "physical_plant_worn",
-            make_drifted_plant(1.0),   # pole at -2 instead of -1
-            t_plant,
-            SyncEngine(SyncMode.WALL_CLOCK, dt=DT),
-        )
+        plant_agent = _make_plant_agent(1.0)
         plant_agent.start(blocking=False)
         drift_applied = True
-        print(f"[t={elapsed:.2f}s] ⚠  Wear injected: plant pole drifted -1 → -2")
+        print(f"[t={elapsed:.2f}s] Wear injected: plant pole drifted -1 -> -2")
 
-    # ── Read from physical bus ────────────────────────────────────────────
-    y_physical = monitor.read("y")[0]
-    u_current  = monitor.read("u")[0]
+    # Monitor reads directly from broker (no extra transport handle needed)
+    y_physical = broker.read("twin/y")[0]
+    u_current  = broker.read("twin/u")[0]
 
-    # ── Step virtual twin with the SAME u ────────────────────────────────
     x_virtual, y_virtual_arr = plant_nominal.evolve(
         x_virtual, np.array([u_current])
     )
     y_virtual = float(y_virtual_arr[0])
 
-    # ── Divergence ────────────────────────────────────────────────────────
     divergence = abs(y_physical - y_virtual)
 
     if divergence > ALERT_THR:
         alerts.append(elapsed)
         if len(alerts) == 1 or (elapsed - alerts[-2]) > 0.5:
-            print(f"[t={elapsed:.2f}s] 🔴 ALERT: divergence = {divergence:.4f} > {ALERT_THR}")
+            print(f"[t={elapsed:.2f}s] ALERT: divergence = {divergence:.4f} > {ALERT_THR}")
 
     log_t.append(elapsed)
     log_yp.append(y_physical)
@@ -165,16 +158,12 @@ while True:
     log_u.append(u_current)
     log_div.append(divergence)
 
-    step += 1
     time.sleep(DT)
 
 # ── Cleanup ───────────────────────────────────────────────────────────────────
 plant_agent.stop()
 ctrl_agent.stop()
-monitor.close()
-t_plant.close()
-t_ctrl.close()
-owner.close()
+broker.close()
 
 # ── Plot results ──────────────────────────────────────────────────────────────
 t_arr   = np.array(log_t)
@@ -186,10 +175,9 @@ div_arr = np.array(log_div)
 fig = plt.figure(figsize=(12, 8))
 gs  = gridspec.GridSpec(3, 1, hspace=0.45)
 
-# ── Panel 1: physical vs virtual ─────────────────────────────────────────────
 ax1 = fig.add_subplot(gs[0])
-ax1.plot(t_arr, yp_arr,  lw=1.8,  color="steelblue",  label="y_physical  (real plant)")
-ax1.plot(t_arr, yv_arr,  lw=1.5,  color="darkorange", linestyle="--", label="y_virtual   (twin model)")
+ax1.plot(t_arr, yp_arr, lw=1.8, color="steelblue",  label="y_physical  (real plant)")
+ax1.plot(t_arr, yv_arr, lw=1.5, color="darkorange", linestyle="--", label="y_virtual   (twin model)")
 ax1.axhline(SETPOINT, color="k", linestyle=":", alpha=0.45, label=f"setpoint = {SETPOINT}")
 ax1.axvline(DRIFT_AT, color="red", linestyle="--", alpha=0.5, lw=1.2, label=f"wear injected t={DRIFT_AT}s")
 ax1.set_ylabel("Output y(t)")
@@ -197,9 +185,8 @@ ax1.set_title("Digital Twin — Physical vs Virtual Model")
 ax1.legend(fontsize=8, loc="lower right")
 ax1.grid(True, alpha=0.3)
 
-# ── Panel 2: divergence ───────────────────────────────────────────────────────
 ax2 = fig.add_subplot(gs[1])
-ax2.plot(t_arr, div_arr, lw=1.6, color="crimson", label="|y_physical − y_virtual|")
+ax2.plot(t_arr, div_arr, lw=1.6, color="crimson", label="|y_physical - y_virtual|")
 ax2.axhline(ALERT_THR, color="red", linestyle="--", lw=1.2, alpha=0.7,
             label=f"alert threshold = {ALERT_THR}")
 ax2.axvline(DRIFT_AT, color="red", linestyle="--", alpha=0.5, lw=1.2)
@@ -211,7 +198,6 @@ ax2.set_title("Anomaly Detection — Divergence Metric")
 ax2.legend(fontsize=8)
 ax2.grid(True, alpha=0.3)
 
-# ── Panel 3: control signal ───────────────────────────────────────────────────
 ax3 = fig.add_subplot(gs[2])
 ax3.plot(t_arr, u_arr, lw=1.4, color="seagreen", label="u(t) — PID output")
 ax3.axvline(DRIFT_AT, color="red", linestyle="--", alpha=0.5, lw=1.2)

--- a/examples/advanced/06_quadcopter_mimo/06a_quadcopter_plant.py
+++ b/examples/advanced/06_quadcopter_mimo/06a_quadcopter_plant.py
@@ -1,12 +1,13 @@
 """Quadcopter plant process — linearised 12-state MIMO via synapsys.
 
-Discretises the hover model at 100 Hz and runs a PlantAgent on shared memory.
+Discretises the hover model at 100 Hz and runs a PlantAgent on a
+MessageBroker backed by shared memory.
 Start this script FIRST, then run 06b_neural_lqr_3d.py.
 
 Architecture
 ------------
-  state (12) ──► SharedMemoryTransport("quad") ──► controller
-  controller ──► SharedMemoryTransport("quad") ──► δu (4)
+  quad/state (12) ──► MessageBroker("quad") ──► controller
+  controller       ──► MessageBroker("quad") ──► quad/u (4)
 
 Usage
 -----
@@ -20,19 +21,17 @@ from pathlib import Path
 
 import numpy as np
 
-# allow running from this directory
 sys.path.insert(0, str(Path(__file__).parent))
+
+from quadcopter_dynamics import U_MAX, U_MIN, build_matrices
 
 from synapsys.agents import PlantAgent, SyncEngine, SyncMode
 from synapsys.api import c2d, ss
-from synapsys.transport import SharedMemoryTransport
+from synapsys.broker import MessageBroker, SharedMemoryBackend, Topic
 
-from quadcopter_dynamics import F_HOVER, U_MAX, U_MIN, build_matrices
-
-# ── Constants ─────────────────────────────────────────────────────────────────
-DT          = 0.01      # 100 Hz
-BUS_NAME    = "quad"
-X0          = np.zeros(12)   # start on the ground, at rest
+DT       = 0.01      # 100 Hz
+BUS_NAME = "quad"
+X0       = np.zeros(12)
 
 
 def main() -> None:
@@ -41,59 +40,65 @@ def main() -> None:
     plant_d = c2d(plant_c, DT)
 
     print("Quadcopter linearised model")
-    print(f"  States  : {plant_d.n_states}   (x,y,z,φ,θ,ψ,ẋ,ẏ,ż,p,q,r)")
-    print(f"  Inputs  : {plant_d.n_inputs}    (δF, τφ, τθ, τψ  — deviations from hover)")
-    print(f"  Outputs : {plant_d.n_outputs}    (x, y, z, ψ)")
+    print(f"  States  : {plant_d.n_states}   (x,y,z,phi,theta,psi,xd,yd,zd,p,q,r)")
+    print(f"  Inputs  : {plant_d.n_inputs}    (dF, tau_phi, tau_theta, tau_psi)")
+    print(f"  Outputs : {plant_d.n_outputs}    (x, y, z, psi)")
     print(f"  dt      : {DT} s  (100 Hz)")
-    print(f"\nCreating shared-memory bus '{BUS_NAME}'…")
 
-    # Expose full 12-state vector + 4 inputs on the bus
-    channels = {"state": plant_d.n_states, "u": plant_d.n_inputs}
+    # ── Broker + topics ───────────────────────────────────────────────────────
+    topic_state = Topic("quad/state", shape=(plant_d.n_states,))
+    topic_u     = Topic("quad/u",     shape=(plant_d.n_inputs,))
 
-    with SharedMemoryTransport(BUS_NAME, channels, create=True) as bus:
-        bus.write("state", X0.copy())
-        bus.write("u",     np.zeros(plant_d.n_inputs))
+    broker = MessageBroker()
+    broker.declare_topic(topic_state)
+    broker.declare_topic(topic_u)
+    broker.add_backend(
+        SharedMemoryBackend(BUS_NAME, [topic_state, topic_u], create=True)
+    )
+    broker.publish("quad/state", X0.copy())
+    broker.publish("quad/u",     np.zeros(plant_d.n_inputs))
 
-        # Wrap the PlantAgent to clip control inputs and add hover equilibrium
-        _inner = plant_d
+    print(f"\nBroker bus '{BUS_NAME}' ready.")
 
-        class _ClippedPlant:
-            """Thin wrapper: clips δu, adds F_HOVER to thrust channel."""
-            n_states  = _inner.n_states
-            n_inputs  = _inner.n_inputs
-            n_outputs = _inner.n_outputs
-            is_discrete = _inner.is_discrete
-            dt = _inner.dt
+    # Thin wrapper: clips control deviations before applying to linearised model
+    _inner = plant_d
 
-            def evolve(
-                self, x: np.ndarray, u: np.ndarray
-            ) -> tuple[np.ndarray, np.ndarray]:
-                u_clipped = np.clip(u, U_MIN, U_MAX)
-                return _inner.evolve(x, u_clipped)
+    class _ClippedPlant:
+        n_states    = _inner.n_states
+        n_inputs    = _inner.n_inputs
+        n_outputs   = _inner.n_outputs
+        is_discrete = _inner.is_discrete
+        dt          = _inner.dt
 
-        sync  = SyncEngine(mode=SyncMode.WALL_CLOCK, dt=DT)
-        agent = PlantAgent(
-            "quad_plant", _ClippedPlant(), bus, sync,  # type: ignore[arg-type]
-            x0=X0.copy(),
-        )
-        agent.start(blocking=False)
+        def evolve(self, x: np.ndarray, u: np.ndarray):
+            return _inner.evolve(x, np.clip(u, U_MIN, U_MAX))
 
-        print("Plant running.  Waiting for controller…")
-        print("Press Ctrl+C to stop.\n")
+    sync  = SyncEngine(mode=SyncMode.WALL_CLOCK, dt=DT)
+    agent = PlantAgent(
+        "quad_plant", _ClippedPlant(), None, sync,  # type: ignore[arg-type]
+        channel_y="quad/state", channel_u="quad/u",
+        x0=X0.copy(), broker=broker,
+    )
+    agent.start(blocking=False)
 
-        try:
-            while True:
-                time.sleep(1.0)
-                state = bus.read("state")
-                print(
-                    f"  z={state[2]:+.3f} m  "
-                    f"φ={np.degrees(state[3]):+.1f}°  "
-                    f"θ={np.degrees(state[4]):+.1f}°  "
-                    f"ψ={np.degrees(state[5]):+.1f}°"
-                )
-        except KeyboardInterrupt:
-            print("\nStopping plant.")
-            agent.stop()
+    print("Plant running.  Waiting for controller…")
+    print("Press Ctrl+C to stop.\n")
+
+    try:
+        while True:
+            time.sleep(1.0)
+            state = broker.read("quad/state")
+            print(
+                f"  z={state[2]:+.3f} m  "
+                f"phi={np.degrees(state[3]):+.1f}  "
+                f"theta={np.degrees(state[4]):+.1f}  "
+                f"psi={np.degrees(state[5]):+.1f}"
+            )
+    except KeyboardInterrupt:
+        print("\nStopping plant.")
+        agent.stop()
+    finally:
+        broker.close()
 
 
 if __name__ == "__main__":

--- a/examples/distributed/01_shared_memory/controller.py
+++ b/examples/distributed/01_shared_memory/controller.py
@@ -3,36 +3,52 @@ Distributed simulation — Controller process.
 
 Run AFTER starting plant.py in a separate terminal.
 
-The controller reads the plant output from shared memory, computes
-a PID control action, and writes it back — without sharing any code
-with the plant process.
+The controller reads plant/y from the shared-memory broker, computes a PID
+control action, and publishes it to plant/u — without sharing any code with
+the plant process.
 
 Usage:
-    python examples/distributed/controller.py
+    python examples/distributed/01_shared_memory/controller.py
 """
-import time
 import numpy as np
 
-from synapsys.transport.shared_memory import SharedMemoryTransport
-from synapsys.algorithms.pid import PID
+from synapsys.agents import ControllerAgent, SyncEngine, SyncMode
+from synapsys.algorithms import PID
+from synapsys.broker import MessageBroker, Topic, SharedMemoryBackend
 
 BUS_NAME = "synapsys_demo"
-CHANNELS = {"y": 1, "u": 1}
-DT = 0.025   # 40 Hz — faster than the plant
+DT       = 0.025   # 40 Hz — faster than the plant
 SETPOINT = 5.0
 
-pid = PID(Kp=3.0, Ki=0.5, dt=DT, u_min=-10.0, u_max=10.0)
+# ── Broker setup (connects to existing bus — create=False) ────────────────────
+topic_y = Topic("plant/y", shape=(1,))
+topic_u = Topic("plant/u", shape=(1,))
 
 try:
-    with SharedMemoryTransport(BUS_NAME, CHANNELS, create=False) as bus:
-        print(f"Controller: connected.  Setpoint = {SETPOINT}")
-        while True:
-            y = bus.read("y")[0]
-            u = pid.compute(setpoint=SETPOINT, measurement=y)
-            bus.write("u", np.array([u]))
-            time.sleep(DT)
-
+    broker = MessageBroker()
+    broker.declare_topic(topic_y)
+    broker.declare_topic(topic_u)
+    broker.add_backend(SharedMemoryBackend(BUS_NAME, [topic_y, topic_u], create=False))
 except FileNotFoundError:
     print("Error: start plant.py first to initialise the shared-memory bus.")
+    raise SystemExit(1)
+
+# ── Control law ───────────────────────────────────────────────────────────────
+pid = PID(Kp=3.0, Ki=0.5, dt=DT, u_min=-10.0, u_max=10.0)
+law = lambda y: np.array([pid.compute(setpoint=SETPOINT, measurement=y[0])])
+
+print(f"Controller: connected to '{BUS_NAME}'.  Setpoint = {SETPOINT}")
+
+sync  = SyncEngine(SyncMode.WALL_CLOCK, dt=DT)
+agent = ControllerAgent(
+    "ctrl", law, None, sync,
+    channel_y="plant/y", channel_u="plant/u",
+    broker=broker,
+)
+
+try:
+    agent.start(blocking=True)
 except KeyboardInterrupt:
     print("\nController: stopped.")
+finally:
+    broker.close()

--- a/examples/distributed/01_shared_memory/plant.py
+++ b/examples/distributed/01_shared_memory/plant.py
@@ -3,38 +3,53 @@ Distributed simulation — Plant process.
 
 Run this FIRST, then start controller.py in a separate terminal.
 
-The plant exposes its state on a shared-memory bus with two channels:
-    y  — plant output (scalar)
-    u  — control input (scalar, written by the controller)
+The plant exposes its state on a MessageBroker backed by shared memory.
+Two topics are declared:
+    plant/y  — plant output (scalar)
+    plant/u  — control input (scalar, written by the controller)
 
 Usage:
-    python examples/distributed/plant.py
+    python examples/distributed/01_shared_memory/plant.py
 """
-import time
 import numpy as np
 
-from synapsys.transport.shared_memory import SharedMemoryTransport
+from synapsys.api import ss, c2d
+from synapsys.agents import PlantAgent, SyncEngine, SyncMode
+from synapsys.broker import MessageBroker, Topic, SharedMemoryBackend
 
 BUS_NAME = "synapsys_demo"
-CHANNELS = {"y": 1, "u": 1}
-DT = 0.05   # 20 Hz
-N_STEPS = 200
+DT       = 0.05   # 20 Hz
 
-with SharedMemoryTransport(BUS_NAME, CHANNELS, create=True) as bus:
-    bus.write("y", np.array([0.0]))
-    bus.write("u", np.array([0.0]))
-    print("Plant: bus ready.  Starting in 2 s — launch controller.py now.")
-    time.sleep(2.0)
+# G(s) = 1/(s+1) discretised with ZOH
+plant_d = c2d(ss([[-1.0]], [[1.0]], [[1.0]], [[0.0]]), dt=DT)
 
-    for k in range(N_STEPS):
-        u = bus.read("u")[0]
-        y = bus.read("y")[0]
+# ── Broker setup ──────────────────────────────────────────────────────────────
+topic_y = Topic("plant/y", shape=(1,))
+topic_u = Topic("plant/u", shape=(1,))
 
-        # Discrete first-order dynamics: y(k+1) = 0.9*y(k) + 0.1*u(k)
-        y_next = 0.9 * y + 0.1 * u
-        bus.write("y", np.array([y_next]))
+broker = MessageBroker()
+broker.declare_topic(topic_y)
+broker.declare_topic(topic_u)
+broker.add_backend(SharedMemoryBackend(BUS_NAME, [topic_y, topic_u], create=True))
 
-        print(f"k={k:03d}  u={u:7.3f}  y={y_next:7.3f}")
-        time.sleep(DT)
+broker.publish("plant/y", np.zeros(1))
+broker.publish("plant/u", np.zeros(1))
 
-print("Plant: simulation complete.")
+print(f"Plant: bus '{BUS_NAME}' ready.  Starting in 2 s — launch controller.py now.")
+import time; time.sleep(2.0)
+
+# ── Agent ─────────────────────────────────────────────────────────────────────
+sync  = SyncEngine(SyncMode.WALL_CLOCK, dt=DT)
+agent = PlantAgent(
+    "plant", plant_d, None, sync,
+    channel_y="plant/y", channel_u="plant/u",
+    broker=broker,
+)
+
+print("Plant running.  Press Ctrl+C to stop.")
+try:
+    agent.start(blocking=True)
+except KeyboardInterrupt:
+    print("\nPlant: stopped.")
+finally:
+    broker.close()

--- a/examples/distributed/02_zmq/controller_zmq.py
+++ b/examples/distributed/02_zmq/controller_zmq.py
@@ -1,52 +1,59 @@
 """
 Distributed simulation via ZeroMQ — Controller process.
 
-The controller subscribes to y from tcp://localhost:5555 (SUB)
-and publishes u on tcp://0.0.0.0:5556 (PUB).
+The controller subscribes to plant/y from tcp://localhost:5555 (SUB)
+and publishes plant/u on tcp://0.0.0.0:5556 (PUB).
 
 Can run on a different machine from plant_zmq.py.
 Change PLANT_HOST to the plant's IP address if remote.
 
 Usage:
-    python examples/distributed/controller_zmq.py
+    python examples/distributed/02_zmq/controller_zmq.py
 """
-import time
 import numpy as np
 
-from synapsys.algorithms.pid import PID
-from synapsys.transport.network import ZMQTransport
+from synapsys.agents import ControllerAgent, SyncEngine, SyncMode
+from synapsys.algorithms import PID
+from synapsys.broker import MessageBroker, Topic
+from synapsys.broker.backends.zmq import ZMQBrokerBackend
 
 PLANT_HOST = "localhost"
-DT = 0.025      # controller runs at 2× plant rate
-SETPOINT = 5.0
+DT         = 0.025      # 40 Hz — 2× plant rate
+SETPOINT   = 5.0
+Y_ADDR     = f"tcp://{PLANT_HOST}:5555"
+U_ADDR     = "tcp://0.0.0.0:5556"
 
+# ── Broker: subscribes y, publishes u ────────────────────────────────────────
+topic_y = Topic("plant/y", shape=(1,))
+topic_u = Topic("plant/u", shape=(1,))
+
+broker = MessageBroker()
+broker.declare_topic(topic_y)
+broker.declare_topic(topic_u)
+
+broker.add_backend(ZMQBrokerBackend(Y_ADDR, subscribe_topics=[topic_y]))
+broker.add_backend(ZMQBrokerBackend(U_ADDR, publish_topics=[topic_u]))
+
+# ── Control law ───────────────────────────────────────────────────────────────
 pid = PID(Kp=3.0, Ki=0.5, dt=DT, u_min=-20.0, u_max=20.0)
+law = lambda y: np.array([pid.compute(setpoint=SETPOINT, measurement=y[0])])
 
-sub = ZMQTransport(f"tcp://{PLANT_HOST}:5555", mode="sub")
-pub = ZMQTransport("tcp://0.0.0.0:5556", mode="pub")
-sub._socket.setsockopt(0x8, 50)  # ZMQ_RCVTIMEO = 50 ms
+import time; time.sleep(0.5)  # let plant start first
 
-print(f"Controller: subscribing y from :{5555}, publishing u on :{5556}")
+print(f"Controller: subscribing plant/y from {Y_ADDR}")
+print(f"Controller: publishing plant/u on {U_ADDR}")
 print(f"Setpoint = {SETPOINT}")
-time.sleep(0.5)  # let plant start first
+
+sync  = SyncEngine(SyncMode.WALL_CLOCK, dt=DT)
+agent = ControllerAgent(
+    "ctrl", law, None, sync,
+    channel_y="plant/y", channel_u="plant/u",
+    broker=broker,
+)
 
 try:
-    while True:
-        t0 = time.monotonic()
-
-        try:
-            y = sub.read("y")
-            u = pid.compute(setpoint=SETPOINT, measurement=y[0])
-            pub.write("u", np.array([u]))
-        except Exception:
-            pass  # plant not ready yet; keep looping
-
-        elapsed = time.monotonic() - t0
-        if DT - elapsed > 0:
-            time.sleep(DT - elapsed)
-
+    agent.start(blocking=True)
 except KeyboardInterrupt:
     print("\nController: stopped.")
 finally:
-    sub.close()
-    pub.close()
+    broker.close()

--- a/examples/distributed/02_zmq/plant_zmq.py
+++ b/examples/distributed/02_zmq/plant_zmq.py
@@ -1,56 +1,60 @@
 """
 Distributed simulation via ZeroMQ — Plant process.
 
-The plant publishes y on tcp://0.0.0.0:5555 (PUB)
-and subscribes to u from tcp://localhost:5556 (SUB).
+The plant publishes plant/y on tcp://0.0.0.0:5555 (PUB)
+and subscribes to plant/u from the controller on tcp://localhost:5556 (SUB).
 
 Can run on a different machine from controller_zmq.py.
 Change CONTROLLER_HOST to the controller's IP address if remote.
 
 Usage:
-    python examples/distributed/plant_zmq.py
+    python examples/distributed/02_zmq/plant_zmq.py
 """
-import time
 import numpy as np
 
-from synapsys.api.matlab_compat import ss, c2d
-from synapsys.transport.network import ZMQTransport
+from synapsys.api import ss, c2d
+from synapsys.agents import PlantAgent, SyncEngine, SyncMode
+from synapsys.broker import MessageBroker, Topic
+from synapsys.broker.backends.zmq import ZMQBrokerBackend
 
 CONTROLLER_HOST = "localhost"
-DT = 0.05
-N_STEPS = 300
+DT              = 0.05     # 20 Hz
+Y_ADDR          = "tcp://0.0.0.0:5555"
+U_ADDR          = f"tcp://{CONTROLLER_HOST}:5556"
 
 # G(s) = 1/(s+1) discretised with ZOH
 plant_d = c2d(ss([[-1.0]], [[1.0]], [[1.0]], [[0.0]]), dt=DT)
-x = np.zeros(plant_d.n_states)
 
-pub = ZMQTransport("tcp://0.0.0.0:5555", mode="pub")
-sub = ZMQTransport(f"tcp://{CONTROLLER_HOST}:5556", mode="sub")
-sub._socket.setsockopt(0x8, 100)  # ZMQ_RCVTIMEO = 100 ms
+# ── Broker: publishes y, subscribes u ────────────────────────────────────────
+topic_y = Topic("plant/y", shape=(1,))
+topic_u = Topic("plant/u", shape=(1,))
 
-print(f"Plant: publishing y on :5555, subscribing u from :{5556}")
-time.sleep(1.0)  # give sockets time to bind
+broker = MessageBroker()
+broker.declare_topic(topic_y)
+broker.declare_topic(topic_u)
 
-u = np.array([0.0])
+# Two separate ZMQ backends: one PUB for y, one SUB for u
+broker.add_backend(ZMQBrokerBackend(Y_ADDR, publish_topics=[topic_y]))
+broker.add_backend(ZMQBrokerBackend(U_ADDR, subscribe_topics=[topic_u]))
 
-for k in range(N_STEPS):
-    t0 = time.monotonic()
+broker.publish("plant/y", np.zeros(1))
 
-    x, y = plant_d.evolve(x, u)
-    pub.write("y", y)
+import time; time.sleep(1.0)  # allow ZMQ sockets to bind
 
-    # Non-blocking read — use last u if controller hasn't sent yet (ZOH)
-    try:
-        u = sub.read("u")
-    except Exception:
-        pass  # keep previous u
+print(f"Plant: publishing plant/y on {Y_ADDR}")
+print(f"Plant: subscribing plant/u from {U_ADDR}")
 
-    print(f"k={k:03d}  u={u[0]:7.3f}  y={y[0]:7.3f}")
+sync  = SyncEngine(SyncMode.WALL_CLOCK, dt=DT)
+agent = PlantAgent(
+    "plant", plant_d, None, sync,
+    channel_y="plant/y", channel_u="plant/u",
+    broker=broker,
+)
 
-    elapsed = time.monotonic() - t0
-    if DT - elapsed > 0:
-        time.sleep(DT - elapsed)
-
-pub.close()
-sub.close()
-print("Plant: done.")
+print("Plant running.  Press Ctrl+C to stop.")
+try:
+    agent.start(blocking=True)
+except KeyboardInterrupt:
+    print("\nPlant: done.")
+finally:
+    broker.close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "synapsys"
-version = "0.2.1"
+version = "0.2.2"
 description = "Modern Python control systems framework with distributed multi-agent simulation"
 readme = "README.md"
 license = { text = "MIT" }

--- a/synapsys/__init__.py
+++ b/synapsys/__init__.py
@@ -1,6 +1,6 @@
 """Synapsys — modern Python control systems framework."""
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 # ── Convenience re-exports ────────────────────────────────────────────────────
 # Users can write `from synapsys import tf` instead of `from synapsys.api import tf`

--- a/synapsys/__init__.py
+++ b/synapsys/__init__.py
@@ -21,6 +21,7 @@ from synapsys.core.state_space import StateSpace
 from synapsys.core.transfer_function import TransferFunction
 from synapsys.core.transfer_function_matrix import TransferFunctionMatrix
 from synapsys.utils import StateEquations, col, mat, row
+from synapsys.broker import MessageBroker, Topic, SharedMemoryBackend, ZMQBrokerBackend
 
 __all__ = [
     "__version__",
@@ -46,4 +47,9 @@ __all__ = [
     "col",
     "row",
     "StateEquations",
+    # Broker
+    "MessageBroker",
+    "Topic",
+    "SharedMemoryBackend",
+    "ZMQBrokerBackend",
 ]

--- a/synapsys/agents/controller_agent.py
+++ b/synapsys/agents/controller_agent.py
@@ -41,12 +41,14 @@ class ControllerAgent(BaseAgent):
         self,
         name: str,
         control_law: Callable[[np.ndarray], np.ndarray],
-        transport: TransportStrategy,
+        transport: TransportStrategy | None,
         sync: SyncEngine,
         channel_y: str = "y",
         channel_u: str = "u",
+        *,
+        broker: object | None = None,
     ):
-        super().__init__(name, transport, sync)
+        super().__init__(name, transport, sync, broker=broker)
         self._law = control_law
         self._ch_y = channel_y
         self._ch_u = channel_u
@@ -55,9 +57,9 @@ class ControllerAgent(BaseAgent):
         pass
 
     def step(self) -> None:
-        y = self.transport.read(self._ch_y)
+        y = self._read(self._ch_y)
         u = np.asarray(self._law(y), dtype=np.float64).flatten()
-        self.transport.write(self._ch_u, u)
+        self._write(self._ch_u, u)
 
     def teardown(self) -> None:
         pass

--- a/synapsys/agents/hardware_agent.py
+++ b/synapsys/agents/hardware_agent.py
@@ -66,13 +66,15 @@ class HardwareAgent(BaseAgent):
         self,
         name: str,
         hardware: HardwareInterface,
-        transport: TransportStrategy,
+        transport: TransportStrategy | None,
         sync: SyncEngine,
         channel_y: str = "y",
         channel_u: str = "u",
         timeout_ms: float = 100.0,
+        *,
+        broker: object | None = None,
     ):
-        super().__init__(name, transport, sync)
+        super().__init__(name, transport, sync, broker=broker)
         self._hw = hardware
         self._ch_y = channel_y
         self._ch_u = channel_u
@@ -83,8 +85,7 @@ class HardwareAgent(BaseAgent):
         self._last_u: np.ndarray = np.zeros(hardware.n_inputs)
 
     def setup(self) -> None:
-        # Initialise bus with zeros so the controller has a valid starting value
-        self.transport.write(self._ch_y, self._last_y.copy())
+        self._write(self._ch_y, self._last_y.copy())
 
     def step(self) -> None:
         # ── Read sensors from hardware (ZOH on timeout) ────────────────────
@@ -97,11 +98,9 @@ class HardwareAgent(BaseAgent):
                 self.name,
             )
 
-        # ── Publish y to the transport bus ────────────────────────────────
-        self.transport.write(self._ch_y, self._last_y)
+        self._write(self._ch_y, self._last_y)
 
-        # ── Read control command from bus ─────────────────────────────────
-        u = self.transport.read(self._ch_u)
+        u = self._read(self._ch_u)
         self._last_u = np.asarray(u, dtype=np.float64).flatten()
 
         # ── Send actuator command to hardware (ZOH on timeout) ────────────

--- a/synapsys/agents/lifecycle.py
+++ b/synapsys/agents/lifecycle.py
@@ -4,6 +4,8 @@ import logging
 import threading
 from abc import ABC, abstractmethod
 
+import numpy as np
+
 from ..transport.base import TransportStrategy
 from .sync_engine import SyncEngine
 
@@ -18,6 +20,10 @@ class BaseAgent(ABC):
     Call ``start()`` to launch the agent in a background thread, or
     ``start(blocking=True)`` to run it in the current thread.
 
+    Accepts either a legacy ``TransportStrategy`` or a ``MessageBroker``
+    (pass ``transport=None, broker=<broker>``). Use ``self._read()`` /
+    ``self._write()`` in subclasses to stay transport-agnostic.
+
     Lifecycle::
 
         setup()  ->  [step() + sync.tick()] * N  ->  teardown()
@@ -26,17 +32,36 @@ class BaseAgent(ABC):
     def __init__(
         self,
         name: str,
-        transport: TransportStrategy,
+        transport: TransportStrategy | None,
         sync: SyncEngine,
+        *,
+        broker: object | None = None,
     ):
         self.name = name
         self.transport = transport
         self.sync = sync
+        self.broker = broker
         self._running = False
         self._thread: threading.Thread | None = None
 
-        # Transport lifetime is owned by the caller, not the agent.
-        # The agent does NOT close the transport on exit.
+        # Transport/broker lifetime is owned by the caller, not the agent.
+
+    # ------------------------------------------------------------------
+    # Unified I/O helpers (transport-agnostic)
+    # ------------------------------------------------------------------
+
+    def _read(self, channel: str) -> np.ndarray:
+        if self.broker is not None:
+            return self.broker.read(channel)  # type: ignore[union-attr]
+        assert self.transport is not None, "Agent has neither transport nor broker."
+        return self.transport.read(channel)
+
+    def _write(self, channel: str, data: np.ndarray) -> None:
+        if self.broker is not None:
+            self.broker.publish(channel, data)  # type: ignore[union-attr]
+        else:
+            assert self.transport is not None, "Agent has neither transport nor broker."
+            self.transport.write(channel, data)
 
     # ------------------------------------------------------------------
     # Interface to implement

--- a/synapsys/agents/plant_agent.py
+++ b/synapsys/agents/plant_agent.py
@@ -39,18 +39,20 @@ class PlantAgent(BaseAgent):
         self,
         name: str,
         plant: StateSpace,
-        transport: TransportStrategy,
+        transport: TransportStrategy | None,
         sync: SyncEngine,
         channel_y: str = "y",
         channel_u: str = "u",
         x0: np.ndarray | None = None,
+        *,
+        broker: object | None = None,
     ):
         if not plant.is_discrete:
             raise ValueError(
                 "PlantAgent requires a discrete plant (dt > 0). "
                 "Discretise it with c2d() first."
             )
-        super().__init__(name, transport, sync)
+        super().__init__(name, transport, sync, broker=broker)
         self._plant = plant
         self._ch_y = channel_y
         self._ch_u = channel_u
@@ -69,12 +71,12 @@ class PlantAgent(BaseAgent):
     def setup(self) -> None:
         u0 = np.zeros(self._plant.n_inputs)
         _, y0 = self._plant.evolve(self._x, u0)
-        self.transport.write(self._ch_y, y0)
+        self._write(self._ch_y, y0)
 
     def step(self) -> None:
-        u = self.transport.read(self._ch_u)
+        u = self._read(self._ch_u)
         self._x, y = self._plant.evolve(self._x, u)
-        self.transport.write(self._ch_y, y)
+        self._write(self._ch_y, y)
 
     def teardown(self) -> None:
         pass

--- a/synapsys/broker/__init__.py
+++ b/synapsys/broker/__init__.py
@@ -1,0 +1,11 @@
+from .broker import MessageBroker
+from .topic import Topic
+from .backends import BrokerBackend, SharedMemoryBackend, ZMQBrokerBackend
+
+__all__ = [
+    "MessageBroker",
+    "Topic",
+    "BrokerBackend",
+    "SharedMemoryBackend",
+    "ZMQBrokerBackend",
+]

--- a/synapsys/broker/backends/__init__.py
+++ b/synapsys/broker/backends/__init__.py
@@ -1,0 +1,5 @@
+from .base import BrokerBackend
+from .shared_memory import SharedMemoryBackend
+from .zmq import ZMQBrokerBackend
+
+__all__ = ["BrokerBackend", "SharedMemoryBackend", "ZMQBrokerBackend"]

--- a/synapsys/broker/backends/base.py
+++ b/synapsys/broker/backends/base.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+import numpy as np
+
+from ..topic import Topic
+
+
+class BrokerBackend(ABC):
+    """Pluggable transport adapter for MessageBroker."""
+
+    @abstractmethod
+    def supports(self, topic: Topic) -> bool:
+        """Return True if this backend handles the given topic."""
+
+    @abstractmethod
+    def write(self, topic: Topic, data: np.ndarray) -> None:
+        """Write validated data to the underlying transport."""
+
+    @abstractmethod
+    def read(self, topic: Topic) -> np.ndarray:
+        """Read latest data from the underlying transport (non-blocking, ZOH)."""
+
+    @abstractmethod
+    def close(self) -> None:
+        """Release all resources."""
+
+    def __enter__(self) -> BrokerBackend:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()

--- a/synapsys/broker/backends/shared_memory.py
+++ b/synapsys/broker/backends/shared_memory.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import numpy as np
+
+from ...transport.shared_memory import SharedMemoryTransport
+from ..topic import Topic
+from .base import BrokerBackend
+
+
+class SharedMemoryBackend(BrokerBackend):
+    """Backend backed by a SharedMemoryTransport (same host, zero-copy)."""
+
+    def __init__(
+        self,
+        bus_name: str,
+        topics: Sequence[Topic],
+        create: bool = False,
+    ) -> None:
+        self._topic_map = {t.name: t for t in topics}
+        channels = {t.name: t.size for t in topics}
+        self._transport = SharedMemoryTransport(bus_name, channels, create=create)
+
+    def supports(self, topic: Topic) -> bool:
+        return topic.name in self._topic_map
+
+    def write(self, topic: Topic, data: np.ndarray) -> None:
+        self._transport.write(topic.name, data.flatten())
+
+    def read(self, topic: Topic) -> np.ndarray:
+        flat = self._transport.read(topic.name)
+        return flat.reshape(topic.shape)
+
+    def close(self) -> None:
+        self._transport.close()

--- a/synapsys/broker/backends/zmq.py
+++ b/synapsys/broker/backends/zmq.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import threading
+from collections.abc import Sequence
+
+import numpy as np
+import zmq
+
+from ..topic import Topic
+from .base import BrokerBackend
+
+
+class ZMQBrokerBackend(BrokerBackend):
+    """
+    Backend backed by ZMQ PUB/SUB.
+
+    A background thread keeps a cache of the latest received value per
+    topic so that read() is always non-blocking (ZOH semantics).
+
+    Parameters
+    ----------
+    address          : ZMQ endpoint, e.g. "tcp://localhost:5555"
+    publish_topics   : Topics this instance will write (PUB socket, binds)
+    subscribe_topics : Topics this instance will read (SUB socket, connects)
+    """
+
+    def __init__(
+        self,
+        address: str,
+        publish_topics: Sequence[Topic] = (),
+        subscribe_topics: Sequence[Topic] = (),
+    ) -> None:
+        self._pub_topics = {t.name: t for t in publish_topics}
+        self._sub_topics = {t.name: t for t in subscribe_topics}
+        self._cache: dict[str, np.ndarray] = {
+            t.name: np.zeros(t.shape, dtype=t.dtype) for t in subscribe_topics
+        }
+        self._cache_lock = threading.Lock()
+        self._running = False
+
+        ctx = zmq.Context.instance()
+        self._pub_socket: zmq.Socket | None = None
+        self._sub_socket: zmq.Socket | None = None
+        self._recv_thread: threading.Thread | None = None
+
+        if publish_topics:
+            self._pub_socket = ctx.socket(zmq.PUB)
+            self._pub_socket.bind(address)
+
+        if subscribe_topics:
+            self._sub_socket = ctx.socket(zmq.SUB)
+            self._sub_socket.connect(address)
+            self._sub_socket.setsockopt_string(zmq.SUBSCRIBE, "")
+            self._running = True
+            self._recv_thread = threading.Thread(
+                target=self._recv_loop, daemon=True, name="zmq-broker-recv"
+            )
+            self._recv_thread.start()
+
+    def _recv_loop(self) -> None:
+        assert self._sub_socket is not None
+        while self._running:
+            try:
+                parts = self._sub_socket.recv_multipart(flags=zmq.NOBLOCK)
+                if len(parts) == 2:
+                    name = parts[0].decode()
+                    if name in self._sub_topics:
+                        t = self._sub_topics[name]
+                        arr = np.frombuffer(parts[1], dtype=t.dtype).reshape(t.shape).copy()
+                        with self._cache_lock:
+                            self._cache[name] = arr
+            except zmq.Again:
+                pass
+
+    def supports(self, topic: Topic) -> bool:
+        return topic.name in self._pub_topics or topic.name in self._sub_topics
+
+    def write(self, topic: Topic, data: np.ndarray) -> None:
+        if self._pub_socket is None:
+            raise RuntimeError(f"No PUB socket configured for topic '{topic.name}'")
+        self._pub_socket.send_multipart([
+            topic.name.encode(),
+            np.asarray(data, dtype=topic.dtype).tobytes(),
+        ])
+
+    def read(self, topic: Topic) -> np.ndarray:
+        with self._cache_lock:
+            return self._cache[topic.name].copy()
+
+    def close(self) -> None:
+        self._running = False
+        if self._pub_socket:
+            self._pub_socket.close(linger=0)
+        if self._sub_socket:
+            self._sub_socket.close(linger=0)

--- a/synapsys/broker/broker.py
+++ b/synapsys/broker/broker.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable
+
+import numpy as np
+
+from .backends.base import BrokerBackend
+from .topic import Topic, TopicRegistry
+
+SubscriberCallback = Callable[[str, np.ndarray], None]
+
+
+class MessageBroker:
+    """
+    Central Mediator routing numpy arrays between agents via typed topics.
+
+    Agents declare topics, publish data by name, and read the latest value
+    (polling / ZOH). Push-model subscribers are notified synchronously inside
+    publish() — callbacks must be fast to avoid stalling the publisher.
+
+    Multiple BrokerBackend instances can coexist; the first backend that
+    supports a topic handles it.
+    """
+
+    def __init__(self) -> None:
+        self._registry = TopicRegistry()
+        self._backends: list[BrokerBackend] = []
+        self._subscriptions: dict[str, list[SubscriberCallback]] = {}
+        self._lock = threading.Lock()
+
+    # ── Configuration ─────────────────────────────────────────────────────────
+
+    def declare_topic(self, topic: Topic) -> None:
+        self._registry.register(topic)
+        with self._lock:
+            self._subscriptions.setdefault(topic.name, [])
+
+    def add_backend(self, backend: BrokerBackend) -> None:
+        with self._lock:
+            self._backends.append(backend)
+
+    # ── Pub/Sub API ───────────────────────────────────────────────────────────
+
+    def publish(self, topic_name: str, data: np.ndarray) -> None:
+        topic = self._registry.get(topic_name)
+        validated = topic.validate(data)
+        self._backend_for(topic).write(topic, validated)
+        with self._lock:
+            callbacks = list(self._subscriptions.get(topic_name, []))
+        for cb in callbacks:
+            cb(topic_name, validated.copy())
+
+    def read(self, topic_name: str) -> np.ndarray:
+        topic = self._registry.get(topic_name)
+        return self._backend_for(topic).read(topic)
+
+    def subscribe(self, topic_name: str, callback: SubscriberCallback) -> None:
+        self._registry.get(topic_name)
+        with self._lock:
+            self._subscriptions[topic_name].append(callback)
+
+    def unsubscribe(self, topic_name: str, callback: SubscriberCallback) -> None:
+        with self._lock:
+            self._subscriptions[topic_name].remove(callback)
+
+    def read_wait(self, topic_name: str, timeout: float = 1.0) -> np.ndarray:
+        """Block until a new publish() on topic_name or timeout, then return value."""
+        event = threading.Event()
+        result: list[np.ndarray] = []
+
+        def _on_publish(name: str, data: np.ndarray) -> None:
+            result.append(data)
+            event.set()
+
+        self.subscribe(topic_name, _on_publish)
+        event.wait(timeout=timeout)
+        self.unsubscribe(topic_name, _on_publish)
+        return result[0] if result else self.read(topic_name)
+
+    # ── Lifecycle ─────────────────────────────────────────────────────────────
+
+    def close(self) -> None:
+        with self._lock:
+            for backend in self._backends:
+                backend.close()
+
+    def __enter__(self) -> MessageBroker:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()
+
+    # ── Internal ──────────────────────────────────────────────────────────────
+
+    def _backend_for(self, topic: Topic) -> BrokerBackend:
+        with self._lock:
+            for backend in self._backends:
+                if backend.supports(topic):
+                    return backend
+        raise RuntimeError(
+            f"No backend registered for topic '{topic.name}'. "
+            "Call broker.add_backend() with a backend that supports this topic."
+        )

--- a/synapsys/broker/topic.py
+++ b/synapsys/broker/topic.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class Topic:
+    """Named, typed channel descriptor used by MessageBroker."""
+
+    name: str
+    shape: tuple[int, ...]
+    dtype: np.dtype = field(default_factory=lambda: np.dtype(np.float64))
+
+    @property
+    def size(self) -> int:
+        result = 1
+        for d in self.shape:
+            result *= d
+        return result
+
+    def validate(self, data: np.ndarray) -> np.ndarray:
+        arr = np.asarray(data, dtype=self.dtype).reshape(self.shape)
+        return np.ascontiguousarray(arr)
+
+
+class TopicRegistry:
+    def __init__(self) -> None:
+        self._topics: dict[str, Topic] = {}
+
+    def register(self, topic: Topic) -> None:
+        if topic.name in self._topics:
+            existing = self._topics[topic.name]
+            if existing != topic:
+                raise ValueError(
+                    f"Topic '{topic.name}' already registered with different schema "
+                    f"(existing shape={existing.shape}, new shape={topic.shape})"
+                )
+            return
+        self._topics[topic.name] = topic
+
+    def get(self, name: str) -> Topic:
+        try:
+            return self._topics[name]
+        except KeyError:
+            raise KeyError(f"Topic '{name}' not registered. Call broker.declare_topic() first.")
+
+    @property
+    def all(self) -> dict[str, Topic]:
+        return dict(self._topics)

--- a/tests/broker/test_broker.py
+++ b/tests/broker/test_broker.py
@@ -1,0 +1,131 @@
+import numpy as np
+import pytest
+
+from synapsys.broker.topic import Topic
+from synapsys.broker.broker import MessageBroker
+from synapsys.broker.backends.base import BrokerBackend
+
+
+class InMemoryBackend(BrokerBackend):
+    """Simple in-memory backend for testing."""
+
+    def __init__(self, topics: list[Topic]) -> None:
+        self._store: dict[str, np.ndarray] = {
+            t.name: np.zeros(t.shape) for t in topics
+        }
+        self._topic_map = {t.name: t for t in topics}
+
+    def supports(self, topic: Topic) -> bool:
+        return topic.name in self._topic_map
+
+    def write(self, topic: Topic, data: np.ndarray) -> None:
+        self._store[topic.name] = data.copy()
+
+    def read(self, topic: Topic) -> np.ndarray:
+        return self._store[topic.name].copy()
+
+    def close(self) -> None:
+        pass
+
+
+@pytest.fixture
+def topic_y():
+    return Topic("plant/y", shape=(1,))
+
+
+@pytest.fixture
+def topic_u():
+    return Topic("plant/u", shape=(1,))
+
+
+@pytest.fixture
+def broker(topic_y, topic_u):
+    b = MessageBroker()
+    b.declare_topic(topic_y)
+    b.declare_topic(topic_u)
+    backend = InMemoryBackend([topic_y, topic_u])
+    b.add_backend(backend)
+    return b
+
+
+class TestMessageBroker:
+    def test_publish_and_read_roundtrip(self, broker):
+        broker.publish("plant/y", np.array([7.5]))
+        result = broker.read("plant/y")
+        np.testing.assert_allclose(result, [7.5])
+
+    def test_read_before_publish_returns_zeros(self, broker):
+        result = broker.read("plant/u")
+        np.testing.assert_allclose(result, [0.0])
+
+    def test_publish_validates_shape(self, broker):
+        with pytest.raises(ValueError):
+            broker.publish("plant/y", np.array([1.0, 2.0]))
+
+    def test_read_undeclared_topic_raises(self, broker):
+        with pytest.raises(KeyError):
+            broker.read("nonexistent/topic")
+
+    def test_publish_undeclared_topic_raises(self, broker):
+        with pytest.raises(KeyError):
+            broker.publish("nonexistent/topic", np.array([1.0]))
+
+    def test_no_backend_for_topic_raises(self):
+        b = MessageBroker()
+        topic = Topic("orphan", shape=(1,))
+        b.declare_topic(topic)
+        with pytest.raises(RuntimeError, match="No backend"):
+            b.publish("orphan", np.array([1.0]))
+
+    def test_subscribe_callback_called_on_publish(self, broker):
+        received = []
+        broker.subscribe("plant/y", lambda name, data: received.append(data.copy()))
+        broker.publish("plant/y", np.array([3.0]))
+        assert len(received) == 1
+        np.testing.assert_allclose(received[0], [3.0])
+
+    def test_multiple_subscribers_all_notified(self, broker):
+        calls = []
+        broker.subscribe("plant/y", lambda n, d: calls.append("cb1"))
+        broker.subscribe("plant/y", lambda n, d: calls.append("cb2"))
+        broker.publish("plant/y", np.array([1.0]))
+        assert calls == ["cb1", "cb2"]
+
+    def test_unsubscribe_stops_notifications(self, broker):
+        calls = []
+
+        def cb(name, data):
+            calls.append(data.copy())
+
+        broker.subscribe("plant/y", cb)
+        broker.publish("plant/y", np.array([1.0]))
+        broker.unsubscribe("plant/y", cb)
+        broker.publish("plant/y", np.array([2.0]))
+        assert len(calls) == 1
+
+    def test_context_manager_closes_cleanly(self, topic_y):
+        b = MessageBroker()
+        b.declare_topic(topic_y)
+        backend = InMemoryBackend([topic_y])
+        b.add_backend(backend)
+        with b:
+            b.publish("plant/y", np.array([1.0]))
+
+    def test_read_wait_unblocks_when_publish_arrives(self, broker):
+        import threading
+
+        def publish_later():
+            import time
+            time.sleep(0.05)
+            broker.publish("plant/y", np.array([42.0]))
+
+        t = threading.Thread(target=publish_later)
+        t.start()
+        result = broker.read_wait("plant/y", timeout=1.0)
+        t.join()
+        np.testing.assert_allclose(result, [42.0])
+
+    def test_read_wait_returns_cached_on_timeout(self, broker):
+        broker.publish("plant/y", np.array([5.0]))
+        result = broker.read_wait("plant/y", timeout=0.01)
+        np.testing.assert_allclose(result, [5.0])

--- a/tests/broker/test_integration.py
+++ b/tests/broker/test_integration.py
@@ -1,0 +1,133 @@
+"""
+Integration tests: agents wired through MessageBroker.
+
+Scenario A: PlantAgent + ControllerAgent converge (broker replaces transport).
+Scenario B: 3-agent — ReconfigAgent publishes new gains; ControllerAgent reacts.
+"""
+import time
+
+import numpy as np
+import pytest
+
+from synapsys.api import ss, c2d
+from synapsys.agents import ControllerAgent, PlantAgent, SyncEngine, SyncMode
+from synapsys.agents.lifecycle import BaseAgent
+from synapsys.algorithms import PID
+from synapsys.broker.backends.shared_memory import SharedMemoryBackend
+from synapsys.broker.broker import MessageBroker
+from synapsys.broker.topic import Topic
+
+
+def _build_broker(bus_name: str, topics: list[Topic]) -> MessageBroker:
+    broker = MessageBroker()
+    for t in topics:
+        broker.declare_topic(t)
+    backend = SharedMemoryBackend(bus_name, topics, create=True)
+    broker.add_backend(backend)
+    return broker
+
+
+# ── Scenario A ────────────────────────────────────────────────────────────────
+
+class TestBrokerConvergence:
+    """Plant+Controller via broker converges the same as via transport."""
+
+    def test_closed_loop_converges_to_setpoint(self):
+        plant_c = ss([[-1.0]], [[1.0]], [[1.0]], [[0.0]])
+        plant_d = c2d(plant_c, dt=0.05)
+
+        topic_y = Topic("A/y", shape=(1,))
+        topic_u = Topic("A/u", shape=(1,))
+        broker = _build_broker("broker_integ_A", [topic_y, topic_u])
+
+        setpoint = 3.0
+        pid = PID(Kp=4.0, Ki=1.0, dt=0.05)
+        law = lambda y: np.array([pid.compute(setpoint=setpoint, measurement=y[0])])
+
+        broker.publish("A/y", np.zeros(1))
+        broker.publish("A/u", np.zeros(1))
+
+        sync_p = SyncEngine(SyncMode.LOCK_STEP, dt=0.05)
+        sync_c = SyncEngine(SyncMode.LOCK_STEP, dt=0.05)
+
+        plant = PlantAgent("plant", plant_d, None, sync_p,
+                           channel_y="A/y", channel_u="A/u", broker=broker)
+        ctrl = ControllerAgent("ctrl", law, None, sync_c,
+                               channel_y="A/y", channel_u="A/u", broker=broker)
+
+        plant.setup()
+        for _ in range(400):
+            ctrl.step()
+            plant.step()
+
+        y_final = broker.read("A/y")[0]
+        assert abs(y_final - setpoint) < 0.15, f"Did not converge: y={y_final}"
+        broker.close()
+
+
+# ── Scenario B ────────────────────────────────────────────────────────────────
+
+class _ReconfigAgent(BaseAgent):
+    """Publishes new PID setpoint after a configurable delay."""
+
+    def __init__(self, broker: MessageBroker, delay_steps: int):
+        sync = SyncEngine(SyncMode.LOCK_STEP, dt=0.05)
+        super().__init__("reconfig", None, sync, broker=broker)
+        self._delay = delay_steps
+        self._k = 0
+        self.published = False
+
+    def setup(self) -> None:
+        pass
+
+    def step(self) -> None:
+        self._k += 1
+        if self._k == self._delay:
+            self._write("ctrl/config", np.array([10.0]))  # new setpoint
+            self.published = True
+
+    def teardown(self) -> None:
+        pass
+
+
+class TestThreeAgentReconfig:
+    """ReconfigAgent changes setpoint; ControllerAgent adapts."""
+
+    def test_reconfig_agent_changes_setpoint_mid_simulation(self):
+        plant_c = ss([[-1.0]], [[1.0]], [[1.0]], [[0.0]])
+        plant_d = c2d(plant_c, dt=0.05)
+
+        topic_y = Topic("B/y", shape=(1,))
+        topic_u = Topic("B/u", shape=(1,))
+        topic_cfg = Topic("ctrl/config", shape=(1,))
+        broker = _build_broker("broker_integ_B", [topic_y, topic_u, topic_cfg])
+
+        broker.publish("B/y", np.zeros(1))
+        broker.publish("B/u", np.zeros(1))
+        broker.publish("ctrl/config", np.array([3.0]))  # initial setpoint
+
+        pid = PID(Kp=4.0, Ki=1.0, dt=0.05)
+
+        def law(y: np.ndarray) -> np.ndarray:
+            cfg = broker.read("ctrl/config")
+            return np.array([pid.compute(setpoint=cfg[0], measurement=y[0])])
+
+        sync_p = SyncEngine(SyncMode.LOCK_STEP, dt=0.05)
+        sync_c = SyncEngine(SyncMode.LOCK_STEP, dt=0.05)
+
+        plant = PlantAgent("plant", plant_d, None, sync_p,
+                           channel_y="B/y", channel_u="B/u", broker=broker)
+        ctrl = ControllerAgent("ctrl", law, None, sync_c,
+                               channel_y="B/y", channel_u="B/u", broker=broker)
+        reconfig = _ReconfigAgent(broker, delay_steps=100)
+
+        for _ in range(200):
+            reconfig.step()
+            ctrl.step()
+            plant.step()
+
+        assert reconfig.published, "ReconfigAgent never published"
+
+        y_final = broker.read("B/y")[0]
+        assert abs(y_final - 10.0) < 0.5, f"Did not converge to new setpoint: y={y_final}"
+        broker.close()

--- a/tests/broker/test_shared_memory_backend.py
+++ b/tests/broker/test_shared_memory_backend.py
@@ -1,0 +1,60 @@
+import numpy as np
+import pytest
+
+from synapsys.broker.topic import Topic
+from synapsys.broker.backends.shared_memory import SharedMemoryBackend
+
+
+@pytest.fixture
+def topics():
+    return [
+        Topic("plant/y", shape=(1,)),
+        Topic("plant/u", shape=(1,)),
+    ]
+
+
+@pytest.fixture
+def backend(topics):
+    b = SharedMemoryBackend("test_broker_shm", topics, create=True)
+    yield b
+    b.close()
+
+
+class TestSharedMemoryBackend:
+    def test_write_and_read_roundtrip(self, backend, topics):
+        t = topics[0]
+        backend.write(t, np.array([3.14]))
+        result = backend.read(t)
+        np.testing.assert_allclose(result, [3.14])
+
+    def test_read_returns_correct_shape(self, backend, topics):
+        t = topics[0]
+        backend.write(t, np.array([1.0]))
+        result = backend.read(t)
+        assert result.shape == (1,)
+
+    def test_multidimensional_topic_roundtrip(self):
+        topic = Topic("matrix", shape=(2, 2))
+        b = SharedMemoryBackend("test_broker_shm_2d", [topic], create=True)
+        try:
+            data = np.array([[1.0, 2.0], [3.0, 4.0]])
+            b.write(topic, data)
+            result = b.read(topic)
+            assert result.shape == (2, 2)
+            np.testing.assert_allclose(result, data)
+        finally:
+            b.close()
+
+    def test_supports_registered_topic(self, backend, topics):
+        assert backend.supports(topics[0]) is True
+
+    def test_does_not_support_unknown_topic(self, backend):
+        unknown = Topic("unknown/topic", shape=(5,))
+        assert backend.supports(unknown) is False
+
+    def test_write_multiple_channels_independently(self, backend, topics):
+        t_y, t_u = topics[0], topics[1]
+        backend.write(t_y, np.array([1.0]))
+        backend.write(t_u, np.array([9.0]))
+        np.testing.assert_allclose(backend.read(t_y), [1.0])
+        np.testing.assert_allclose(backend.read(t_u), [9.0])

--- a/tests/broker/test_topic.py
+++ b/tests/broker/test_topic.py
@@ -1,0 +1,72 @@
+import numpy as np
+import pytest
+
+from synapsys.broker.topic import Topic, TopicRegistry
+
+
+class TestTopic:
+    def test_validate_correct_shape_returns_contiguous_array(self):
+        topic = Topic("plant/y", shape=(3,))
+        data = np.array([1.0, 2.0, 3.0])
+        result = topic.validate(data)
+        assert result.shape == (3,)
+        assert result.flags["C_CONTIGUOUS"]
+
+    def test_validate_wrong_shape_raises(self):
+        topic = Topic("plant/y", shape=(3,))
+        with pytest.raises(ValueError):
+            topic.validate(np.array([1.0, 2.0]))
+
+    def test_validate_coerces_dtype(self):
+        topic = Topic("plant/y", shape=(2,))
+        result = topic.validate(np.array([1, 2], dtype=np.int32))
+        assert result.dtype == np.float64
+
+    def test_size_1d(self):
+        assert Topic("t", shape=(4,)).size == 4
+
+    def test_size_2d(self):
+        assert Topic("t", shape=(2, 3)).size == 6
+
+    def test_topic_is_hashable(self):
+        t = Topic("plant/y", shape=(1,))
+        assert hash(t) is not None
+        d = {t: "value"}
+        assert d[t] == "value"
+
+    def test_equal_topics_are_equal(self):
+        assert Topic("a", shape=(2,)) == Topic("a", shape=(2,))
+
+    def test_different_shape_topics_not_equal(self):
+        assert Topic("a", shape=(2,)) != Topic("a", shape=(3,))
+
+
+class TestTopicRegistry:
+    def test_register_and_get(self):
+        reg = TopicRegistry()
+        t = Topic("plant/y", shape=(1,))
+        reg.register(t)
+        assert reg.get("plant/y") is t
+
+    def test_get_unknown_raises(self):
+        reg = TopicRegistry()
+        with pytest.raises(KeyError):
+            reg.get("nonexistent")
+
+    def test_register_same_topic_twice_is_idempotent(self):
+        reg = TopicRegistry()
+        t = Topic("plant/y", shape=(1,))
+        reg.register(t)
+        reg.register(t)  # should not raise
+
+    def test_register_duplicate_name_different_schema_raises(self):
+        reg = TopicRegistry()
+        reg.register(Topic("plant/y", shape=(1,)))
+        with pytest.raises(ValueError, match="already registered"):
+            reg.register(Topic("plant/y", shape=(2,)))
+
+    def test_all_returns_copy(self):
+        reg = TopicRegistry()
+        reg.register(Topic("a", shape=(1,)))
+        reg.register(Topic("b", shape=(2,)))
+        assert set(reg.all.keys()) == {"a", "b"}

--- a/tests/broker/test_zmq_backend.py
+++ b/tests/broker/test_zmq_backend.py
@@ -1,0 +1,58 @@
+import time
+
+import numpy as np
+import pytest
+
+from synapsys.broker.topic import Topic
+from synapsys.broker.backends.zmq import ZMQBrokerBackend
+
+ADDR = "tcp://127.0.0.1:15779"
+
+
+@pytest.fixture
+def topics():
+    return [Topic("sensor/x", shape=(2,))]
+
+
+class TestZMQBrokerBackend:
+    def test_read_before_publish_returns_zeros(self, topics):
+        sub = ZMQBrokerBackend(ADDR, subscribe_topics=topics)
+        try:
+            result = sub.read(topics[0])
+            np.testing.assert_allclose(result, np.zeros((2,)))
+        finally:
+            sub.close()
+
+    def test_publish_subscribe_cache_update(self, topics):
+        pub = ZMQBrokerBackend(ADDR, publish_topics=topics)
+        sub = ZMQBrokerBackend(ADDR, subscribe_topics=topics)
+        try:
+            time.sleep(0.05)  # allow ZMQ slow-joiner to settle
+            pub.write(topics[0], np.array([1.5, 2.5]))
+            time.sleep(0.05)  # allow recv thread to pick up message
+            result = sub.read(topics[0])
+            np.testing.assert_allclose(result, [1.5, 2.5])
+        finally:
+            pub.close()
+            sub.close()
+
+    def test_supports_registered_topic(self, topics):
+        b = ZMQBrokerBackend(ADDR, publish_topics=topics)
+        try:
+            assert b.supports(topics[0]) is True
+        finally:
+            b.close()
+
+    def test_does_not_support_unknown_topic(self, topics):
+        b = ZMQBrokerBackend(ADDR, publish_topics=topics)
+        try:
+            assert b.supports(Topic("unknown", shape=(1,))) is False
+        finally:
+            b.close()
+
+    def test_close_stops_recv_thread(self, topics):
+        b = ZMQBrokerBackend(ADDR, subscribe_topics=topics)
+        b.close()
+        if b._recv_thread is not None:
+            b._recv_thread.join(timeout=1.0)
+            assert not b._recv_thread.is_alive()

--- a/uv.lock
+++ b/uv.lock
@@ -733,6 +733,23 @@ wheels = [
 ]
 
 [[package]]
+name = "cyclopts"
+version = "4.10.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "docstring-parser" },
+    { name = "rich" },
+    { name = "rich-rst" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/2c/fced34890f6e5a93a4b7afb2c71e8eee2a0719fb26193a0abf159ecb714d/cyclopts-4.10.2.tar.gz", hash = "sha256:d7b950457ef2563596d56331f80cbbbf86a2772535fb8b315c4f03bc7e6127f1", size = 166664, upload-time = "2026-04-08T23:57:45.805Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/bd/05055d8360cef0757d79367157f3b15c0a0715e81e08f86a04018ec045f0/cyclopts-4.10.2-py3-none-any.whl", hash = "sha256:a1f2d6f8f7afac9456b48f75a40b36658778ddc9c6d406b520d017ae32c990fe", size = 204314, upload-time = "2026-04-08T23:57:46.969Z" },
+]
+
+[[package]]
 name = "debugpy"
 version = "1.8.20"
 source = { registry = "https://pypi.org/simple" }
@@ -777,6 +794,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
+name = "docutils"
+version = "0.22.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
 ]
 
 [[package]]
@@ -1594,6 +1629,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1763,6 +1810,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c7/74/97e72a36efd4ae2bccb3463284300f8953f199b5ffbc04cbbb0ec78f74b1/matplotlib_inline-0.2.1.tar.gz", hash = "sha256:e1ee949c340d771fc39e241ea75683deb94762c8fa5f2927ec57c83c4dffa9fe", size = 8110, upload-time = "2025-10-23T09:00:22.126Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/af/33/ee4519fa02ed11a94aef9559552f3b17bb863f2ecfe1a35dc7f548cde231/matplotlib_inline-0.2.1-py3-none-any.whl", hash = "sha256:d56ce5156ba6085e00a9d54fead6ed29a9c47e215cd1bba2e976ef39f5710a76", size = 9516, upload-time = "2025-10-23T09:00:20.675Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -2443,6 +2499,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pooch"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "platformdirs" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/43/85ef45e8b36c6a48546af7b266592dc32d7f67837a6514d111bced6d7d75/pooch-1.9.0.tar.gz", hash = "sha256:de46729579b9857ffd3e741987a2f6d5e0e03219892c167c6578c0091fb511ed", size = 61788, upload-time = "2026-01-30T19:15:09.649Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/2d/d4bf65e47cea8ff2c794a600c4fd1273a7902f268757c531e0ee9f18aa58/pooch-1.9.0-py3-none-any.whl", hash = "sha256:f265597baa9f760d25ceb29d0beb8186c243d6607b0f60b83ecf14078dbc703b", size = 67175, upload-time = "2026-01-30T19:15:08.36Z" },
+]
+
+[[package]]
 name = "prometheus-client"
 version = "0.25.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2587,6 +2657,26 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f7/ff/3cc9165fd44106973cd7ac9facb674a65ed853494592541d339bdc9a30eb/python_json_logger-4.1.0.tar.gz", hash = "sha256:b396b9e3ed782b09ff9d6e4f1683d46c83ad0d35d2e407c09a9ebbf038f88195", size = 17573, upload-time = "2026-03-29T04:39:56.805Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/27/be/0631a861af4d1c875f096c07d34e9a63639560a717130e7a87cbc82b7e3f/python_json_logger-4.1.0-py3-none-any.whl", hash = "sha256:132994765cf75bf44554be9aa49b06ef2345d23661a96720262716438141b6b2", size = 15021, upload-time = "2026-03-29T04:39:55.266Z" },
+]
+
+[[package]]
+name = "pyvista"
+version = "0.47.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cyclopts" },
+    { name = "matplotlib" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pillow" },
+    { name = "pooch" },
+    { name = "scooby" },
+    { name = "typing-extensions" },
+    { name = "vtk" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/36/512c05b1cd431150d47479d1397013915eaf5c6d3f728eada53a601871b8/pyvista-0.47.3.tar.gz", hash = "sha256:03ce3923b42053cf8c9c151ea385431474f11b286d31fe9513cf5b7bf29fe848", size = 2463344, upload-time = "2026-04-10T17:47:07.39Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/33/f2775b3c7ee908bdd96c665cb1d6658a02d123dea33b9ee861e7d56ad2ae/pyvista-0.47.3-py3-none-any.whl", hash = "sha256:8db0dd77c744d2673a1b34333694cb4e8828a9193bbe2c0a8b3ceb9bfc12dd0f", size = 2508590, upload-time = "2026-04-10T17:47:05.532Z" },
 ]
 
 [[package]]
@@ -2808,6 +2898,32 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2c/06/37c1a5557acf449e8e406a830a05bf885ac47d33270aec454ef78675008d/rfc3987_syntax-1.1.0.tar.gz", hash = "sha256:717a62cbf33cffdd16dfa3a497d81ce48a660ea691b1ddd7be710c22f00b4a0d", size = 14239, upload-time = "2025-07-18T01:05:05.015Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/71/44ce230e1b7fadd372515a97e32a83011f906ddded8d03e3c6aafbdedbb7/rfc3987_syntax-1.1.0-py3-none-any.whl", hash = "sha256:6c3d97604e4c5ce9f714898e05401a0445a641cfa276432b0a648c80856f6a3f", size = 8046, upload-time = "2025-07-18T01:05:03.843Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "rich-rst"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/6d/a506aaa4a9eaa945ed8ab2b7347859f53593864289853c5d6d62b77246e0/rich_rst-1.3.2.tar.gz", hash = "sha256:a1196fdddf1e364b02ec68a05e8ff8f6914fee10fbca2e6b6735f166bb0da8d4", size = 14936, upload-time = "2025-10-14T16:49:45.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/2f/b4530fbf948867702d0a3f27de4a6aab1d156f406d72852ab902c4d04de9/rich_rst-1.3.2-py3-none-any.whl", hash = "sha256:a99b4907cbe118cf9d18b0b44de272efa61f15117c61e39ebdc431baf5df722a", size = 12567, upload-time = "2025-10-14T16:49:42.953Z" },
 ]
 
 [[package]]
@@ -3093,6 +3209,15 @@ wheels = [
 ]
 
 [[package]]
+name = "scooby"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/d1/a28f3be1503a9c474a4878424bbeb93a55a2ec7d0cb66559aa258e690aea/scooby-0.11.0.tar.gz", hash = "sha256:3dfacc6becf2d6558efa4b625bae3b844ced5d256f3143ebf774e005367e712a", size = 22102, upload-time = "2025-11-01T19:22:53.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/bb/bbae36d06c0fd670e8373da67096cd57058b57c9bad7d92969b5e3b730af/scooby-0.11.0-py3-none-any.whl", hash = "sha256:a79663d1a7711eb104e4b2935988ea1ed5f7be6b7288fad23b4fba7462832f9d", size = 19877, upload-time = "2025-11-01T19:22:53.046Z" },
+]
+
+[[package]]
 name = "send2trash"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3156,7 +3281,7 @@ wheels = [
 
 [[package]]
 name = "synapsys"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -3178,6 +3303,9 @@ dev = [
     { name = "ruff" },
     { name = "torch" },
 ]
+viz = [
+    { name = "pyvista" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -3189,12 +3317,13 @@ requires-dist = [
     { name = "numpy", specifier = ">=1.24" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
+    { name = "pyvista", marker = "extra == 'viz'", specifier = ">=0.43" },
     { name = "pyzmq", specifier = ">=25.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1" },
     { name = "scipy", specifier = ">=1.10" },
     { name = "torch", marker = "extra == 'dev'", specifier = ">=2.0" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["viz", "dev"]
 
 [[package]]
 name = "terminado"
@@ -3409,6 +3538,43 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "vtk"
+version = "9.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "matplotlib" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/96/2d5b00082972749502733f67cc12b87e9fd119bb09e23d980313a8fa5de8/vtk-9.6.1-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:43e9dbb046a18e81b0d434dfeccf58085e4249c281171bc4ee8c1aea687d6a1e", size = 114551525, upload-time = "2026-03-26T23:34:04.649Z" },
+    { url = "https://files.pythonhosted.org/packages/78/93/28fa69a8577779b8db1645a723a055ac25fcd01ea7c699283eef582ded3f/vtk-9.6.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:feebb3e0ddb8d5fd6e42abddbf1f55e5b7a9e9d9c265175d81d44bdafa8a41c1", size = 106761625, upload-time = "2026-03-26T23:34:09.219Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/70/b8219d1613d24133d1d6bd7ab1e7a3a8ff5cdb0283653a0bf2ffe2966fac/vtk-9.6.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d88c70f82716a40a67d9d151c93414458da8ba376ad493a2d1d58ea2de8a74c7", size = 145873736, upload-time = "2026-03-26T23:34:13.742Z" },
+    { url = "https://files.pythonhosted.org/packages/96/cc/0debcae27170fb20a3af92c536c60e3aa206d747a86c16b0b510028ca690/vtk-9.6.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:00120e937967c584ac6d5aae6c460b8e6a4df0d33ffcf64c0e7683feaf082a78", size = 135625431, upload-time = "2026-03-26T23:34:19.167Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/f5/e87bf4c9bfe54e6ce61fd733840bb71e33262e1d4fc0a12dea3a15abdf64/vtk-9.6.1-cp310-cp310-win_amd64.whl", hash = "sha256:bd999531a7007a24b5af8da2c763f4b7c6d6c235671832be2175b0a79db8b5cb", size = 81247078, upload-time = "2026-03-26T23:34:24.544Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/70/8a68245293652aeba3448230ef30b90ab7aaa199fc158e7af8c4de66edf3/vtk-9.6.1-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:a2945c0320b5df8f697d49f7d759b2c230ac293188158574526c20bbcaf10241", size = 114551474, upload-time = "2026-03-26T23:34:29.585Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/4d/cdc2b1eb0ea3e322dc707a08e3d145ed556d897eb10385a923cbc932edc0/vtk-9.6.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b49b3c36e599f652077e60ead865957a65b557a1b53bcd60b26bdaabb81d170d", size = 106761418, upload-time = "2026-03-26T23:34:34.064Z" },
+    { url = "https://files.pythonhosted.org/packages/72/92/5c9b9cdfe2738cc7b0dd51adacae67456ef53fcedae16b21a2cf9fbbd767/vtk-9.6.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3b3537cae99226f3082d3aeef2350b7329ee3cef7e7bd88d4ecacfcbfdadfaeb", size = 145873720, upload-time = "2026-03-26T23:34:39.925Z" },
+    { url = "https://files.pythonhosted.org/packages/82/04/029bbc011f2346719e770e0ac961ff419948817a16fcda1249fe17a13525/vtk-9.6.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:30a21c6810d2465dc34dd5987f9fb566dcb8d4e65e06367d10a018c24eea6747", size = 135625426, upload-time = "2026-03-27T13:48:20.901Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/4f/bb831b2c46d63db2e6bfa11dcd8b405d526ed376390af66a27f6949749cf/vtk-9.6.1-cp311-cp311-win_amd64.whl", hash = "sha256:dde3627b9d33b75efebe2465183cbc682a9f9a7c1529cf027a8871e60e11b3b2", size = 81247644, upload-time = "2026-03-27T13:49:52.1Z" },
+    { url = "https://files.pythonhosted.org/packages/95/89/c274101ec7b9bf7356333fdacf5e634803fe6b40f776e82c6ce9d941e0ad/vtk-9.6.1-cp312-cp312-macosx_10_10_x86_64.whl", hash = "sha256:b8125e3e3bc3160e18853a15be98101d0efe662c16036179ab15ddf1669b32af", size = 114729308, upload-time = "2026-03-27T13:50:37.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1a/ecbebaf31724a00f85fc4dbf95992b507328f615362ee8fa5ea1a38cf9d6/vtk-9.6.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:956d05b8c53c6a9eba569de244e9c8229815bbb3e024bb9954fafe163407e66d", size = 106814956, upload-time = "2026-03-27T13:51:24.324Z" },
+    { url = "https://files.pythonhosted.org/packages/46/66/ba3c8b277cfa8058e982bfbd47875d9c6b4c06e65f98d577c69a2628f8d4/vtk-9.6.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9728e8d41889a0f105b5d20a73a4da80f398b2cfe6057fa7a94cd61128c3ceb4", size = 145920093, upload-time = "2026-03-27T13:53:12.49Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/cb/0bbf91cd45a8d8f5453fe01cddf44c913db6316b3a2b15f41893ae0ca9ad/vtk-9.6.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:3b5ec2e56bd6165189aa2e6e896edda29460e63040f897e1a123a1592810266d", size = 135683842, upload-time = "2026-03-27T13:52:15.218Z" },
+    { url = "https://files.pythonhosted.org/packages/08/c0/653c94939498a3976157f054b830ade5c1da48ae288a23547f55fc25a262/vtk-9.6.1-cp312-cp312-win_amd64.whl", hash = "sha256:4022fda8af46636f74c3c1932c2365da13a1dc8779a6b1ea4b13dc5bbcdb729f", size = 81262921, upload-time = "2026-03-27T13:53:50.192Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/8d/16e597f86241772fe188bbdd86a74ce48eadd2dd9513e2410b4ea07f78aa/vtk-9.6.1-cp313-cp313-macosx_10_10_x86_64.whl", hash = "sha256:88983bce26f7665ac6e4fb7de16cf53b896140a1a6cadd942d3c13e7c74a8530", size = 114747320, upload-time = "2026-03-27T13:54:33.138Z" },
+    { url = "https://files.pythonhosted.org/packages/63/ca/8f0c19bded437423479d0d3ff0b7457cf6ef68def322666df867e6dacc0f/vtk-9.6.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:94ed369a54c6cfacea0b34f42d7d3ef41fa06c1aabfc75d93cabdc9047454293", size = 106817051, upload-time = "2026-03-27T13:55:21.903Z" },
+    { url = "https://files.pythonhosted.org/packages/82/22/c1d98e6e191481af1e5c82ae3fa750798d868aa442a76db027f6a7901b95/vtk-9.6.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:deeb86794cd42f922ea75711b9717e45841777624203727eb84595b709af1382", size = 145920554, upload-time = "2026-03-27T13:57:14.258Z" },
+    { url = "https://files.pythonhosted.org/packages/16/5d/658f60209de7b41b634178aee1f458bcad149aa2654d16bd023c09afd29c/vtk-9.6.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:fef8abc33168ad38b2622cf29048b7d5fe48a45789bf0a0421781f5cafa1e554", size = 135686060, upload-time = "2026-03-27T13:56:23.89Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/31/e4eb318901a8e736c936491e759ce03a1656792f728ae912db0e20997e9a/vtk-9.6.1-cp313-cp313-win_amd64.whl", hash = "sha256:a5db7b2ff8fc3f56b547c8b9b7bc117a869c902683c86ef5cd6197c087f66183", size = 81264861, upload-time = "2026-03-27T13:57:47.164Z" },
+    { url = "https://files.pythonhosted.org/packages/43/de/ad1ccb188681d51b5e5621f383afa0a1dd8711ff8f3dcba4ff950f758cbb/vtk-9.6.1-cp314-cp314-macosx_10_10_x86_64.whl", hash = "sha256:91257894723dfced8be264915d81ba418d08e5bbdb4873da0f12b02c1e21f244", size = 114382745, upload-time = "2026-03-27T13:58:30.592Z" },
+    { url = "https://files.pythonhosted.org/packages/59/21/7bb2bd61b4ae05db79e2f40df452a6dbcd3bb66c259fd2043aaf60bbe5b7/vtk-9.6.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e119721774418fba34e95852efaefe5ac4156a4a270362fef06894cdc1377b6e", size = 106826433, upload-time = "2026-03-27T13:59:22.109Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/e4/5317afdeaa4a66fe037e1fedcb6bde86b888b8227c89aba6c8ad2946e380/vtk-9.6.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:98df48bcd630a4ffa71ac09d6aebb69c628925902920419e3db838dc7f7ce0ed", size = 145936133, upload-time = "2026-03-27T14:01:19.29Z" },
+    { url = "https://files.pythonhosted.org/packages/67/7f/f1375aa3ef1835e39b4bea978da06d4985bc1407e3e91384dfaabf5e09d0/vtk-9.6.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:3ea3c3e466a4a9cd8fa7e5b64595215467a7936c9f0fd61ec3275954c122a79c", size = 135710278, upload-time = "2026-03-27T14:00:19.358Z" },
+    { url = "https://files.pythonhosted.org/packages/91/25/7ff877a0d4f3e848d994d3a774d5a8e4495681ed26c32eb9dbb2a86b50e5/vtk-9.6.1-cp314-cp314-win_amd64.whl", hash = "sha256:a05e12ab8c82e81b225feee5ca08fda5fff814520a11c2941cc866335d990e03", size = 83197720, upload-time = "2026-03-27T14:01:53.313Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/ae/f621aaed0a36c99ba3c1b2f2593386094222132a8396f21c616adffacaaf/vtk-9.6.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:043fb013a2669180180bd0ab667f318f2e1f14da69ae943192a7443f5ce3721a", size = 145557875, upload-time = "2026-03-27T14:03:45.531Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/d5/41edd3f8b38ad45b8fb30d12ef35be3d62e1221e455722a5d7d103ca2f0d/vtk-9.6.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:d08b3760cbd8bffdbb4551033c4c9d87afe30e9e9d4c0e5cad29cbe7107c9af7", size = 135524312, upload-time = "2026-03-27T14:02:46.035Z" },
 ]
 
 [[package]]

--- a/website/docs/api/agents.md
+++ b/website/docs/api/agents.md
@@ -61,6 +61,8 @@ Abstract base class. Subclass and override `setup()`, `step()`, and `teardown()`
 | `start(blocking=True)` | Starts the simulation loop in the **current thread** (`True`) or a background daemon thread (`False`) |
 | `stop()` | Signals the agent to stop after the current tick |
 
+Use `self._read(channel)` / `self._write(channel, data)` in subclasses — these helpers dispatch to either the `broker` or the legacy `transport`, whichever is set.
+
 ## PlantAgent
 
 Simulates a discrete `StateSpace` plant in real time.
@@ -69,11 +71,13 @@ Simulates a discrete `StateSpace` plant in real time.
 PlantAgent(
     name: str,
     plant: StateSpace,
-    transport: TransportStrategy,
+    transport: TransportStrategy | None,   # pass None when using broker
     sync: SyncEngine,
-    channel_y: str = "y",   # channel name for plant output
-    channel_u: str = "u",   # channel name for control input
+    channel_y: str = "y",
+    channel_u: str = "u",
     x0: np.ndarray | None = None,
+    *,
+    broker: MessageBroker | None = None,   # recommended
 )
 ```
 
@@ -85,16 +89,18 @@ Applies a control law in real time.
 ControllerAgent(
     name: str,
     control_law: Callable[[np.ndarray], np.ndarray],
-    transport: TransportStrategy,
+    transport: TransportStrategy | None,   # pass None when using broker
     sync: SyncEngine,
-    channel_y: str = "y",   # channel name to read measurements from
-    channel_u: str = "u",   # channel name to write control commands to
+    channel_y: str = "y",
+    channel_u: str = "u",
+    *,
+    broker: MessageBroker | None = None,   # recommended
 )
 ```
 
 ## HardwareAgent
 
-Bridges a physical (or mock) hardware device into the transport layer.
+Bridges a physical (or mock) hardware device into the broker layer.
 Replaces `PlantAgent` in a HIL (Hardware-in-the-Loop) setup — the real
 device becomes the plant.
 
@@ -102,27 +108,41 @@ device becomes the plant.
 HardwareAgent(
     name: str,
     hardware: HardwareInterface,
-    transport: TransportStrategy,
+    transport: TransportStrategy | None,   # pass None when using broker
     sync: SyncEngine,
-    channel_y: str = "y",      # channel to publish sensor measurements
-    channel_u: str = "u",      # channel to read actuator commands from
-    timeout_ms: float = 100.0, # per-call hardware I/O timeout
+    channel_y: str = "y",
+    channel_u: str = "u",
+    timeout_ms: float = 100.0,
+    *,
+    broker: MessageBroker | None = None,   # recommended
 )
 ```
 
-Each tick: reads `y` from hardware → writes `y` to transport → reads `u` from
-transport → writes `u` to hardware. On `TimeoutError`, the last known `y`/`u`
+Each tick: reads `y` from hardware → publishes `y` to broker → reads `u` from
+broker → writes `u` to hardware. On `TimeoutError`, the last known `y`/`u`
 are held (Zero-Order Hold) and a warning is logged.
 
 ```python
 from synapsys.hw import MockHardwareInterface
 from synapsys.agents import HardwareAgent, SyncEngine, SyncMode
-from synapsys.transport import SharedMemoryTransport
+from synapsys.broker import MessageBroker, Topic, SharedMemoryBackend
+
+topic_y = Topic("hw/y", shape=(1,))
+topic_u = Topic("hw/u", shape=(1,))
+
+broker = MessageBroker()
+broker.declare_topic(topic_y)
+broker.declare_topic(topic_u)
+broker.add_backend(SharedMemoryBackend("hil_bus", [topic_y, topic_u], create=True))
+broker.publish("hw/y", np.zeros(1))
+broker.publish("hw/u", np.zeros(1))
 
 hw    = MockHardwareInterface(n_inputs=1, n_outputs=1)
-bus   = SharedMemoryTransport("hil_bus", {"y": 1, "u": 1}, create=True)
 sync  = SyncEngine(SyncMode.WALL_CLOCK, dt=0.01)
-agent = HardwareAgent("hw_plant", hw, bus, sync)
+agent = HardwareAgent(
+    "hw_plant", hw, None, sync,
+    channel_y="hw/y", channel_u="hw/u", broker=broker,
+)
 
 with hw:
     agent.start(blocking=False)

--- a/website/docs/api/transport.md
+++ b/website/docs/api/transport.md
@@ -1,12 +1,119 @@
 ---
 id: transport
-title: synapsys.transport
+title: synapsys.broker / synapsys.transport
 sidebar_position: 5
+---
+
+# synapsys.broker
+
+Central pub/sub routing layer. **This is the recommended interface for all agent communication.**
+
+## Topic
+
+Typed, shaped, hashable signal descriptor. Frozen dataclass.
+
+```python
+Topic(
+    name: str,
+    shape: tuple[int, ...],
+    dtype: np.dtype = np.dtype(np.float64),
+)
+```
+
+| Property | Description |
+|---|---|
+| `name` | Hierarchical string identifier, e.g. `"plant/y"` |
+| `shape` | Expected array shape; validated on every `publish` |
+| `dtype` | NumPy dtype (default `float64`) |
+| `size` *(property)* | Total number of elements (product of `shape`) |
+
+## BrokerBackend (Abstract Base Class)
+
+Interface implemented by all backends.
+
+| Method | Description |
+|---|---|
+| `supports(topic: Topic) -> bool` | Returns `True` if this backend handles the given topic |
+| `write(topic: Topic, data: np.ndarray) -> None` | Writes validated data to the transport |
+| `read(topic: Topic) -> np.ndarray` | Reads data from the transport (ZOH — returns last value if no new data) |
+| `close() -> None` | Releases resources |
+
+Backends are context managers: `with backend: ...` calls `close()` on exit.
+
+## SharedMemoryBackend
+
+Zero-copy backend using OS shared memory. Best for agents on the same machine.
+
+```python
+SharedMemoryBackend(
+    name: str,
+    topics: list[Topic],
+    create: bool = False,
+)
+```
+
+| Parameter | Description |
+|---|---|
+| `name` | OS shared memory block identifier |
+| `topics` | Topics routed through this backend |
+| `create` | `True` for the owner process (allocates memory and calls `unlink()` on close) |
+
+Arrays are flattened on write and reshaped to `topic.shape` on read.
+
+## ZMQBrokerBackend
+
+Async PUB/SUB backend for cross-machine communication.
+
+```python
+ZMQBrokerBackend(
+    address: str,
+    topics: list[Topic],
+    mode: Literal["pub", "sub"],
+)
+```
+
+- In `"pub"` mode the socket **binds** to `address`.
+- In `"sub"` mode the socket **connects** to `address` and starts a background recv thread.
+- Reads are non-blocking (Zero-Order Hold cache).
+- `linger=0` on close — no blocking on teardown.
+
+## MessageBroker
+
+```python
+broker = MessageBroker()
+```
+
+| Method | Description |
+|---|---|
+| `declare_topic(topic: Topic)` | Registers a topic. Must be called before `publish` or `read`. |
+| `add_backend(backend: BrokerBackend)` | Attaches a backend. Topics are routed to the first matching backend. |
+| `publish(name: str, data: np.ndarray)` | Validates shape → writes to backend → fires callbacks. |
+| `read(name: str) -> np.ndarray` | Non-blocking read from backend (ZOH). |
+| `subscribe(name: str, callback)` | Registers a `Callable[[np.ndarray], None]` fired on every `publish`. |
+| `unsubscribe(name: str, callback)` | Removes a previously registered callback. |
+| `read_wait(name: str, timeout: float = 1.0) -> np.ndarray` | Blocks until new data arrives or `timeout` seconds elapse. |
+| `close()` | Closes all registered backends. |
+
+```python
+from synapsys.broker import MessageBroker, Topic, SharedMemoryBackend
+import numpy as np
+
+topic_y = Topic("plant/y", shape=(1,))
+topic_u = Topic("plant/u", shape=(1,))
+
+broker = MessageBroker()
+broker.declare_topic(topic_y)
+broker.declare_topic(topic_u)
+broker.add_backend(SharedMemoryBackend("ctrl_bus", [topic_y, topic_u], create=True))
+broker.publish("plant/y", np.zeros(1))
+broker.publish("plant/u", np.zeros(1))
+```
+
 ---
 
 # synapsys.transport
 
-Transport strategy implementations for inter-process communication.
+Low-level transport strategy implementations. Use these directly only when you need custom integrations or are building a new `BrokerBackend`.
 
 ## TransportStrategy (Abstract Base Class)
 
@@ -20,7 +127,7 @@ All transports implement this interface:
 
 ## SharedMemoryTransport
 
-Zero-copy transport using OS shared memory. Best for processes on the same machine.
+Zero-copy transport using OS shared memory.
 
 ```python
 SharedMemoryTransport(
@@ -62,4 +169,4 @@ Server must call `read()` before `write()`. Client must call `write()` before `r
 
 ## Source
 
-See [`synapsys/transport/`](https://github.com/synapsys-lab/synapsys/tree/main/synapsys/transport) on GitHub.
+See [`synapsys/broker/`](https://github.com/synapsys-lab/synapsys/tree/main/synapsys/broker) and [`synapsys/transport/`](https://github.com/synapsys-lab/synapsys/tree/main/synapsys/transport) on GitHub.

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -6,7 +6,7 @@ sidebar_position: 3
 
 # Architecture
 
-Synapsys is built in **six layers**. Each layer has a single responsibility and depends only on the layers below. This means you can use the mathematical core alone without touching the agent infrastructure, or swap the transport without changing any control logic.
+Synapsys is built in **seven layers**. Each layer has a single responsibility and depends only on the layers below. This means you can use the mathematical core alone without touching the agent infrastructure, or swap the transport backend without changing any control logic.
 
 ## Layer diagram
 
@@ -45,19 +45,28 @@ flowchart TB
         direction TB
         A1["FIPA ACL Messages\nINFORM, REQUEST, ..."]
         A2["SyncEngine\nWALL_CLOCK / LOCK_STEP"]
-        A3["BaseAgent -> PlantAgent, ControllerAgent"]
+        A3["BaseAgent → PlantAgent, ControllerAgent, HardwareAgent"]
     end
 
-    subgraph Transport["5. Transport — synapsys.transport"]
+    subgraph BrokerLayer["5. Broker — synapsys.broker"]
+        direction TB
+        B1["MessageBroker\nMediator / router"]
+        B2["Topic\nTyped, shaped signal descriptor"]
+        B3["SharedMemoryBackend\nZMQBrokerBackend"]
+        B1 --> B2
+        B1 --> B3
+    end
+
+    subgraph Transport["6. Transport — synapsys.transport"]
         direction TB
         T1{"TransportStrategy (ABC)"}
-        T2["SharedMemoryTransport\nZero-copy latency"]
+        T2["SharedMemoryTransport\nZero-copy IPC"]
         T3["ZMQTransport / ZMQReqRepTransport\nTCP network"]
         T1 --> T2
         T1 --> T3
     end
 
-    subgraph Hardware["6. Hardware — synapsys.hw"]
+    subgraph Hardware["7. Hardware — synapsys.hw"]
         direction LR
         H1["HardwareInterface (ABC)"]
         H2["FPGA / FPAA (planned)"]
@@ -67,7 +76,8 @@ flowchart TB
     UserAPI ==> CoreMath
     UserAPI ==> MAS
     CoreMath ==> ControlLogic
-    MAS ==> Transport
+    MAS ==> BrokerLayer
+    BrokerLayer ==> Transport
     Transport -.-> Hardware
     ControlLogic -.-> MAS
 ```
@@ -88,13 +98,15 @@ T = (C * G).feedback()   # closed loop: C in series with G
 
 `TransferFunctionMatrix` extends this algebra to MIMO plants: `*` performs matrix multiplication (series) and `+` is element-wise (parallel). Simulation and analysis delegate to a minimal `StateSpace` realisation built lazily by `to_state_space()`.
 
-### Strategy pattern in transport
+### Broker as mediator
 
-`PlantAgent` and `ControllerAgent` do not know **how** data is sent. They call `transport.write()` and `transport.read()`. The concrete implementation is injected at construction time — no control logic changes needed.
+`PlantAgent`, `ControllerAgent`, and `HardwareAgent` do not know **how** data is sent. They call `self._read(channel)` and `self._write(channel, data)`, which dispatch to the `MessageBroker` injected at construction time. The broker routes each channel to the appropriate backend (`SharedMemoryBackend`, `ZMQBrokerBackend`, or a custom one) — no control logic changes needed.
+
+This mediator pattern enables **many-to-many topologies**: a `ControllerAgent` can simultaneously receive plant output (`plant/y`) and live parameter updates from a `ReconfigAgent` (`ctrl/config`) through the same broker instance.
 
 ### Transport lifecycle
 
-The transport is **owned by the caller**, not the agent. The agent never calls `transport.close()`. This prevents double-free when multiple agents share views of the same memory block.
+The transport backend is **owned by the caller** via the `MessageBroker`. Agents never call `backend.close()` directly. This prevents double-free when multiple agents share views of the same memory block. Always call `broker.close()` in a `finally` block or at program exit.
 
 ### Continuous vs discrete
 

--- a/website/docs/examples/advanced/custom-signals.md
+++ b/website/docs/examples/advanced/custom-signals.md
@@ -107,3 +107,11 @@ plt.show()
 ```bash
 uv run python examples/advanced/01_custom_signals/01_custom_signals.py
 ```
+
+---
+
+## Source
+
+| File | Description |
+|------|-------------|
+| [`examples/advanced/01_custom_signals/01_custom_signals.py`](https://github.com/synapsys-lab/synapsys/blob/main/examples/advanced/01_custom_signals/01_custom_signals.py) | Complete example — MIL batch simulation, SIL ramp injection, custom signal superposition |

--- a/website/docs/examples/advanced/digital-twin.md
+++ b/website/docs/examples/advanced/digital-twin.md
@@ -137,3 +137,11 @@ Expected terminal output:
 ...
 Simulation complete. N ticks with divergence > 0.15.
 ```
+
+---
+
+## Source
+
+| File | Description |
+|------|-------------|
+| [`examples/advanced/05_digital_twin/05_digital_twin.py`](https://github.com/synapsys-lab/synapsys/blob/main/examples/advanced/05_digital_twin/05_digital_twin.py) | Complete example — physical plant, virtual twin, PID, wear injection, divergence monitoring, 3-panel plot |

--- a/website/docs/examples/advanced/digital-twin.md
+++ b/website/docs/examples/advanced/digital-twin.md
@@ -70,9 +70,9 @@ grows past the alert threshold $\delta_{\text{thr}} = 0.15$ within a few ticks o
 The twin evolves **in the main thread** via `evolve()`, synchronised with each bus read:
 
 ```python
-# Read physical output from bus
-y_physical = monitor.read("y")[0]
-u_current  = monitor.read("u")[0]
+# Observer reads directly from the broker — no extra transport handle needed
+y_physical = broker.read("twin/y")[0]
+u_current  = broker.read("twin/u")[0]
 
 # Step the twin with the SAME u
 x_virtual, y_virtual_arr = plant_nominal.evolve(
@@ -132,8 +132,8 @@ uv run python examples/advanced/05_digital_twin/05_digital_twin.py
 
 Expected terminal output:
 ```
-[t=3.00s] ⚠  Wear injected: plant pole drifted -1 → -2
-[t=3.05s] 🔴 ALERT: divergence = 0.18 > 0.15
+[t=3.00s] Wear injected: plant pole drifted -1 -> -2
+[t=3.05s] ALERT: divergence = 0.18 > 0.15
 ...
 Simulation complete. N ticks with divergence > 0.15.
 ```

--- a/website/docs/examples/advanced/quadcopter-mimo.md
+++ b/website/docs/examples/advanced/quadcopter-mimo.md
@@ -333,8 +333,8 @@ Saves `quadcopter_3d.gif` (~1.8 MB) and `quadcopter_telemetry.gif` (~4 MB) in un
 # Terminal 1 — start the linearised plant on shared memory
 python 06a_quadcopter_plant.py
 
-# Terminal 2 — connect an external controller via SharedMemoryTransport
-# (adapt 06b to read from bus instead of running its own simulation)
+# Terminal 2 — connect an external controller via MessageBroker + SharedMemoryBackend
+# (adapt 06b to read from the bus instead of running its own simulation)
 ```
 
 :::tip[Extending the Neural-LQR]
@@ -356,7 +356,7 @@ The hover model is valid only for $|\varphi|, |\theta| \leq 15°$. Aggressive ma
 | File | Purpose |
 |---|---|
 | `quadcopter_dynamics.py` | Physical constants, `build_matrices()`, `figure8_ref()`, LQR weights |
-| `06a_quadcopter_plant.py` | Two-process SIL plant via `PlantAgent` + `SharedMemoryTransport` |
+| `06a_quadcopter_plant.py` | Two-process SIL plant via `PlantAgent` + `SharedMemoryBackend` |
 | `06b_neural_lqr_3d.py` | Standalone simulation: config GUI, Neural-LQR, PyVista 3D, matplotlib |
 
 ### Key synapsys API calls

--- a/website/docs/examples/advanced/quadcopter-mimo.md
+++ b/website/docs/examples/advanced/quadcopter-mimo.md
@@ -367,3 +367,13 @@ The hover model is valid only for $|\varphi|, |\theta| \leq 15°$. Aggressive ma
 | `c2d(sys_c, dt)` | Discretises to ZOH discrete-time `StateSpace` |
 | `sys_d.evolve(x, u)` | One-step state update: returns $(x_{k+1},\, y_k)$ |
 | `lqr(A, B, Q, R)` | Solves ARE, returns gain matrix $K$ and cost matrix $P$ |
+
+---
+
+## Source
+
+| File | Description |
+|------|-------------|
+| [`examples/advanced/06_quadcopter_mimo/quadcopter_dynamics.py`](https://github.com/synapsys-lab/synapsys/blob/main/examples/advanced/06_quadcopter_mimo/quadcopter_dynamics.py) | Physical constants, `build_matrices()`, reference trajectory generators, LQR weight matrices |
+| [`examples/advanced/06_quadcopter_mimo/06a_quadcopter_plant.py`](https://github.com/synapsys-lab/synapsys/blob/main/examples/advanced/06_quadcopter_mimo/06a_quadcopter_plant.py) | Two-process SIL plant — `PlantAgent` + `SharedMemoryBackend` |
+| [`examples/advanced/06_quadcopter_mimo/06b_neural_lqr_3d.py`](https://github.com/synapsys-lab/synapsys/blob/main/examples/advanced/06_quadcopter_mimo/06b_neural_lqr_3d.py) | Standalone simulation — tkinter GUI, Neural-LQR, PyVista 3D, matplotlib telemetry, GIF export |

--- a/website/docs/examples/advanced/realtime-oscilloscope.md
+++ b/website/docs/examples/advanced/realtime-oscilloscope.md
@@ -113,3 +113,11 @@ uv run python examples/advanced/04_realtime_oscilloscope/04_realtime_matplotlib.
 ```
 
 The oscilloscope window opens immediately. Close it to stop the simulation.
+
+---
+
+## Source
+
+| File | Description |
+|------|-------------|
+| [`examples/advanced/04_realtime_oscilloscope/04_realtime_matplotlib.py`](https://github.com/synapsys-lab/synapsys/blob/main/examples/advanced/04_realtime_oscilloscope/04_realtime_matplotlib.py) | Complete example — sinusoidal reference, rolling-window deque, live matplotlib oscilloscope |

--- a/website/docs/examples/advanced/realtime-scope.md
+++ b/website/docs/examples/advanced/realtime-scope.md
@@ -107,3 +107,11 @@ uv run python examples/advanced/03_realtime_scope/03_realtime_scope.py
 ```
 
 Press `Ctrl+C` to stop the monitor. The plant and controller keep running.
+
+---
+
+## Source
+
+| File | Description |
+|------|-------------|
+| [`examples/advanced/03_realtime_scope/03_realtime_scope.py`](https://github.com/synapsys-lab/synapsys/blob/main/examples/advanced/03_realtime_scope/03_realtime_scope.py) | Headless terminal monitor — read-only observer connecting to the `sil_2dof` bus |

--- a/website/docs/examples/advanced/realtime-scope.md
+++ b/website/docs/examples/advanced/realtime-scope.md
@@ -49,22 +49,38 @@ The dashed line indicates the monitor **never writes** to the bus — it is comp
 ## Code
 
 ```python
-from synapsys.transport import SharedMemoryTransport
+from synapsys.broker import MessageBroker, Topic, SharedMemoryBackend
 import time, sys
 
-monitor = SharedMemoryTransport("sil_bus", {"y": 1, "u": 1}, create=False)
+topic_state = Topic("sil/state", shape=(4,))
+topic_u     = Topic("sil/u",     shape=(1,))
+
+broker = MessageBroker()
+broker.declare_topic(topic_state)
+broker.declare_topic(topic_u)
+broker.add_backend(
+    SharedMemoryBackend("sil_2dof", [topic_state, topic_u], create=False)
+)
+
 start_time = time.time()
 
-while True:
-    y = monitor.read("y")[0]
-    u = monitor.read("u")[0]
-    elapsed = time.time() - start_time
+try:
+    while True:
+        state   = broker.read("sil/state")
+        u       = broker.read("sil/u")[0]
+        elapsed = time.time() - start_time
 
-    sys.stdout.write(
-        f"\r[t={elapsed:6.2f}s] y(t): {y:8.4f} | u(t): {u:8.4f}"
-    )
-    sys.stdout.flush()
-    time.sleep(0.05)   # 20 Hz display rate
+        sys.stdout.write(
+            f"\r[t={elapsed:6.2f}s]  "
+            f"x1={state[0]:7.4f}  x2={state[1]:7.4f}  "
+            f"v1={state[2]:7.4f}  v2={state[3]:7.4f}  u={u:8.4f}"
+        )
+        sys.stdout.flush()
+        time.sleep(0.05)   # 20 Hz display rate
+except KeyboardInterrupt:
+    pass
+finally:
+    broker.close()
 ```
 
 ### How the in-place update works

--- a/website/docs/examples/advanced/sil-ai-controller.md
+++ b/website/docs/examples/advanced/sil-ai-controller.md
@@ -206,3 +206,12 @@ Replace the `NeuralLQR` forward pass with any `nn.Module` trained by PPO, SAC or
 :::tip[Multi-setpoint tracking]
 Change `X2_REF` at runtime, or implement a time-varying reference inside `control_law()`. The MLP's hidden layers can learn non-linear compensation beyond what the linear LQR initialisation provides.
 :::
+
+---
+
+## Source
+
+| File | Description |
+|------|-------------|
+| [`examples/advanced/02_sil_ai_controller/02a_sil_plant.py`](https://github.com/synapsys-lab/synapsys/blob/main/examples/advanced/02_sil_ai_controller/02a_sil_plant.py) | Plant process — 2-DOF double-integrator via `PlantAgent` + shared memory broker |
+| [`examples/advanced/02_sil_ai_controller/02b_sil_ai_controller.py`](https://github.com/synapsys-lab/synapsys/blob/main/examples/advanced/02_sil_ai_controller/02b_sil_ai_controller.py) | Controller process — Neural-LQR (`NeuralLQR` class, PyTorch), live matplotlib telemetry |

--- a/website/docs/examples/basic/step-response.md
+++ b/website/docs/examples/basic/step-response.md
@@ -106,3 +106,11 @@ uv run python examples/basic/01_step_response/step_response.py
 ```
 
 Output: a plot window + `step_response.png` saved to the working directory.
+
+---
+
+## Source
+
+| File | Description |
+|------|-------------|
+| [`examples/basic/01_step_response/step_response.py`](https://github.com/synapsys-lab/synapsys/blob/main/examples/basic/01_step_response/step_response.py) | Complete example — LTI analysis, PID closed-loop, step response plot |

--- a/website/docs/examples/distributed/shared-memory.md
+++ b/website/docs/examples/distributed/shared-memory.md
@@ -56,21 +56,26 @@ flowchart LR
 ## Plant (`plant.py`)
 
 ```python
-with SharedMemoryTransport(BUS_NAME, CHANNELS, create=True) as bus:
-    bus.write("y", np.array([0.0]))
-    bus.write("u", np.array([0.0]))
-    time.sleep(2.0)   # wait for controller to connect
+topic_y = Topic("plant/y", shape=(1,))
+topic_u = Topic("plant/u", shape=(1,))
 
-    for k in range(N_STEPS):
-        u = bus.read("u")[0]
-        y = bus.read("y")[0]
+broker = MessageBroker()
+broker.declare_topic(topic_y)
+broker.declare_topic(topic_u)
+broker.add_backend(SharedMemoryBackend(BUS_NAME, [topic_y, topic_u], create=True))
 
-        y_next = 0.9 * y + 0.1 * u   # discrete first-order dynamics
-        bus.write("y", np.array([y_next]))
-        time.sleep(DT)
+broker.publish("plant/y", np.zeros(1))
+broker.publish("plant/u", np.zeros(1))
+
+sync  = SyncEngine(SyncMode.WALL_CLOCK, dt=DT)
+agent = PlantAgent(
+    "plant", plant_d, None, sync,
+    channel_y="plant/y", channel_u="plant/u", broker=broker,
+)
+agent.start(blocking=True)
 ```
 
-The plant **creates** the shared memory block (`create=True`). The `with` block ensures the OS resource is released even on crash.
+The plant **creates** the shared memory block (`create=True`). The `PlantAgent` automatically handles the discrete-time simulation loop — no manual `for k in range(...)` needed.
 
 Discrete dynamics: $y(k+1) = 0.9\,y(k) + 0.1\,u(k)$ — equivalent to $G(s)=\tfrac{1}{s+1}$ with ZOH at ~20 Hz.
 
@@ -79,15 +84,24 @@ Discrete dynamics: $y(k+1) = 0.9\,y(k) + 0.1\,u(k)$ — equivalent to $G(s)=\tfr
 ## Controller (`controller.py`)
 
 ```python
-with SharedMemoryTransport(BUS_NAME, CHANNELS, create=False) as bus:
-    while True:
-        y = bus.read("y")[0]
-        u = pid.compute(setpoint=5.0, measurement=y)
-        bus.write("u", np.array([u]))
-        time.sleep(DT)    # 40 Hz
+topic_y = Topic("plant/y", shape=(1,))
+topic_u = Topic("plant/u", shape=(1,))
+
+broker = MessageBroker()
+broker.declare_topic(topic_y)
+broker.declare_topic(topic_u)
+broker.add_backend(SharedMemoryBackend(BUS_NAME, [topic_y, topic_u], create=False))
+
+law   = lambda y: np.array([pid.compute(setpoint=5.0, measurement=y[0])])
+sync  = SyncEngine(SyncMode.WALL_CLOCK, dt=DT)
+agent = ControllerAgent(
+    "ctrl", law, None, sync,
+    channel_y="plant/y", channel_u="plant/u", broker=broker,
+)
+agent.start(blocking=True)
 ```
 
-The controller **connects** to the existing block (`create=False`). It runs at **40 Hz** — twice the plant rate. Between plant updates, the controller reuses the last `y` value. This demonstrates **rate decoupling**: processes do not need to be synchronised.
+The controller **connects** to the existing block (`create=False`). It runs at **40 Hz** — twice the plant rate. This demonstrates **rate decoupling**: processes do not need to be synchronised.
 
 PID parameters: `Kp=3.0, Ki=0.5, dt=0.025` — tuned to drive `y` to `setpoint=5.0`.
 

--- a/website/docs/examples/distributed/shared-memory.md
+++ b/website/docs/examples/distributed/shared-memory.md
@@ -118,3 +118,12 @@ uv run python examples/distributed/01_shared_memory/controller.py
 ```
 
 You should see `y` converge to `5.0` within the first few steps. The plant runs for 200 steps (~10 s) then exits. Press `Ctrl+C` to stop the controller.
+
+---
+
+## Source
+
+| File | Description |
+|------|-------------|
+| [`examples/distributed/01_shared_memory/plant.py`](https://github.com/synapsys-lab/synapsys/blob/main/examples/distributed/01_shared_memory/plant.py) | Plant process — creates shared memory bus, runs `PlantAgent` |
+| [`examples/distributed/01_shared_memory/controller.py`](https://github.com/synapsys-lab/synapsys/blob/main/examples/distributed/01_shared_memory/controller.py) | Controller process — connects to bus, runs `ControllerAgent` with PID |

--- a/website/docs/examples/distributed/zmq.md
+++ b/website/docs/examples/distributed/zmq.md
@@ -146,3 +146,12 @@ The plant runs for 300 steps (~15 s). Press `Ctrl+C` to stop the controller.
 :::warning[Port conflict]
 If a previous run left sockets open, run `fuser -k 5555/tcp 5556/tcp` before starting.
 :::
+
+---
+
+## Source
+
+| File | Description |
+|------|-------------|
+| [`examples/distributed/02_zmq/plant_zmq.py`](https://github.com/synapsys-lab/synapsys/blob/main/examples/distributed/02_zmq/plant_zmq.py) | Plant process — PUB `y` on `:5555`, SUB `u` on `:5556` |
+| [`examples/distributed/02_zmq/controller_zmq.py`](https://github.com/synapsys-lab/synapsys/blob/main/examples/distributed/02_zmq/controller_zmq.py) | Controller process — SUB `y` from `:5555`, PUB `u` on `:5556` |

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -34,6 +34,12 @@ uv sync --extra dev
 | Extra | Command | What it adds |
 |-------|---------|--------------|
 | `dev` | `uv sync --extra dev` | pytest, ruff, mypy, matplotlib |
+| `ml` | `pip install synapsys torch` | PyTorch for Neural-LQR and RL controller examples |
+| `viz` | `pip install synapsys pyvista imageio` | PyVista 3D visualisation and GIF export (quadcopter example) |
+
+:::note
+`ml` and `viz` are not packaged as PyPI extras because their wheel sizes and platform support vary widely. Install them separately as shown above.
+:::
 
 ## Verify installation
 

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -208,6 +208,71 @@ flowchart LR
     NET -->|"SUB u"| P
 ```
 
+**Plant (Machine A):**
+
+```python
+import numpy as np
+from synapsys.api import ss, c2d
+from synapsys.agents import PlantAgent, SyncEngine, SyncMode
+from synapsys.broker import MessageBroker, Topic, ZMQBrokerBackend
+
+DT = 0.01
+plant_d = c2d(ss([[-1]], [[1]], [[1]], [[0]]), dt=DT)
+
+topic_y = Topic("plant/y", shape=(1,))
+topic_u = Topic("plant/u", shape=(1,))
+
+broker = MessageBroker()
+broker.declare_topic(topic_y)
+broker.declare_topic(topic_u)
+# PUB y on :5555 — controller subscribes there
+# SUB u on :5556 — controller publishes there
+broker.add_backend(ZMQBrokerBackend("tcp://0.0.0.0:5555", [topic_y], mode="pub"))
+broker.add_backend(ZMQBrokerBackend("tcp://0.0.0.0:5556", [topic_u], mode="sub"))
+broker.publish("plant/y", np.zeros(1))
+broker.publish("plant/u", np.zeros(1))
+
+agent = PlantAgent(
+    "plant", plant_d, None, SyncEngine(SyncMode.WALL_CLOCK, dt=DT),
+    channel_y="plant/y", channel_u="plant/u", broker=broker,
+)
+agent.start(blocking=True)
+```
+
+**Controller (Machine B — set `PLANT_HOST` to Machine A's IP):**
+
+```python
+import os, numpy as np
+from synapsys.algorithms import PID
+from synapsys.agents import ControllerAgent, SyncEngine, SyncMode
+from synapsys.broker import MessageBroker, Topic, ZMQBrokerBackend
+
+DT = 0.01
+PLANT_HOST = os.environ.get("PLANT_HOST", "localhost")
+
+pid = PID(Kp=3.0, Ki=0.5, dt=DT)
+
+topic_y = Topic("plant/y", shape=(1,))
+topic_u = Topic("plant/u", shape=(1,))
+
+broker = MessageBroker()
+broker.declare_topic(topic_y)
+broker.declare_topic(topic_u)
+# SUB y from plant :5555
+# PUB u to :5556 — plant subscribes there
+broker.add_backend(ZMQBrokerBackend(f"tcp://{PLANT_HOST}:5555", [topic_y], mode="sub"))
+broker.add_backend(ZMQBrokerBackend("tcp://0.0.0.0:5556", [topic_u], mode="pub"))
+broker.publish("plant/u", np.zeros(1))
+
+agent = ControllerAgent(
+    "ctrl",
+    lambda y: np.array([pid.compute(5.0, y[0])]),
+    None, SyncEngine(SyncMode.WALL_CLOCK, dt=DT),
+    channel_y="plant/y", channel_u="plant/u", broker=broker,
+)
+agent.start(blocking=True)
+```
+
 ```bash
 # Machine A — plant
 python examples/distributed/02_zmq/plant_zmq.py

--- a/website/docs/guide/agents/controller-agent.md
+++ b/website/docs/guide/agents/controller-agent.md
@@ -6,7 +6,7 @@ sidebar_position: 3
 
 # ControllerAgent
 
-`ControllerAgent` applies a **control law** in real time. It reads `y` from the transport, calls `control_law(y)`, and writes `u` back.
+`ControllerAgent` applies a **control law** in real time. It reads `y` from the broker, calls `control_law(y)`, and publishes `u` back.
 
 The control law is a `Callable[[np.ndarray], np.ndarray]` — any Python callable, including PID, LQR, or an AI model.
 
@@ -18,18 +18,28 @@ The control law is a `Callable[[np.ndarray], np.ndarray]` — any Python callabl
 import numpy as np
 from synapsys.algorithms import PID
 from synapsys.agents import ControllerAgent, SyncEngine, SyncMode
-from synapsys.transport import SharedMemoryTransport
+from synapsys.broker import MessageBroker, Topic, SharedMemoryBackend
 
 pid = PID(Kp=3.0, Ki=0.5, dt=0.025, u_min=-10.0, u_max=10.0)
 setpoint = 5.0
 
-# Lambda adapting PID signature to the agent contract
 law = lambda y: np.array([pid.compute(setpoint=setpoint, measurement=y[0])])
 
-transport = SharedMemoryTransport("my_simulation", {"y": 1, "u": 1})
-sync = SyncEngine(SyncMode.WALL_CLOCK, dt=0.025)
+# Broker must already be declared (e.g. by PlantAgent process)
+topic_y = Topic("plant/y", shape=(1,))
+topic_u = Topic("plant/u", shape=(1,))
 
-ctrl = ControllerAgent("controller", law, transport, sync)
+broker = MessageBroker()
+broker.declare_topic(topic_y)
+broker.declare_topic(topic_u)
+broker.add_backend(SharedMemoryBackend("my_simulation", [topic_y, topic_u], create=False))
+
+sync = SyncEngine(SyncMode.WALL_CLOCK, dt=0.025)
+ctrl = ControllerAgent(
+    "controller", law, None, sync,
+    channel_y="plant/y", channel_u="plant/u",
+    broker=broker,
+)
 ctrl.start(blocking=False)
 ```
 
@@ -44,7 +54,11 @@ K, _ = lqr(A, B, Q, R)
 # LQR: u = -K @ x  (here y is the full state)
 law = lambda y: -(K @ y.reshape(-1, 1)).flatten()
 
-ctrl = ControllerAgent("lqr_ctrl", law, transport, sync)
+ctrl = ControllerAgent(
+    "lqr_ctrl", law, None, sync,
+    channel_y="plant/y", channel_u="plant/u",
+    broker=broker,
+)
 ```
 
 ### With any callable
@@ -54,7 +68,11 @@ ctrl = ControllerAgent("lqr_ctrl", law, transport, sync)
 def bang_bang(y: np.ndarray) -> np.ndarray:
     return np.array([10.0 if y[0] < setpoint else -10.0])
 
-ctrl = ControllerAgent("bang_bang", bang_bang, transport, sync)
+ctrl = ControllerAgent(
+    "bang_bang", bang_bang, None, sync,
+    channel_y="plant/y", channel_u="plant/u",
+    broker=broker,
+)
 ```
 
 ## API Reference

--- a/website/docs/guide/agents/digital-twins.md
+++ b/website/docs/guide/agents/digital-twins.md
@@ -44,24 +44,29 @@ Synapsys's agent separation solves this trivially: you just connect a **third in
 
 ```python
 import time
-from synapsys.transport import SharedMemoryTransport
-# You could launch real-time rendering libraries like PyQtGraph here!
+from synapsys.broker import MessageBroker, Topic, SharedMemoryBackend
 
-# Attach a read-only handle to the ongoing simulation
-monitor = SharedMemoryTransport("ctrl_bus", {"y": 2, "u": 1}, create=False)
+# Connect to the running broker bus as a read-only observer
+topic_y = Topic("plant/y", shape=(2,))
+topic_u = Topic("plant/u", shape=(1,))
+
+broker = MessageBroker()
+broker.declare_topic(topic_y)
+broker.declare_topic(topic_u)
+broker.add_backend(SharedMemoryBackend("ctrl_bus", [topic_y, topic_u], create=False))
 
 try:
     while True:
-        y = monitor.read("y")
-        u = monitor.read("u")
-        
+        y = broker.read("plant/y")
+        u = broker.read("plant/u")
+
         print(f"Time: {time.time():.4f} | Output: {y} | Input: {u}")
-        
-        # Run extremely fast async GUI scope updates here
-        time.sleep(0.01) 
-        
+        time.sleep(0.01)
+
 except KeyboardInterrupt:
     pass
+finally:
+    broker.close()
 ```
 
 The `ControllerAgent` and `PlantAgent` processes never know the monitor exists. Their strict microsecond mathematical timings continue performing flawlessly.
@@ -118,7 +123,10 @@ def ramp_control_law(y: np.ndarray) -> np.ndarray:
     u = 0.5 * sync.elapsed   # linear ramp: +0.5 u per real second
     return np.array([u])
 
-ctrl = ControllerAgent("ramp_ctrl", ramp_control_law, transport, sync)
+ctrl = ControllerAgent(
+    "ramp_ctrl", ramp_control_law, None, sync,
+    channel_y="plant/y", channel_u="plant/u", broker=broker,
+)
 ctrl.start()
 ```
 

--- a/website/docs/guide/agents/digital-twins.md
+++ b/website/docs/guide/agents/digital-twins.md
@@ -34,6 +34,49 @@ flowchart LR
 
 By continuously evaluating the virtual state matrix (`x_virtual`) using the exact physical input signals `u(t)` received from the hardware, engineers can compare the mathematical `.evolve(x, u)` output with the real physical sensor data. **Divergence** between the two implies that the physical plant has changed—a common indicator of mechanical wear, unpredicted friction buildup, or imminent system faults.
 
+### Virtual twin loop
+
+The twin runs in the main thread, fed by the same `u` the physical plant receives:
+
+```python
+import numpy as np
+from synapsys.api import c2d, ss
+from synapsys.broker import MessageBroker, Topic, SharedMemoryBackend
+
+# Nominal model — stays fixed even when the physical plant drifts
+plant_nominal = c2d(ss([[-1]], [[1]], [[1]], [[0]]), dt=0.01)
+x_virtual = np.zeros(plant_nominal.n_states)
+
+topic_y = Topic("twin/y", shape=(1,))
+topic_u = Topic("twin/u", shape=(1,))
+
+broker = MessageBroker()
+broker.declare_topic(topic_y)
+broker.declare_topic(topic_u)
+broker.add_backend(SharedMemoryBackend("twin_bus", [topic_y, topic_u], create=False))
+
+THRESHOLD = 0.15
+alerts = 0
+
+while True:
+    # Read physical output and current control input from the bus
+    y_physical = broker.read("twin/y")[0]
+    u_current  = broker.read("twin/u")[0]
+
+    # Step the virtual twin with the SAME u — only internal model differs
+    x_virtual, y_virtual_arr = plant_nominal.evolve(
+        x_virtual, np.array([u_current])
+    )
+    y_virtual = float(y_virtual_arr[0])
+
+    divergence = abs(y_physical - y_virtual)
+    if divergence > THRESHOLD:
+        alerts += 1
+        print(f"ALERT: divergence = {divergence:.2f} > {THRESHOLD}")
+```
+
+See the [Digital Twin example](../../examples/advanced/digital-twin) for the full simulation including wear injection and real-time plotting.
+
 ---
 
 ## 2. Real-Time Plotting and Oscilloscopes

--- a/website/docs/guide/agents/hil-sil.md
+++ b/website/docs/guide/agents/hil-sil.md
@@ -58,7 +58,7 @@ for k in range(100):
 
 In **Software-in-the-Loop (SIL)**, the control algorithm runs exactly as it would in deployment, but it executes on a desktop/server (often in a separate process or Docker container) rather than embedded hardware. The plant remains simulated.
 
-To transition from MIL to SIL in Synapsys, you wrap your components into **Agents** and connect them using a real transport mechanism (e.g., `SharedMemoryTransport` or `ZMQTransport`).
+To transition from MIL to SIL in Synapsys, you wrap your components into **Agents** and connect them via a `MessageBroker` backed by shared memory or ZeroMQ.
 
 ```mermaid
 %%{init: {'theme': 'dark'}}%%
@@ -85,17 +85,43 @@ flowchart LR
 
 **Terminal 1 (Plant)**
 ```python
-transport_plant = SharedMemoryTransport("bus", {"y": 1, "u": 1}, create=True)
-plant_agent = PlantAgent("plant", plant_d, transport_plant, SyncEngine())
+from synapsys.broker import MessageBroker, Topic, SharedMemoryBackend
+
+topic_y = Topic("plant/y", shape=(1,))
+topic_u = Topic("plant/u", shape=(1,))
+
+broker = MessageBroker()
+broker.declare_topic(topic_y)
+broker.declare_topic(topic_u)
+broker.add_backend(SharedMemoryBackend("bus", [topic_y, topic_u], create=True))
+broker.publish("plant/y", np.zeros(1))
+broker.publish("plant/u", np.zeros(1))
+
+plant_agent = PlantAgent(
+    "plant", plant_d, None, SyncEngine(),
+    channel_y="plant/y", channel_u="plant/u", broker=broker,
+)
 plant_agent.start(blocking=True)
 ```
 
 **Terminal 2 (Controller)**
 ```python
-transport_ctrl = SharedMemoryTransport("bus", {"y": 1, "u": 1}, create=False)
-law = lambda y: pid.compute(setpoint=1.0, measurement=y[0])
+from synapsys.broker import MessageBroker, Topic, SharedMemoryBackend
 
-ctrl_agent = ControllerAgent("ctrl", law, transport_ctrl, SyncEngine())
+topic_y = Topic("plant/y", shape=(1,))
+topic_u = Topic("plant/u", shape=(1,))
+
+broker = MessageBroker()
+broker.declare_topic(topic_y)
+broker.declare_topic(topic_u)
+broker.add_backend(SharedMemoryBackend("bus", [topic_y, topic_u], create=False))
+
+law = lambda y: np.array([pid.compute(setpoint=1.0, measurement=y[0])])
+
+ctrl_agent = ControllerAgent(
+    "ctrl", law, None, SyncEngine(),
+    channel_y="plant/y", channel_u="plant/u", broker=broker,
+)
 ctrl_agent.start(blocking=True)
 ```
 
@@ -208,26 +234,32 @@ flowchart TD
 import torch
 import numpy as np
 from synapsys.agents import ControllerAgent, SyncEngine, SyncMode
-from synapsys.transport import SharedMemoryTransport
+from synapsys.broker import MessageBroker, Topic, SharedMemoryBackend
 
 # Load your pre-trained PyTorch model
 model = torch.load("rl_controller.pth")
 model.eval()
 
 def ai_control_law(y: np.ndarray) -> np.ndarray:
-    # Convert latest sensor data to tensor
     state_tensor = torch.tensor(y, dtype=torch.float32)
-    
-    # Run inference to predict control action
     with torch.no_grad():
         action = model(state_tensor).numpy()
-        
     return action
 
-# Create transport and run the AI controller as an agent
-ai_transport = SharedMemoryTransport("ctrl_bus", {"y": 2, "u": 1}, create=False)
+# Connect to the running broker bus
+topic_y = Topic("plant/y", shape=(2,))
+topic_u = Topic("plant/u", shape=(1,))
+
+broker = MessageBroker()
+broker.declare_topic(topic_y)
+broker.declare_topic(topic_u)
+broker.add_backend(SharedMemoryBackend("ctrl_bus", [topic_y, topic_u], create=False))
+
 sync = SyncEngine(mode=SyncMode.WALL_CLOCK, dt=0.01)
 
-ai_agent = ControllerAgent("ai_ctrl", ai_control_law, ai_transport, sync)
+ai_agent = ControllerAgent(
+    "ai_ctrl", ai_control_law, None, sync,
+    channel_y="plant/y", channel_u="plant/u", broker=broker,
+)
 ai_agent.start(blocking=True)
 ```

--- a/website/docs/guide/agents/hil-sil.md
+++ b/website/docs/guide/agents/hil-sil.md
@@ -162,21 +162,42 @@ flowchart LR
 
 ### HIL Bridge Concept
 
-Instead of instantiating a `ControllerAgent`, you bind the plant's transport to a hardware bridge layer (`synapsys.hw`). *Note: Concrete hardware interfaces are planned for v0.5.*
+Instead of instantiating a `ControllerAgent`, you bind the plant's broker to a `HardwareAgent` that bridges the broker bus to a physical device via `synapsys.hw`.
+
+:::warning[Planned feature — v0.5]
+Concrete hardware interfaces (`SerialHardwareInterface`, `OPCUAHardwareInterface`, `FPGAHardwareInterface`) are **not yet implemented**. The code below illustrates the intended pattern using the available `MockHardwareInterface`. Replace `MockHardwareInterface` with the appropriate concrete class once v0.5 is released.
+:::
 
 ```python
-from synapsys.hw import SerialHardwareInterface
+from synapsys.hw import MockHardwareInterface   # replace with SerialHardwareInterface in v0.5
+from synapsys.agents import HardwareAgent, SyncEngine, SyncMode
+from synapsys.broker import MessageBroker, Topic, SharedMemoryBackend
+import numpy as np
 
-# Connect to the physical controller via USB/UART
-hw_bridge = SerialHardwareInterface(port="/dev/ttyACM0", baudrate=115200)
+topic_y = Topic("hw/y", shape=(1,))
+topic_u = Topic("hw/u", shape=(1,))
 
-while True:
-    y = transport_plant.read("y")
-    hw_bridge.write(y)           # Send sensor data over Serial
-    
-    u = hw_bridge.read()         # Wait for MCU control action
-    transport_plant.write("u", u)
+broker = MessageBroker()
+broker.declare_topic(topic_y)
+broker.declare_topic(topic_u)
+broker.add_backend(SharedMemoryBackend("hil_bus", [topic_y, topic_u], create=True))
+broker.publish("hw/y", np.zeros(1))
+broker.publish("hw/u", np.zeros(1))
+
+# MockHardwareInterface simulates a real device — swap for SerialHardwareInterface later
+hw = MockHardwareInterface(n_inputs=1, n_outputs=1)
+sync = SyncEngine(SyncMode.WALL_CLOCK, dt=0.01)
+
+agent = HardwareAgent(
+    "hw_plant", hw, None, sync,
+    channel_y="hw/y", channel_u="hw/u", broker=broker,
+)
+
+with hw:
+    agent.start(blocking=True)
 ```
+
+Each tick: reads `y` from hardware → publishes `y` to broker → reads `u` from broker → writes `u` to hardware. On `TimeoutError`, the last known `y`/`u` are held (Zero-Order Hold).
 
 :::note
 **Advantage:** You can rigorously test boundary conditions, system failures, and corner cases on the final compiled C/C++ firmware without risking physical damage to an expensive, actual plant (e.g., drones, industrial motors).

--- a/website/docs/guide/agents/plant-agent.md
+++ b/website/docs/guide/agents/plant-agent.md
@@ -11,7 +11,7 @@ sidebar_position: 2
 ## Requirements
 
 - The plant must be discrete. Use `c2d()` to discretise a continuous plant.
-- The transport must have two channels: one for `y` (output) and one for `u` (input).
+- A `MessageBroker` must have two declared topics: one for `y` (output) and one for `u` (input).
 
 ## Complete example
 
@@ -19,25 +19,31 @@ sidebar_position: 2
 import numpy as np
 from synapsys.api import ss, c2d
 from synapsys.agents import PlantAgent, SyncEngine, SyncMode
-from synapsys.transport import SharedMemoryTransport
+from synapsys.broker import MessageBroker, Topic, SharedMemoryBackend
 
 # 1. Define and discretise the plant
 plant_c = ss([[-1.0]], [[1.0]], [[1.0]], [[0.0]])   # G(s) = 1/(s+1)
 plant_d = c2d(plant_c, dt=0.01)                      # ZOH, 100 Hz
 
-# 2. Create the shared-memory bus
-BUS = "my_simulation"
-CHANNELS = {"y": 1, "u": 1}
+# 2. Declare topics and build broker
+topic_y = Topic("plant/y", shape=(1,))
+topic_u = Topic("plant/u", shape=(1,))
 
-owner = SharedMemoryTransport(BUS, CHANNELS, create=True)
-owner.write("u", np.array([0.0]))
-owner.write("y", np.array([0.0]))
+broker = MessageBroker()
+broker.declare_topic(topic_y)
+broker.declare_topic(topic_u)
+broker.add_backend(SharedMemoryBackend("my_simulation", [topic_y, topic_u], create=True))
 
-# 3. Each agent gets its own handle (as if in separate processes)
-t_plant = SharedMemoryTransport(BUS, CHANNELS)
+broker.publish("plant/y", np.zeros(1))
+broker.publish("plant/u", np.zeros(1))
 
-sync = SyncEngine(SyncMode.WALL_CLOCK, dt=0.01)
-agent = PlantAgent("plant", plant_d, t_plant, sync)
+# 3. Wire agent — transport=None, broker= kwarg
+sync  = SyncEngine(SyncMode.WALL_CLOCK, dt=0.01)
+agent = PlantAgent(
+    "plant", plant_d, None, sync,
+    channel_y="plant/y", channel_u="plant/u",
+    broker=broker,
+)
 
 # 4. Start in background
 agent.start(blocking=False)
@@ -45,15 +51,18 @@ agent.start(blocking=False)
 # ... controller running in another thread/process ...
 
 agent.stop()
-t_plant.close()
-owner.close()
+broker.close()
 ```
 
 ## Initial state
 
 ```python
 x0 = np.array([2.0])    # non-zero initial state
-agent = PlantAgent("plant", plant_d, transport, sync, x0=x0)
+agent = PlantAgent(
+    "plant", plant_d, None, sync,
+    channel_y="plant/y", channel_u="plant/u",
+    x0=x0, broker=broker,
+)
 ```
 
 ## API Reference

--- a/website/docs/guide/transport/broker.md
+++ b/website/docs/guide/transport/broker.md
@@ -1,0 +1,187 @@
+---
+id: broker
+title: MessageBroker
+sidebar_position: 2
+---
+
+# MessageBroker — Central Routing Layer
+
+The `MessageBroker` is the **recommended** way to wire agents together in Synapsys. It acts as a mediator: agents publish to named `Topic`s and read from them without holding any transport reference directly. This decoupling enables **many-to-many** topologies that are impossible with a single point-to-point transport handle.
+
+---
+
+## Core abstractions
+
+### Topic
+
+A `Topic` describes a named signal: its shape and dtype. It acts as a typed key in the broker registry.
+
+```python
+from synapsys.broker import Topic
+import numpy as np
+
+topic_y = Topic("plant/y", shape=(4,))          # 4-element float64 vector
+topic_u = Topic("plant/u", shape=(1,))
+topic_cfg = Topic("ctrl/config", shape=(1,), dtype=np.dtype(np.float32))
+```
+
+Topics are **frozen dataclasses** — hashable and immutable. The broker uses them to validate every `publish()` call: if the array shape does not match the declared shape, a `ValueError` is raised before any data is written.
+
+Topic names follow a hierarchical convention: `"<system>/<signal>"`.  
+Examples: `"plant/y"`, `"quad/state"`, `"ctrl/config"`.
+
+### BrokerBackend
+
+A `BrokerBackend` is the physical transport underneath the broker. The two built-in backends are:
+
+| Backend | Transport | Best for |
+|---|---|---|
+| `SharedMemoryBackend` | OS shared memory | Same-machine agents, latency < 1 µs |
+| `ZMQBrokerBackend` | ZeroMQ PUB/SUB | Cross-machine agents, async pub/sub |
+
+### MessageBroker
+
+```python
+from synapsys.broker import MessageBroker, Topic, SharedMemoryBackend
+
+broker = MessageBroker()
+broker.declare_topic(topic_y)
+broker.declare_topic(topic_u)
+broker.add_backend(SharedMemoryBackend("my_bus", [topic_y, topic_u], create=True))
+
+# Initialise before agents start
+broker.publish("plant/y", np.zeros(4))
+broker.publish("plant/u", np.zeros(1))
+```
+
+| Method | Description |
+|---|---|
+| `declare_topic(topic)` | Registers a `Topic`. Must be called before `publish` or `read`. |
+| `add_backend(backend)` | Attaches a backend. A topic is routed to the first backend that supports it. |
+| `publish(name, data)` | Validates shape → writes to backend → notifies callbacks. |
+| `read(name)` | Non-blocking read from backend (ZOH if no new data). |
+| `subscribe(name, callback)` | Registers a callback invoked on every `publish`. |
+| `read_wait(name, timeout)` | Blocking read — waits until new data arrives or timeout. |
+| `close()` | Closes all backends and releases resources. |
+
+---
+
+## Wiring agents
+
+Agents accept a `broker=` keyword argument. Pass `None` as the `transport` positional argument when using the broker:
+
+```python
+from synapsys.agents import PlantAgent, ControllerAgent, SyncEngine
+from synapsys.algorithms import PID
+
+plant_agent = PlantAgent(
+    "plant", plant_d, None, SyncEngine(),
+    channel_y="plant/y", channel_u="plant/u", broker=broker,
+)
+
+pid = PID(Kp=3.0, Ki=0.5, dt=0.01)
+ctrl_agent = ControllerAgent(
+    "ctrl",
+    lambda y: np.array([pid.compute(5.0, y[0])]),
+    None, SyncEngine(),
+    channel_y="plant/y", channel_u="plant/u", broker=broker,
+)
+
+plant_agent.start(blocking=False)
+ctrl_agent.start(blocking=True)
+```
+
+Both agents share the **same broker instance**. The broker routes `"plant/y"` and `"plant/u"` through the `SharedMemoryBackend` without either agent knowing about shared memory.
+
+---
+
+## Observer pattern
+
+Any code that needs to monitor signals can call `broker.read()` directly — no extra transport handle, no impact on the closed-loop agents:
+
+```python
+import time
+
+# Third-party monitor — read-only, completely transparent
+try:
+    while True:
+        y = broker.read("plant/y")
+        u = broker.read("plant/u")
+        print(f"y={y}  u={u}")
+        time.sleep(0.05)
+except KeyboardInterrupt:
+    broker.close()
+```
+
+This is the pattern used by the [Real-Time Scope](../../examples/advanced/realtime-scope) and [Digital Twin](../../examples/advanced/digital-twin) examples.
+
+---
+
+## Multi-agent reconfiguration
+
+Because any number of agents can publish and subscribe to any topic, a `ReconfigAgent` can send live parameter updates to a running controller — something impossible with a single point-to-point transport:
+
+```mermaid
+%%{init: {'theme': 'dark'}}%%
+flowchart LR
+    P["PlantAgent"] -->|publish plant/y| B(["MessageBroker"])
+    B -->|read plant/y| C["ControllerAgent"]
+    C -->|publish plant/u| B
+    B -->|read plant/u| P
+    R["ReconfigAgent"] -->|publish ctrl/config| B
+    B -->|read ctrl/config| C
+```
+
+```python
+topic_cfg = Topic("ctrl/config", shape=(1,))
+broker.declare_topic(topic_cfg)
+broker.publish("ctrl/config", np.array([5.0]))   # initial setpoint
+
+# ControllerAgent reads config each tick
+def adaptive_law(y: np.ndarray) -> np.ndarray:
+    setpoint = broker.read("ctrl/config")[0]
+    return np.array([pid.compute(setpoint, y[0])])
+
+# ReconfigAgent publishes a new setpoint at any time
+broker.publish("ctrl/config", np.array([10.0]))  # live update
+```
+
+---
+
+## Choosing a backend
+
+```mermaid
+%%{init: {'theme': 'dark'}}%%
+flowchart LR
+    Q{Same machine?}
+    Q -->|Yes| SHM["SharedMemoryBackend\nZero-copy, < 1 µs"]
+    Q -->|No| ZMQ["ZMQBrokerBackend\nTCP PUB/SUB, ~100 µs"]
+```
+
+For cross-machine setups each process creates its **own** broker and connects two `ZMQBrokerBackend` instances (one for PUB topics, one for SUB topics). See [ZeroMQ Transport](zmq.md) for the bidirectional wiring details.
+
+---
+
+## Lifecycle
+
+```python
+# Setup
+broker = MessageBroker()
+broker.declare_topic(topic_y)
+broker.add_backend(SharedMemoryBackend("bus", [topic_y], create=True))
+broker.publish("plant/y", np.zeros(1))   # initialise before agents start
+
+# Run
+agent.start(blocking=True)
+
+# Teardown — always close the broker
+broker.close()
+```
+
+Calling `broker.close()` closes all registered backends. For `SharedMemoryBackend`, the `create=True` instance also calls `unlink()` to release the OS shared memory block.
+
+---
+
+## API Reference
+
+See the full reference at [synapsys.broker →](../../api/transport#synapsysbroker).

--- a/website/docs/guide/transport/overview.md
+++ b/website/docs/guide/transport/overview.md
@@ -6,32 +6,59 @@ sidebar_position: 1
 
 # Transport Layer — Overview
 
-The transport layer abstracts **how data flows** between agents. Every implementation follows the `TransportStrategy` interface:
+The transport layer abstracts **how data flows** between agents. Synapsys offers two levels of abstraction:
+
+| Level | Interface | When to use |
+|---|---|---|
+| **High-level** | `MessageBroker` + `Topic` | Recommended for all new code — named, typed channels, multi-agent topologies |
+| **Low-level** | `TransportStrategy` | Direct access for custom integrations or legacy code |
+
+---
+
+## Recommended: MessageBroker
+
+The `MessageBroker` is a mediator that routes named `Topic`s through pluggable backends. Agents publish and subscribe to topic names — they never hold transport references directly.
 
 ```python
-transport.write("channel", np.array([1.0, 2.0]))
-data = transport.read("channel")   # -> np.ndarray
+from synapsys.broker import MessageBroker, Topic, SharedMemoryBackend
+import numpy as np
+
+topic_y = Topic("plant/y", shape=(1,))
+topic_u = Topic("plant/u", shape=(1,))
+
+broker = MessageBroker()
+broker.declare_topic(topic_y)
+broker.declare_topic(topic_u)
+broker.add_backend(SharedMemoryBackend("demo_bus", [topic_y, topic_u], create=True))
+broker.publish("plant/y", np.zeros(1))
+broker.publish("plant/u", np.zeros(1))
 ```
 
-## Choosing a transport
+See [MessageBroker →](broker.md) for the full guide.
+
+---
+
+## Choosing a transport backend
 
 ```mermaid
 %%{init: {'theme': 'dark'}}%%
 flowchart LR
     Q{Plant and controller\non the same machine?}
-    Q -->|Yes| SM["SharedMemoryTransport\nZero-copy, latency ~µs"]
-    Q -->|No| ZQ{Synchrony\nrequired?}
-    ZQ -->|Asynchronous| PUB["ZMQTransport\nPUB/SUB"]
-    ZQ -->|Lock-step| REP["ZMQReqRepTransport\nREQ/REP"]
+    Q -->|Yes| SM["SharedMemoryBackend\nZero-copy, latency < 1 µs"]
+    Q -->|No| ZQ["ZMQBrokerBackend\nTCP PUB/SUB, ~100 µs"]
 ```
 
-| Transport | Typical latency | Topology | Use case |
+| Backend | Latency | Topology | Use case |
 |---|---|---|---|
-| `SharedMemoryTransport` | < 1 µs | same machine | High-frequency simulation |
-| `ZMQTransport` (PUB/SUB) | ~100 µs–1 ms | network | Controller on another machine, multiple observers |
-| `ZMQReqRepTransport` | ~100 µs–1 ms | network | Lock-step simulation over the network |
+| `SharedMemoryBackend` | < 1 µs | Same machine | High-frequency real-time simulation |
+| `ZMQBrokerBackend` | ~100 µs–1 ms | Network | Controller on another machine, async pub/sub |
+| `ZMQReqRepTransport` *(low-level)* | ~100 µs–1 ms | Network | Lock-step simulation over the network |
 
-## Common interface
+---
+
+## Low-level interface (advanced)
+
+`TransportStrategy` is the abstract base for all backends. You can use it directly when you need fine-grained control or are building a custom integration:
 
 ```python
 import numpy as np
@@ -43,7 +70,7 @@ with SharedMemoryTransport("bus", {"y": 2, "u": 1}, create=True) as t:
     y = t.read("y")
 ```
 
-## Implementing a custom transport
+### Implementing a custom transport
 
 ```python
 import numpy as np
@@ -60,3 +87,5 @@ class RedisTransport(TransportStrategy):
     def close(self) -> None:
         self._redis.close()
 ```
+
+To plug a custom transport into the broker layer, wrap it in a `BrokerBackend` subclass — see [`synapsys/broker/backends/base.py`](https://github.com/synapsys-lab/synapsys/tree/main/synapsys/broker/backends/base.py).

--- a/website/docs/guide/transport/shared-memory.md
+++ b/website/docs/guide/transport/shared-memory.md
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 # Shared Memory Transport
 
-`SharedMemoryTransport` uses the **OS shared-memory mechanism** (`multiprocessing.shared_memory`) for **zero-copy** communication between processes on the same machine.
+`SharedMemoryBackend` (via `SharedMemoryTransport` underneath) uses the **OS shared-memory mechanism** (`multiprocessing.shared_memory`) for **zero-copy** communication between processes on the same machine.
 
 Data is written directly to physical RAM addresses mapped as NumPy arrays. No serialisation, no copying, no kernel bypass — just a pointer to the same address.
 
@@ -15,51 +15,74 @@ Data is written directly to physical RAM addresses mapped as NumPy arrays. No se
 ```
 Process A (plant)             Physical RAM              Process B (controller)
 ─────────────────────    ┌──────────────────────┐    ──────────────────────────
-bus._buf -> array  ─────▶│  [y0, y1, ..., u0]  │◀────── bus._buf -> array
+broker.publish(...)  ───▶│  [y0, y1, ..., u0]  │◀──── broker.read(...)
                           └──────────────────────┘
                                "ctrl_bus" (OS name)
 ```
 
-## Usage
+## Usage with MessageBroker
 
 ```python
-from synapsys.transport import SharedMemoryTransport
+from synapsys.broker import MessageBroker, Topic, SharedMemoryBackend
 import numpy as np
 
-CHANNELS = {
-    "y": 2,    # plant output — 2 floats
-    "u": 1,    # control signal — 1 float
-}
+topic_y = Topic("plant/y", shape=(2,))   # plant output — 2 floats
+topic_u = Topic("plant/u", shape=(1,))   # control signal — 1 float
 
 # Owner process: creates the block (create=True)
-owner = SharedMemoryTransport("ctrl_bus", CHANNELS, create=True)
-owner.write("y", np.array([0.0, 0.0]))
-owner.write("u", np.array([0.0]))
+broker = MessageBroker()
+broker.declare_topic(topic_y)
+broker.declare_topic(topic_u)
+broker.add_backend(SharedMemoryBackend("ctrl_bus", [topic_y, topic_u], create=True))
 
-# Other processes: connect by name (create=False, default)
-client = SharedMemoryTransport("ctrl_bus", CHANNELS)
-y = client.read("y")
+broker.publish("plant/y", np.zeros(2))
+broker.publish("plant/u", np.zeros(1))
+
+# Other processes: connect by name (create=False)
+broker2 = MessageBroker()
+broker2.declare_topic(topic_y)
+broker2.declare_topic(topic_u)
+broker2.add_backend(SharedMemoryBackend("ctrl_bus", [topic_y, topic_u], create=False))
+
+y = broker2.read("plant/y")
 ```
 
 :::warning[Owner is responsible for unlink]
 Only the `create=True` process releases memory in the OS on close.
-Clients call only `close()` — not `unlink()`.
+Client processes call only `broker.close()`.
 :::
 
 ## Multiple agents on the same block
 
-```python
-# Each agent needs its own Python object
-# (even if they point to the same RAM block)
-t_plant = SharedMemoryTransport("ctrl_bus", CHANNELS)   # plant agent handle
-t_ctrl  = SharedMemoryTransport("ctrl_bus", CHANNELS)   # controller agent handle
+With `MessageBroker`, a single broker instance is shared by all agents in the same process — no need for multiple transport handles:
 
-plant_agent = PlantAgent(..., transport=t_plant, ...)
-ctrl_agent  = ControllerAgent(..., transport=t_ctrl, ...)
+```python
+from synapsys.broker import MessageBroker, Topic, SharedMemoryBackend
+from synapsys.agents import PlantAgent, ControllerAgent, SyncEngine, SyncMode
+
+topic_y = Topic("plant/y", shape=(1,))
+topic_u = Topic("plant/u", shape=(1,))
+
+broker = MessageBroker()
+broker.declare_topic(topic_y)
+broker.declare_topic(topic_u)
+broker.add_backend(SharedMemoryBackend("ctrl_bus", [topic_y, topic_u], create=True))
+
+broker.publish("plant/y", np.zeros(1))
+broker.publish("plant/u", np.zeros(1))
+
+plant_agent = PlantAgent(
+    "plant", plant_d, None, SyncEngine(SyncMode.WALL_CLOCK, dt=0.01),
+    channel_y="plant/y", channel_u="plant/u", broker=broker,
+)
+ctrl_agent = ControllerAgent(
+    "ctrl", law, None, SyncEngine(SyncMode.WALL_CLOCK, dt=0.01),
+    channel_y="plant/y", channel_u="plant/u", broker=broker,
+)
 ```
 
 :::danger[Race conditions]
-There is no mutex in the current implementation. If two processes write to the same channel simultaneously, corruption may occur. Architect your channels so that each process is the sole writer of its channel.
+There is no mutex in the current implementation. Architect your topics so that each agent is the sole writer of its topic.
 :::
 
 ## API Reference

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -22,57 +22,63 @@ Synapsys is designed as a MATLAB-compatible alternative for control engineers wh
 
 ---
 
-## Features
+## Overview
+
+Synapsys covers the full control-design workflow — from continuous-time LTI modelling to discrete real-time closed-loop simulation — with a consistent API across all stages.
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 <Tabs>
-  <TabItem value="core" label="Core Math">
+  <TabItem value="lti" label="LTI Models">
 
 ```python
 from synapsys.api import tf, ss, step, bode, feedback, c2d
 
 # Transfer function — same syntax as MATLAB
-G = tf([1], [1, 2, 1])        # G(s) = 1 / (s^2 + 2s + 1)
+G = tf([1], [1, 2, 1])        # G(s) = 1 / (s² + 2s + 1)
 
 # Block algebra
 T = feedback(G)                # T = G / (1 + G)
 t, y = step(T)                 # step response
 w, mag, ph = bode(G)           # Bode diagram
 
-# ZOH discretisation
+# ZOH discretisation at 20 Hz
 Gd = c2d(G, dt=0.05)
+print(Gd.is_stable())          # True
 ```
 
   </TabItem>
-  <TabItem value="algorithms" label="Algorithms">
+  <TabItem value="algorithms" label="PID / LQR">
 
 ```python
 from synapsys.algorithms import PID, lqr
+import numpy as np
 
-# Discrete PID with anti-windup
+# Discrete PID with anti-windup saturation
 pid = PID(Kp=3.0, Ki=0.5, Kd=0.1, dt=0.01,
           u_min=-10.0, u_max=10.0)
 u = pid.compute(setpoint=5.0, measurement=y)
 
 # LQR — solves the algebraic Riccati equation
-K, P = lqr(A, B, Q, R)
+# Returns optimal gain K and cost matrix P
+K, P = lqr(A, B, Q, R)        # u = -K @ (x - x_ref)
 ```
 
   </TabItem>
-  <TabItem value="distributed" label="Distributed Simulation">
+  <TabItem value="distributed" label="Real-Time Simulation">
 
 ```python
 import numpy as np
 from synapsys.api import ss, c2d
-from synapsys.agents import PlantAgent, ControllerAgent, SyncEngine, SyncMode
+from synapsys.agents import PlantAgent, ControllerAgent, SyncEngine
 from synapsys.broker import MessageBroker, Topic, SharedMemoryBackend
+from synapsys.algorithms import PID
 
-# Discretise the plant
-plant_d = c2d(ss([[-1]], [[1]], [[1]], [[0]]), dt=0.01)
+DT = 0.01
+plant_d = c2d(ss([[-1]], [[1]], [[1]], [[0]]), dt=DT)
+pid = PID(Kp=3.0, Ki=0.5, dt=DT)
 
-# Single broker — declare topics, add backend
 topic_y = Topic("plant/y", shape=(1,))
 topic_u = Topic("plant/u", shape=(1,))
 
@@ -83,12 +89,47 @@ broker.add_backend(SharedMemoryBackend("ctrl_bus", [topic_y, topic_u], create=Tr
 broker.publish("plant/y", np.zeros(1))
 broker.publish("plant/u", np.zeros(1))
 
-# Agents share the same broker — no multiple transport handles needed
-agent = PlantAgent(
-    "plant", plant_d, None, SyncEngine(),
+plant = PlantAgent("plant", plant_d, None, SyncEngine(dt=DT),
+                   channel_y="plant/y", channel_u="plant/u", broker=broker)
+ctrl  = ControllerAgent(
+    "ctrl", lambda y: np.array([pid.compute(5.0, y[0])]),
+    None, SyncEngine(dt=DT),
     channel_y="plant/y", channel_u="plant/u", broker=broker,
 )
-agent.start()   # non-blocking background thread
+plant.start(blocking=False)
+ctrl.start(blocking=True)
+```
+
+  </TabItem>
+  <TabItem value="ai" label="AI Integration">
+
+```python
+import torch, torch.nn as nn, numpy as np
+from synapsys.agents import ControllerAgent, SyncEngine
+from synapsys.broker import MessageBroker, Topic, SharedMemoryBackend
+
+# Pre-trained neural controller (PyTorch)
+model = torch.load("neural_lqr.pth")
+model.eval()
+
+def ai_control_law(y: np.ndarray) -> np.ndarray:
+    with torch.no_grad():
+        u = model(torch.tensor(y, dtype=torch.float32))
+    return u.numpy()
+
+topic_y = Topic("plant/y", shape=(4,))
+topic_u = Topic("plant/u", shape=(1,))
+
+broker = MessageBroker()
+broker.declare_topic(topic_y)
+broker.declare_topic(topic_u)
+broker.add_backend(SharedMemoryBackend("ctrl_bus", [topic_y, topic_u], create=False))
+
+ctrl = ControllerAgent(
+    "ai_ctrl", ai_control_law, None, SyncEngine(dt=0.01),
+    channel_y="plant/y", channel_u="plant/u", broker=broker,
+)
+ctrl.start(blocking=True)
 ```
 
   </TabItem>

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -64,18 +64,30 @@ K, P = lqr(A, B, Q, R)
   <TabItem value="distributed" label="Distributed Simulation">
 
 ```python
+import numpy as np
 from synapsys.api import ss, c2d
 from synapsys.agents import PlantAgent, ControllerAgent, SyncEngine, SyncMode
-from synapsys.transport import SharedMemoryTransport
+from synapsys.broker import MessageBroker, Topic, SharedMemoryBackend
 
 # Discretise the plant
 plant_d = c2d(ss([[-1]], [[1]], [[1]], [[0]]), dt=0.01)
 
-# Each process gets its own transport handle to the same bus
-bus = SharedMemoryTransport("ctrl_bus", {"y": 1, "u": 1}, create=True)
-t_plant = SharedMemoryTransport("ctrl_bus", {"y": 1, "u": 1})
+# Single broker — declare topics, add backend
+topic_y = Topic("plant/y", shape=(1,))
+topic_u = Topic("plant/u", shape=(1,))
 
-agent = PlantAgent("plant", plant_d, t_plant, SyncEngine())
+broker = MessageBroker()
+broker.declare_topic(topic_y)
+broker.declare_topic(topic_u)
+broker.add_backend(SharedMemoryBackend("ctrl_bus", [topic_y, topic_u], create=True))
+broker.publish("plant/y", np.zeros(1))
+broker.publish("plant/u", np.zeros(1))
+
+# Agents share the same broker — no multiple transport handles needed
+agent = PlantAgent(
+    "plant", plant_d, None, SyncEngine(),
+    channel_y="plant/y", channel_u="plant/u", broker=broker,
+)
 agent.start()   # non-blocking background thread
 ```
 
@@ -124,6 +136,7 @@ Synapsys is under active development. The API may change between versions.
 | `synapsys.core` — LTI, StateSpace, TransferFunction | Stable |
 | `synapsys.algorithms` — PID, LQR | Stable |
 | `synapsys.agents` — PlantAgent, ControllerAgent | Functional |
+| `synapsys.broker` — MessageBroker, Topic, backends | Functional |
 | `synapsys.transport` — SharedMemory, ZMQ | Functional |
 | `synapsys.api` — MATLAB-compat layer | Stable |
 | `synapsys.hw` — Hardware abstraction | Interface only |

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -135,9 +135,9 @@ Synapsys is under active development. The API may change between versions.
 |--------|--------|
 | `synapsys.core` — LTI, StateSpace, TransferFunction | Stable |
 | `synapsys.algorithms` — PID, LQR | Stable |
-| `synapsys.agents` — PlantAgent, ControllerAgent | Functional |
-| `synapsys.broker` — MessageBroker, Topic, backends | Functional |
-| `synapsys.transport` — SharedMemory, ZMQ | Functional |
+| `synapsys.broker` — MessageBroker, Topic, SharedMemoryBackend, ZMQBrokerBackend | Stable |
+| `synapsys.agents` — PlantAgent, ControllerAgent, HardwareAgent | Functional |
+| `synapsys.transport` — SharedMemory, ZMQ (low-level) | Functional |
 | `synapsys.api` — MATLAB-compat layer | Stable |
 | `synapsys.hw` — Hardware abstraction | Interface only |
 | MPC, adaptive control | Planned |

--- a/website/docs/roadmap.md
+++ b/website/docs/roadmap.md
@@ -6,7 +6,7 @@ sidebar_position: 99
 
 # Roadmap
 
-## Current state — v0.2.1
+## Current state — v0.2.2
 
 The library is complete and tested (222 tests, Python 3.10–3.12, 90 % coverage).
 

--- a/website/docs/roadmap.md
+++ b/website/docs/roadmap.md
@@ -6,15 +6,16 @@ sidebar_position: 99
 
 # Roadmap
 
-## Current state — v0.2.0
+## Current state — v0.2.1
 
-The library is complete and tested (184 tests, Python 3.10–3.12, 90 % coverage).
+The library is complete and tested (222 tests, Python 3.10–3.12, 90 % coverage).
 
 | Module | Status |
 |--------|--------|
 | `synapsys.core` — TransferFunction, StateSpace, TransferFunctionMatrix (continuous + discrete) | Done |
 | `synapsys.algorithms` — PID (anti-windup), LQR (Q/R validated) | Done |
-| `synapsys.agents` — PlantAgent, ControllerAgent, FIPA ACL, SyncEngine | Done |
+| `synapsys.agents` — PlantAgent, ControllerAgent, HardwareAgent, FIPA ACL, SyncEngine | Done |
+| `synapsys.broker` — MessageBroker, Topic, SharedMemoryBackend, ZMQBrokerBackend | Done |
 | `synapsys.transport` — SharedMemory (zero-copy), ZMQ (PUB/SUB, REQ/REP) | Done |
 | `synapsys.api` — tf(), ss(), c2d(), step(), bode(), feedback() (SISO + MIMO) | Done |
 | `synapsys.hw` — Interface defined, no concrete implementations yet | Pending |

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -57,6 +57,7 @@ const sidebars: SidebarsConfig = {
           label: 'Transport Layer',
           items: [
             'guide/transport/overview',
+            'guide/transport/broker',
             'guide/transport/shared-memory',
             'guide/transport/zmq',
           ],


### PR DESCRIPTION
## Summary

- Adds `synapsys.broker` — a central pub/sub routing layer that decouples agents from direct transport handles, enabling many-to-many communication topologies
- `PlantAgent`, `ControllerAgent`, and `HardwareAgent` now accept a `broker=` keyword arg; `transport=` accepts `None` for broker-only setups (fully backward-compatible)
- All distributed examples and advanced examples migrated to the broker pattern
- All documentation updated to reflect the new API

## What's new

**`synapsys/broker/`**
- `Topic` — typed, shaped, hashable topic descriptor with array validation
- `BrokerBackend` ABC — `supports` / `write` / `read` / `close`
- `SharedMemoryBackend` — wraps `SharedMemoryTransport`
- `ZMQBrokerBackend` — PUB/SUB with background recv thread and ZOH cache
- `MessageBroker` — `declare_topic`, `add_backend`, `publish`, `read`, `subscribe`, `read_wait`, `close`

**Agent changes**
- `BaseAgent` gains `broker=` kwarg and `_read()` / `_write()` dispatch helpers
- All three concrete agents updated; `transport` positional arg kept for backward compatibility

**Tests**: 37 new tests in `tests/broker/` (topic, shared memory backend, ZMQ backend, broker unit, integration with real agents)

## Test plan

- [ ] `uv run pytest` — all 222 tests pass
- [ ] `examples/distributed/01_shared_memory/` — two-terminal shared memory demo
- [ ] `examples/advanced/05_digital_twin/` — wear-injection anomaly detection