### PR TITLE
fix(blog): align PT slugs so locale switcher works

### DIFF
--- a/website/i18n/pt/docusaurus-plugin-content-blog/2026-04-19-welcome/index.md
+++ b/website/i18n/pt/docusaurus-plugin-content-blog/2026-04-19-welcome/index.md
@@ -1,5 +1,5 @@
 ---
-slug: bem-vindo-ao-blog-synapsys
+slug: welcome-to-synapsys-blog
 title: "Bem-vindo ao Blog Synapsys"
 description: >
   Apresentando o Blog Synapsys — um espaço para tutoriais, insights de pesquisa

--- a/website/i18n/pt/docusaurus-plugin-content-blog/2026-04-20-inverted-pendulum-lqr/index.md
+++ b/website/i18n/pt/docusaurus-plugin-content-blog/2026-04-20-inverted-pendulum-lqr/index.md
@@ -1,5 +1,5 @@
 ---
-slug: pendulo-invertido-lqr
+slug: inverted-pendulum-lqr
 title: "Estabilizando um Pêndulo Invertido com LQR"
 description: >
   Um guia completo: derive o modelo linearizado em espaço de estados de um pêndulo

--- a/website/i18n/pt/docusaurus-plugin-content-blog/2026-04-21-quadcopter-mimo-neural-lqr/index.md
+++ b/website/i18n/pt/docusaurus-plugin-content-blog/2026-04-21-quadcopter-mimo-neural-lqr/index.md
@@ -1,5 +1,5 @@
 ---
-slug: quadrotor-mimo-neural-lqr
+slug: quadcopter-mimo-neural-lqr
 title: "Controle MIMO de um Quadrotor com Neural-LQR"
 description: >
   Como modelar um quadrotor linearizado de 12 estados, projetar um LQR MIMO,

--- a/website/i18n/pt/docusaurus-plugin-content-blog/2026-04-22-mil-sil-hil/index.md
+++ b/website/i18n/pt/docusaurus-plugin-content-blog/2026-04-22-mil-sil-hil/index.md
@@ -1,5 +1,5 @@
 ---
-slug: mil-sil-hil-deployment-controle
+slug: mil-sil-hil-control-deployment
 title: "Do Modelo ao Hardware: MIL → SIL → HIL em Três Etapas"
 description: >
   Um guia prático para o fluxo de desenvolvimento MIL/SIL/HIL com Synapsys —

--- a/website/i18n/pt/docusaurus-plugin-content-blog/2026-04-23-pid-antiwindup-research/index.md
+++ b/website/i18n/pt/docusaurus-plugin-content-blog/2026-04-23-pid-antiwindup-research/index.md
@@ -1,5 +1,5 @@
 ---
-slug: pid-anti-windup-pesquisa
+slug: pid-anti-windup-research
 title: "PID com Anti-Windup: Teoria, Ajuste e Validação Experimental"
 description: >
   Um deep-dive orientado à pesquisa sobre PID discreto com anti-windup por


### PR DESCRIPTION
PT blog post slugs were different from EN, causing 404 when switching locale. Aligned all 5 slugs to match EN.