### PR TITLE
feat(release): v0.2.1 — quadcopter MIMO, PT website fixes, author profile

### DIFF
--- a/website/blog/authors.yml
+++ b/website/blog/authors.yml
@@ -6,6 +6,14 @@ oseias:
   page: true
   socials:
     github: Oseiasdfarias
+    linkedin: oseiasfarias
+  links:
+    - label: Portfolio
+      href: https://oseiasdfarias.github.io
+    - label: ORCID
+      href: https://orcid.org/0009-0005-4960-0271
+    - label: Lattes
+      href: http://lattes.cnpq.br/2199717385351494
 
 synapsys:
   name: Synapsys Team

--- a/website/i18n/pt/docusaurus-plugin-content-blog/2026-04-20-inverted-pendulum-lqr/index.md
+++ b/website/i18n/pt/docusaurus-plugin-content-blog/2026-04-20-inverted-pendulum-lqr/index.md
@@ -1,4 +1,5 @@
 ---
+format: md
 slug: inverted-pendulum-lqr
 title: "Estabilizando um Pêndulo Invertido com LQR"
 description: >
@@ -10,15 +11,13 @@ tags: [tutorial, lqr, control-theory, simulation, python]
 hide_table_of_contents: false
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 O pêndulo invertido é o benchmark canônico do controle não-linear — instável, simples
 o suficiente para modelar analiticamente, mas rico o suficiente para revelar todo o
 fluxo de projeto LQR. Este post deriva o modelo linearizado a partir da física e mostra
 como estabilizá-lo com Synapsys em poucas dezenas de linhas de Python.
 
-{/* truncate */}
+<!-- truncate -->
 
 ## Física e linearização
 

--- a/website/i18n/pt/docusaurus-plugin-content-blog/2026-04-21-quadcopter-mimo-neural-lqr/index.md
+++ b/website/i18n/pt/docusaurus-plugin-content-blog/2026-04-21-quadcopter-mimo-neural-lqr/index.md
@@ -1,4 +1,5 @@
 ---
+format: md
 slug: quadcopter-mimo-neural-lqr
 title: "Controle MIMO de um Quadrotor com Neural-LQR"
 description: >
@@ -10,8 +11,6 @@ tags: [research, mimo, lqr, neural-lqr, simulation, python]
 hide_table_of_contents: false
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 <div align="center">
 
@@ -24,7 +23,7 @@ rotacional totalmente acoplada — é o benchmark MIMO da robótica aérea. Este
 percorre o pipeline completo de projeto: física → linearização → LQR → residual
 Neural-LQR → simulação 3D.
 
-{/* truncate */}
+<!-- truncate -->
 
 ## Modelo em espaço de estados
 

--- a/website/i18n/pt/docusaurus-plugin-content-docs/current/examples/advanced/custom-signals.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/current/examples/advanced/custom-signals.md
@@ -1,4 +1,5 @@
 ---
+format: md
 id: custom-signals
 title: Custom Signal Injection
 sidebar_position: 1

--- a/website/i18n/pt/docusaurus-plugin-content-docs/current/examples/advanced/digital-twin.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/current/examples/advanced/digital-twin.md
@@ -1,4 +1,5 @@
 ---
+format: md
 id: digital-twin
 title: Digital Twin
 sidebar_position: 5

--- a/website/i18n/pt/docusaurus-plugin-content-docs/current/examples/advanced/quadcopter-mimo.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/current/examples/advanced/quadcopter-mimo.md
@@ -1,4 +1,5 @@
 ---
+format: md
 id: quadcopter-mimo
 title: Quadricóptero MIMO Neural-LQR 3D
 sidebar_position: 6

--- a/website/i18n/pt/docusaurus-plugin-content-docs/current/examples/advanced/sil-ai-controller.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/current/examples/advanced/sil-ai-controller.md
@@ -1,4 +1,5 @@
 ---
+format: md
 id: sil-ai-controller
 title: SIL + Neural-LQR Controller
 sidebar_position: 2

--- a/website/i18n/pt/docusaurus-plugin-content-docs/current/examples/basic/step-response.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/current/examples/basic/step-response.md
@@ -1,4 +1,5 @@
 ---
+format: md
 id: step-response
 title: Step Response
 sidebar_position: 1

--- a/website/i18n/pt/docusaurus-plugin-content-docs/current/guide/algorithms/pid.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/current/guide/algorithms/pid.md
@@ -1,4 +1,5 @@
 ---
+format: md
 id: pid
 title: Controlador PID
 sidebar_position: 1

--- a/website/i18n/pt/docusaurus-plugin-content-docs/current/guide/utils/matrix-builders.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/current/guide/utils/matrix-builders.md
@@ -1,4 +1,5 @@
 ---
+format: md
 id: matrix-builders
 title: Matrix Builders
 sidebar_position: 1


### PR DESCRIPTION
## Summary

- Quadcopter MIMO Neural-LQR 3D example with PyVista visualization
- Fix MDX math compilation errors in 8 PT locale files (`format: md` frontmatter)
- Add LinkedIn, ORCID, Lattes and Portfolio links to author profile
- Full EN+PT Docusaurus build passes with `onBrokenLinks: throw`

## Test plan

- [x] `npm run build` (all locales) passes with no broken-link errors
- [x] PT locale math blocks render correctly in browser
- [x] Author social links visible on blog author page
- [x] Quadcopter example runs end-to-end with `uv run`