### PR TITLE
feat(simulators): failure detection, linearised CartPole, PlantAgent+Sim, CartPole2DView, camera presets, trajectory trail

### DIFF
--- a/synapsys/agents/plant_agent.py
+++ b/synapsys/agents/plant_agent.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 import numpy as np
 
 from ..core.state_space import StateSpace
+from ..simulators.base import SimulatorBase
 from ..transport.base import TransportStrategy
 from .lifecycle import BaseAgent
 from .sync_engine import SyncEngine
@@ -12,75 +13,97 @@ from .sync_engine import SyncEngine
 if TYPE_CHECKING:
     from ..broker.broker import MessageBroker
 
+_Plant = Union[StateSpace, SimulatorBase]
+
 
 class PlantAgent(BaseAgent):
-    """
-    Agent that simulates a discrete-time StateSpace plant in real-time.
+    """Agent that simulates a plant in real-time.
+
+    Accepts either:
+
+    * A **discrete** ``StateSpace`` (legacy path) — use ``c2d()`` to discretise first.
+    * A ``SimulatorBase`` (nonlinear continuous simulator) — pass ``dt`` so the agent
+      knows the integration step to use on each tick.
 
     Each tick:
         1. Read ``u`` from transport.
-        2. Compute  x(k+1) = A·x(k) + B·u(k),  y(k) = C·x(k) + D·u(k)
+        2. Advance the plant by one step.
         3. Write ``y`` to transport.
 
-    The plant must be discrete (``plant.is_discrete == True``).
-    Use ``c2d()`` to discretise a continuous model before passing it here.
+    Example (StateSpace)::
 
-    Example::
-
-        from synapsys.api import ss, c2d
-        from synapsys.agents import PlantAgent, SyncEngine, SyncMode
-        from synapsys.transport import SharedMemoryTransport
-
-        plant_c = ss([[-1]], [[1]], [[1]], [[0]])   # G(s) = 1/(s+1)
-        plant_d = c2d(plant_c, dt=0.05)
-
-        transport = SharedMemoryTransport("bus", {"y": 1, "u": 1}, create=True)
-        sync = SyncEngine(SyncMode.WALL_CLOCK, dt=0.05)
+        plant_d = c2d(ss([[-1]], [[1]], [[1]], [[0]]), dt=0.05)
         agent = PlantAgent("plant", plant_d, transport, sync)
-        agent.start()
+
+    Example (SimulatorBase)::
+
+        sim = MassSpringDamperSim(m=1.0, c=0.5, k=2.0)
+        agent = PlantAgent("plant", sim, transport, sync, dt=0.01)
     """
 
     def __init__(
         self,
         name: str,
-        plant: StateSpace,
+        plant: _Plant,
         transport: TransportStrategy | None,
         sync: SyncEngine,
         channel_y: str = "y",
         channel_u: str = "u",
         x0: np.ndarray | None = None,
+        dt: float | None = None,
         *,
         broker: "MessageBroker | None" = None,
     ):
-        if not plant.is_discrete:
-            raise ValueError(
-                "PlantAgent requires a discrete plant (dt > 0). "
-                "Discretise it with c2d() first."
-            )
         super().__init__(name, transport, sync, broker=broker)
-        self._plant = plant
         self._ch_y = channel_y
         self._ch_u = channel_u
-        n = plant.n_states
-        if x0 is None:
-            self._x: np.ndarray = np.zeros(n)
+
+        if isinstance(plant, SimulatorBase):
+            self._sim: SimulatorBase | None = plant
+            self._plant: StateSpace | None = None
+            if dt is None:
+                raise ValueError("dt is required when plant is a SimulatorBase.")
+            self._dt = float(dt)
+            self._sim.reset(**({"x0": x0} if x0 is not None else {}))
         else:
-            x0_arr = np.asarray(x0, dtype=np.float64).flatten()
-            if x0_arr.size != n:
+            self._sim = None
+            self._plant = plant
+            self._dt = plant.dt
+            if not plant.is_discrete:
                 raise ValueError(
-                    f"x0 must have {n} element(s) to match plant.n_states, "
-                    f"got {x0_arr.size}"
+                    "PlantAgent requires a discrete plant (dt > 0). "
+                    "Discretise it with c2d() first."
                 )
-            self._x = x0_arr
+            n = plant.n_states
+            if x0 is None:
+                self._x: np.ndarray = np.zeros(n)
+            else:
+                x0_arr = np.asarray(x0, dtype=np.float64).flatten()
+                if x0_arr.size != n:
+                    raise ValueError(
+                        f"x0 must have {n} element(s) to match plant.n_states, "
+                        f"got {x0_arr.size}"
+                    )
+                self._x = x0_arr
 
     def setup(self) -> None:
-        u0 = np.zeros(self._plant.n_inputs)
-        _, y0 = self._plant.evolve(self._x, u0)
+        if self._sim is not None:
+            u0 = np.zeros(self._sim.input_dim)
+            y0, _ = self._sim.step(u0, self._dt)
+            self._sim.reset()
+        else:
+            assert self._plant is not None
+            u0 = np.zeros(self._plant.n_inputs)
+            _, y0 = self._plant.evolve(self._x, u0)
         self._write(self._ch_y, y0)
 
     def step(self) -> None:
         u = self._read(self._ch_u)
-        self._x, y = self._plant.evolve(self._x, u)
+        if self._sim is not None:
+            y, _ = self._sim.step(u, self._dt)
+        else:
+            assert self._plant is not None
+            self._x, y = self._plant.evolve(self._x, u)
         self._write(self._ch_y, y)
 
     def teardown(self) -> None:

--- a/synapsys/simulators/base.py
+++ b/synapsys/simulators/base.py
@@ -110,7 +110,15 @@ class SimulatorBase(ABC):
             if self._noise_std > 0.0:
                 y = y + np.random.normal(0.0, self._noise_std, y.shape)
 
-        return y, {"x": self._x.copy(), "t_step": dt}
+        return y, {"x": self._x.copy(), "t_step": dt, "failed": self.failed(self._x)}
+
+    def failed(self, x: ndarray) -> bool:
+        """Return True when the simulator has reached a terminal failure state.
+
+        Override in subclasses that have well-defined failure conditions
+        (e.g. pole fallen, cart out of bounds). Default: always False.
+        """
+        return False
 
     def linearize(self, x0: ndarray, u0: ndarray) -> StateSpace:
         """Numerical linearization around equilibrium (x0, u0).

--- a/synapsys/simulators/cartpole.py
+++ b/synapsys/simulators/cartpole.py
@@ -63,15 +63,21 @@ class CartPoleSim(SimulatorBase):
         integrator: Literal["euler", "rk4", "rk45"] = "rk4",
         noise_std: float = 0.0,
         disturbance_std: float = 0.0,
+        linearised: bool = False,
     ) -> None:
         self._m_c = float(m_c)
         self._m_p = float(m_p)
         self._l = float(l)
         self._g = float(g)
+        self._linearised = bool(linearised)
         self._params_lock = threading.Lock()
         super().__init__(
             integrator=integrator, noise_std=noise_std, disturbance_std=disturbance_std
         )
+
+    @property
+    def linearised(self) -> bool:
+        return self._linearised
 
     # ------------------------------------------------------------------
     # Abstract properties
@@ -100,6 +106,12 @@ class CartPoleSim(SimulatorBase):
         _, p_dot, theta, theta_dot = x
         F = u[0]
 
+        if self._linearised:
+            # Linearised around (θ=0, ṗ=0, θ̇=0, F=0)
+            p_ddot = F / m_c - m_p * g * theta / m_c
+            theta_ddot = (m_c + m_p) * g * theta / (m_c * l) - F / (m_c * l)
+            return np.array([p_dot, p_ddot, theta_dot, theta_ddot])
+
         sin_t = np.sin(theta)
         cos_t = np.cos(theta)
         delta = m_c + m_p * sin_t**2
@@ -111,6 +123,10 @@ class CartPoleSim(SimulatorBase):
 
     def output(self, x: ndarray) -> ndarray:
         return np.array([x[0], x[2]])
+
+    def failed(self, x: ndarray) -> bool:
+        p, _, theta, _ = x
+        return bool(abs(p) > 4.8 or abs(theta) > np.pi / 3)
 
     def reset(self, x0: ndarray | None = None, **kwargs: Any) -> ndarray:
         if x0 is not None:

--- a/synapsys/simulators/inverted_pendulum.py
+++ b/synapsys/simulators/inverted_pendulum.py
@@ -106,6 +106,9 @@ class InvertedPendulumSim(SimulatorBase):
     def output(self, x: ndarray) -> ndarray:
         return np.array([x[0]])
 
+    def failed(self, x: ndarray) -> bool:
+        return bool(abs(x[0]) > np.pi / 2)
+
     def reset(self, x0: ndarray | None = None, **kwargs: Any) -> ndarray:
         if x0 is not None:
             self._x = np.asarray(x0, dtype=float).ravel()

--- a/synapsys/viz/__init__.py
+++ b/synapsys/viz/__init__.py
@@ -1,11 +1,13 @@
 """synapsys.viz — Utilities for real-time and static visualisation."""
 
+from .cartpole2d import CartPole2DView
 from .palette import Dark, mpl_theme
 from .simview import CartPoleView, MassSpringDamperView, PendulumView
 
 __all__ = [
     "Dark",
     "mpl_theme",
+    "CartPole2DView",
     "CartPoleView",
     "PendulumView",
     "MassSpringDamperView",

--- a/synapsys/viz/__init__.py
+++ b/synapsys/viz/__init__.py
@@ -2,13 +2,23 @@
 
 from .cartpole2d import CartPole2DView
 from .palette import Dark, mpl_theme
-from .simview import CartPoleView, MassSpringDamperView, PendulumView
 
-__all__ = [
-    "Dark",
-    "mpl_theme",
-    "CartPole2DView",
-    "CartPoleView",
-    "PendulumView",
-    "MassSpringDamperView",
-]
+# SimView classes depend on Qt/PyVista — import lazily so that
+# CartPole2DView (pure matplotlib) remains importable on headless environments.
+try:
+    from .simview import CartPoleView, MassSpringDamperView, PendulumView
+
+    __all__ = [
+        "Dark",
+        "mpl_theme",
+        "CartPole2DView",
+        "CartPoleView",
+        "PendulumView",
+        "MassSpringDamperView",
+    ]
+except ImportError:
+    __all__ = [
+        "Dark",
+        "mpl_theme",
+        "CartPole2DView",
+    ]

--- a/synapsys/viz/cartpole2d.py
+++ b/synapsys/viz/cartpole2d.py
@@ -1,0 +1,178 @@
+"""CartPole2DView — lightweight 2-D matplotlib animation for CartPoleSim."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import matplotlib.patches as patches
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.animation import FuncAnimation
+from numpy import ndarray
+
+from synapsys.algorithms.lqr import lqr
+from synapsys.simulators import CartPoleSim
+
+_DEFAULT_X0 = np.array([0.0, 0.0, 0.15, 0.0])
+_DEFAULT_Q = np.diag([1.0, 0.1, 100.0, 10.0])
+_DEFAULT_R = np.eye(1) * 0.01
+_U_CLIP = 50.0
+
+
+class CartPole2DView:
+    """2D matplotlib animation of CartPoleSim with pluggable controller.
+
+    Parameters
+    ----------
+    sim:
+        CartPoleSim instance.  A default one is created if not supplied.
+    controller:
+        Callable ``(x: ndarray) -> ndarray`` returning the control force.
+        If *None*, an LQR gain is designed automatically.
+    dt:
+        Integration / animation step (seconds).
+    duration:
+        Total simulation time (seconds).
+    x0:
+        Initial state ``[p, ṗ, θ, θ̇]``.  Defaults to ``[0, 0, 0.15, 0]``.
+
+    Usage::
+
+        CartPole2DView().simulate()          # run and return history dict
+        CartPole2DView().animate()           # build animation object
+        CartPole2DView().run()               # simulate → animate → plt.show()
+    """
+
+    def __init__(
+        self,
+        sim: CartPoleSim | None = None,
+        controller: Callable | None = None,
+        dt: float = 0.02,
+        duration: float = 10.0,
+        x0: ndarray | None = None,
+    ) -> None:
+        self._sim = sim if sim is not None else CartPoleSim()
+        self.controller = controller
+        self.dt = float(dt)
+        self.duration = float(duration)
+        self.x0 = np.array(x0 if x0 is not None else _DEFAULT_X0, dtype=float)
+        self.history: dict | None = None
+
+        if controller is None:
+            self._sim.reset()
+            ss = self._sim.linearize(np.zeros(4), np.zeros(1))
+            K, _ = lqr(ss.A, ss.B, _DEFAULT_Q, _DEFAULT_R)
+            self._K = K
+        else:
+            self._K = None
+
+    def _control(self, x: ndarray) -> ndarray:
+        if self.controller is not None:
+            return np.asarray(self.controller(x), dtype=float).ravel()
+        return np.clip(-self._K @ x, -_U_CLIP, _U_CLIP).ravel()
+
+    # ── public API ────────────────────────────────────────────────────────────
+
+    def simulate(self) -> dict:
+        """Run the simulation and return a history dict.
+
+        Returns
+        -------
+        dict with keys ``t``, ``pos``, ``angle``, ``force``, ``states``.
+        All values are 1-D arrays of length ``steps = int(duration / dt)``.
+        """
+        steps = int(self.duration / self.dt)
+        self._sim.reset(x0=self.x0)
+
+        t_arr = np.empty(steps)
+        pos_arr = np.empty(steps)
+        angle_arr = np.empty(steps)
+        force_arr = np.empty(steps)
+        states = np.empty((steps, 4))
+
+        for i in range(steps):
+            x = self._sim.state
+            u = self._control(x)
+            self._sim.step(u, self.dt)
+            t_arr[i] = i * self.dt
+            pos_arr[i] = x[0]
+            angle_arr[i] = x[2]
+            force_arr[i] = u[0]
+            states[i] = x
+
+        self.history = {
+            "t": t_arr,
+            "pos": pos_arr,
+            "angle": angle_arr,
+            "force": force_arr,
+            "states": states,
+        }
+        return self.history
+
+    def animate(self, save: str | None = None) -> FuncAnimation:
+        """Build and return a :class:`~matplotlib.animation.FuncAnimation`.
+
+        Parameters
+        ----------
+        save:
+            If given, save the animation to this path (e.g. ``"out.gif"``).
+            Requires *Pillow* for GIFs or *ffmpeg* for MP4.
+
+        Returns the ``FuncAnimation`` object (call ``plt.show()`` separately
+        or use :meth:`run` for an all-in-one entry point).
+        """
+        if self.history is None:
+            self.simulate()
+
+        hist = self.history
+        states = hist["states"]
+        t_arr = hist["t"]
+        l = self._sim._l  # pole length
+
+        fig, ax = plt.subplots(figsize=(9, 4))
+        ax.set_xlim(-3, 3)
+        ax.set_ylim(-0.3, 1.2)
+        ax.set_aspect("equal")
+        ax.grid(True, alpha=0.3)
+        ax.axhline(0, color="k", lw=1)
+        ax.set_title("Cart-Pole Animation")
+
+        cart_w, cart_h = 0.4, 0.15
+        cart_patch = patches.FancyBboxPatch(
+            (-cart_w / 2, -cart_h / 2),
+            cart_w,
+            cart_h,
+            boxstyle="round,pad=0.02",
+            fc="#2563eb",
+            ec="white",
+            lw=1.5,
+        )
+        ax.add_patch(cart_patch)
+        (pole_line,) = ax.plot([], [], "o-", color="#c8a870", lw=3, ms=10)
+        time_text = ax.text(0.02, 0.92, "", transform=ax.transAxes, fontsize=10)
+
+        def _update(frame):
+            p, theta = states[frame, 0], states[frame, 2]
+            cart_patch.set_x(p - cart_w / 2)
+            tip_x = p + l * np.sin(theta)
+            tip_y = l * np.cos(theta)
+            pole_line.set_data([p, tip_x], [0, tip_y])
+            time_text.set_text(
+                f"t = {t_arr[frame]:.2f} s   θ = {np.degrees(theta):.1f}°"
+            )
+            return cart_patch, pole_line, time_text
+
+        anim = FuncAnimation(
+            fig, _update, frames=len(states), interval=self.dt * 1000, blit=True
+        )
+
+        if save is not None:
+            anim.save(save)
+
+        return anim
+
+    def run(self) -> None:
+        """Simulate, build animation, and call ``plt.show()``."""
+        self.simulate()
+        self.animate()
+        plt.show()

--- a/synapsys/viz/simview/_base.py
+++ b/synapsys/viz/simview/_base.py
@@ -41,6 +41,14 @@ from synapsys.algorithms.lqr import lqr
 from synapsys.simulators import SimulatorBase
 from synapsys.viz.palette import Dark
 
+# ── camera presets ─────────────────────────────────────────────────────────────
+CAMERA_PRESETS: dict[str, tuple] = {
+    "iso": ((5, -5, 3), (0, 0, 0.4), (0, 0, 1)),
+    "top": ((0, 0, 8), (0, 0, 0), (0, 1, 0)),
+    "side": ((0, -7, 1.5), (0, 0, 0.5), (0, 0, 1)),
+    "follow": ((0, -5.5, 1.2), (0, 0, 0.4), (0, 0, 1)),
+}
+
 
 class SimViewBase(QMainWindow):
     """Unified 3D PyVista + matplotlib sim window with pluggable controller.
@@ -94,6 +102,10 @@ class SimViewBase(QMainWindow):
         self._status_lbl: QLabel | None = None
         self._hud = None
         self._ctrl_label: str = "LQR (auto)"
+        # ── trail state ──────────────────────────────────────────────────────
+        self._trail_enabled: bool = False
+        self._trail_max_pts: int = 200
+        self._trail_positions: list = []
 
     # ── public entry point ────────────────────────────────────────────────────
 
@@ -455,6 +467,39 @@ class SimViewBase(QMainWindow):
     def handle_key_release(self, key: int) -> None:
         if key in (Qt.Key_A, Qt.Key_D):
             self._set_pert(0.0)
+
+    # ── camera presets ────────────────────────────────────────────────────────
+
+    def set_camera_preset(self, name: str) -> None:
+        """Switch the camera to a named preset.
+
+        Parameters
+        ----------
+        name:
+            One of ``'iso'``, ``'top'``, ``'side'``, ``'follow'``.
+
+        Raises
+        ------
+        KeyError
+            If *name* is not in :data:`CAMERA_PRESETS`.
+        """
+        self._cam_pos = CAMERA_PRESETS[name]
+        if hasattr(self, "_pl") and self._pl is not None:
+            self._pl.camera_position = self._cam_pos
+
+    # ── trajectory trail ──────────────────────────────────────────────────────
+
+    def toggle_trail(self) -> None:
+        """Toggle trajectory trail rendering on/off."""
+        self._trail_enabled = not self._trail_enabled
+        if not self._trail_enabled:
+            self._trail_positions.clear()
+
+    def _append_trail_position(self, point: np.ndarray) -> None:
+        """Append *point* (3-D) to the trail buffer, respecting max length."""
+        self._trail_positions.append(point.copy())
+        if len(self._trail_positions) > self._trail_max_pts:
+            self._trail_positions.pop(0)
 
     def closeEvent(self, event) -> None:
         self._timer.stop()

--- a/tests/agents/test_agents.py
+++ b/tests/agents/test_agents.py
@@ -309,3 +309,65 @@ class TestPlantAgentX0Valid:
         sync = SyncEngine(SyncMode.LOCK_STEP, dt=0.01)
         agent = PlantAgent("p", plant_d, None, sync, x0=np.array([0.5]))
         np.testing.assert_allclose(agent._x, [0.5])
+
+
+# ── PlantAgent + SimulatorBase ────────────────────────────────────────────────
+
+
+class TestPlantAgentSimulator:
+    def _make_bus(self):
+        from synapsys.transport import SharedMemoryTransport
+
+        return SharedMemoryTransport("test_sim_agent", {"y": 1, "u": 1}, create=True)
+
+    def test_plant_agent_accepts_simulator_base(self):
+        from synapsys.agents import PlantAgent, SyncEngine, SyncMode
+        from synapsys.simulators import MassSpringDamperSim
+
+        sim = MassSpringDamperSim()
+        sync = SyncEngine(SyncMode.LOCK_STEP, dt=0.01)
+        agent = PlantAgent("plant", sim, None, sync, dt=0.01)
+        assert agent is not None
+
+    def test_plant_agent_simulator_setup_writes_initial_y(self):
+        from synapsys.agents import PlantAgent, SyncEngine, SyncMode
+        from synapsys.simulators import MassSpringDamperSim
+
+        sim = MassSpringDamperSim()
+        sync = SyncEngine(SyncMode.LOCK_STEP, dt=0.01)
+        bus = self._make_bus()
+        try:
+            bus.write("u", np.zeros(1))
+            agent = PlantAgent("plant", sim, bus, sync, dt=0.01)
+            agent.setup()
+            y = bus.read("y")
+            assert y.shape == (1,)
+        finally:
+            bus.close()
+
+    def test_plant_agent_simulator_step_advances_state(self):
+        from synapsys.agents import PlantAgent, SyncEngine, SyncMode
+        from synapsys.simulators import MassSpringDamperSim
+
+        sim = MassSpringDamperSim()
+        sync = SyncEngine(SyncMode.LOCK_STEP, dt=0.01)
+        bus = self._make_bus()
+        try:
+            bus.write("u", np.array([1.0]))
+            agent = PlantAgent("plant", sim, bus, sync, dt=0.01)
+            agent.setup()
+            agent.step()
+            y = bus.read("y")
+            assert y.shape == (1,)
+        finally:
+            bus.close()
+
+    def test_plant_agent_simulator_requires_dt(self):
+        """dt=None raises ValueError when plant is a SimulatorBase."""
+        from synapsys.agents import PlantAgent, SyncEngine, SyncMode
+        from synapsys.simulators import MassSpringDamperSim
+
+        sim = MassSpringDamperSim()
+        sync = SyncEngine(SyncMode.LOCK_STEP, dt=0.01)
+        with pytest.raises(ValueError, match="dt is required"):
+            PlantAgent("plant", sim, None, sync)

--- a/tests/simulators/test_cartpole.py
+++ b/tests/simulators/test_cartpole.py
@@ -268,3 +268,63 @@ class TestSetParams:
             t.join()
 
         assert errors == []
+
+
+# ── linearised mode ───────────────────────────────────────────────────────────
+
+
+class TestLinearisedMode:
+    def test_linearised_false_is_default(self):
+        sim = CartPoleSim()
+        assert sim.linearised is False
+
+    def test_linearised_true_constructor(self):
+        sim = CartPoleSim(linearised=True)
+        assert sim.linearised is True
+
+    def test_linearised_dynamics_matches_nonlinear_near_upright(self):
+        x0 = np.array([0.0, 0.0, 0.01, 0.0])
+        u0 = np.zeros(1)
+        sim_nl = CartPoleSim(linearised=False)
+        sim_l = CartPoleSim(linearised=True)
+        sim_nl.reset(x0=x0)
+        sim_l.reset(x0=x0)
+        y_nl, _ = sim_nl.step(u0, dt=0.01)
+        y_l, _ = sim_l.step(u0, dt=0.01)
+        np.testing.assert_allclose(y_nl, y_l, atol=1e-4)
+
+    def test_linearised_dynamics_differs_from_nonlinear_at_large_angle(self):
+        x0 = np.array([0.0, 0.0, 0.5, 0.0])
+        u0 = np.zeros(1)
+        sim_nl = CartPoleSim(linearised=False)
+        sim_l = CartPoleSim(linearised=True)
+        sim_nl.reset(x0=x0)
+        sim_l.reset(x0=x0)
+        y_nl, _ = sim_nl.step(u0, dt=0.1)
+        y_l, _ = sim_l.step(u0, dt=0.1)
+        assert not np.allclose(y_nl, y_l, atol=1e-3)
+
+
+# ── failure detection ─────────────────────────────────────────────────────────
+
+
+class TestFailureDetection:
+    def test_info_contains_failed_key(self, sim):
+        _, info = sim.step(np.zeros(1), dt=0.01)
+        assert "failed" in info
+
+    def test_not_failed_when_pole_upright(self, sim):
+        _, info = sim.step(np.zeros(1), dt=0.01)
+        assert info["failed"] is False
+
+    def test_failed_when_pole_angle_exceeds_threshold(self):
+        sim = CartPoleSim()
+        sim.reset(x0=np.array([0.0, 0.0, 1.2, 0.0]))  # θ = 1.2 rad > π/3
+        _, info = sim.step(np.zeros(1), dt=0.01)
+        assert info["failed"] is True
+
+    def test_failed_when_cart_out_of_bounds(self):
+        sim = CartPoleSim()
+        sim.reset(x0=np.array([5.0, 0.0, 0.0, 0.0]))  # p = 5 m
+        _, info = sim.step(np.zeros(1), dt=0.01)
+        assert info["failed"] is True

--- a/tests/simulators/test_cartpole2d.py
+++ b/tests/simulators/test_cartpole2d.py
@@ -1,0 +1,109 @@
+"""Tests for CartPole2DView — 2D matplotlib animation.
+
+All tests use the Agg backend so no display is required.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import numpy as np
+import pytest
+
+from synapsys.viz.cartpole2d import CartPole2DView
+
+# ── Construction ──────────────────────────────────────────────────────────────
+
+
+class TestConstruction:
+    def test_default_instantiation(self):
+        view = CartPole2DView()
+        assert view is not None
+
+    def test_custom_dt_and_duration(self):
+        view = CartPole2DView(dt=0.01, duration=5.0)
+        assert view.dt == pytest.approx(0.01)
+        assert view.duration == pytest.approx(5.0)
+
+    def test_custom_x0(self):
+        x0 = np.array([0.0, 0.0, 0.2, 0.0])
+        view = CartPole2DView(x0=x0)
+        np.testing.assert_array_equal(view.x0, x0)
+
+    def test_custom_controller_stored(self):
+        ctrl = lambda x: np.zeros(1)
+        view = CartPole2DView(controller=ctrl)
+        assert view.controller is ctrl
+
+
+# ── simulate ──────────────────────────────────────────────────────────────────
+
+
+class TestSimulate:
+    def test_returns_history_dict(self):
+        view = CartPole2DView(dt=0.02, duration=0.1)
+        hist = view.simulate()
+        assert isinstance(hist, dict)
+
+    def test_history_has_expected_keys(self):
+        view = CartPole2DView(dt=0.02, duration=0.1)
+        hist = view.simulate()
+        assert "t" in hist
+        assert "pos" in hist
+        assert "angle" in hist
+        assert "force" in hist
+
+    def test_history_length_matches_steps(self):
+        dt, duration = 0.02, 0.2
+        view = CartPole2DView(dt=dt, duration=duration)
+        hist = view.simulate()
+        expected_steps = int(duration / dt)
+        assert len(hist["t"]) == expected_steps
+        assert len(hist["pos"]) == expected_steps
+        assert len(hist["angle"]) == expected_steps
+
+    def test_lqr_stabilises_pole(self):
+        """Default LQR controller must stabilise a small perturbation."""
+        x0 = np.array([0.0, 0.0, 0.15, 0.0])
+        view = CartPole2DView(dt=0.02, duration=5.0, x0=x0)
+        hist = view.simulate()
+        final_angle = hist["angle"][-1]
+        assert abs(final_angle) < 0.05  # nearly upright
+
+    def test_custom_controller_called(self):
+        calls = [0]
+
+        def counting_ctrl(x):
+            calls[0] += 1
+            return np.zeros(1)
+
+        view = CartPole2DView(dt=0.02, duration=0.1, controller=counting_ctrl)
+        view.simulate()
+        assert calls[0] > 0
+
+    def test_simulate_stores_history(self):
+        view = CartPole2DView(dt=0.02, duration=0.1)
+        hist = view.simulate()
+        assert view.history is hist
+
+
+# ── animate ───────────────────────────────────────────────────────────────────
+
+
+class TestAnimate:
+    def test_animate_returns_func_animation(self):
+        from matplotlib.animation import FuncAnimation
+
+        view = CartPole2DView(dt=0.02, duration=0.2)
+        view.simulate()
+        anim = view.animate()
+        assert isinstance(anim, FuncAnimation)
+
+    def test_animate_without_prior_simulate_calls_simulate(self):
+        from matplotlib.animation import FuncAnimation
+
+        view = CartPole2DView(dt=0.02, duration=0.1)
+        anim = view.animate()  # must not raise; triggers simulate() internally
+        assert isinstance(anim, FuncAnimation)

--- a/tests/simulators/test_inverted_pendulum.py
+++ b/tests/simulators/test_inverted_pendulum.py
@@ -291,3 +291,22 @@ class TestSetParams:
         for t in threads:
             t.join()
         assert errors == []
+
+
+# ── failure detection ─────────────────────────────────────────────────────────
+
+
+class TestFailureDetection:
+    def test_info_contains_failed_key(self, sim):
+        _, info = sim.step(np.zeros(1), dt=0.01)
+        assert "failed" in info
+
+    def test_not_failed_near_upright(self, sim):
+        _, info = sim.step(np.zeros(1), dt=0.01)
+        assert info["failed"] is False
+
+    def test_failed_when_angle_exceeds_threshold(self):
+        sim = InvertedPendulumSim()
+        sim.reset(x0=np.array([2.0, 0.0]))  # θ = 2.0 rad > π/2
+        _, info = sim.step(np.zeros(1), dt=0.01)
+        assert info["failed"] is True

--- a/tests/simulators/test_simview.py
+++ b/tests/simulators/test_simview.py
@@ -419,3 +419,83 @@ class TestCartPoleTrackLimits:
         v = CartPoleView()
         v._pert = 0.0
         assert np.allclose(v._pert_vector(), 0.0)
+
+
+# ── camera presets ─────────────────────────────────────────────────────────────
+
+
+class TestCameraPresets:
+    def test_camera_presets_dict_exists(self):
+        from synapsys.viz.simview._base import CAMERA_PRESETS
+
+        assert isinstance(CAMERA_PRESETS, dict)
+
+    def test_camera_presets_has_expected_keys(self):
+        from synapsys.viz.simview._base import CAMERA_PRESETS
+
+        for key in ("iso", "top", "side", "follow"):
+            assert key in CAMERA_PRESETS
+
+    def test_each_preset_is_three_tuple(self):
+        from synapsys.viz.simview._base import CAMERA_PRESETS
+
+        for name, preset in CAMERA_PRESETS.items():
+            assert len(preset) == 3, f"preset {name!r} must be a 3-tuple"
+
+    def test_set_camera_preset_updates_cam_pos(self):
+        v = CartPoleView()
+        v.set_camera_preset("top")
+        from synapsys.viz.simview._base import CAMERA_PRESETS
+
+        assert v._cam_pos == CAMERA_PRESETS["top"]
+
+    def test_set_camera_preset_iso(self):
+        v = CartPoleView()
+        v.set_camera_preset("iso")
+        from synapsys.viz.simview._base import CAMERA_PRESETS
+
+        assert v._cam_pos == CAMERA_PRESETS["iso"]
+
+    def test_set_camera_preset_unknown_raises(self):
+        v = CartPoleView()
+        with pytest.raises(KeyError):
+            v.set_camera_preset("nonexistent")
+
+
+# ── trajectory trail state ─────────────────────────────────────────────────────
+
+
+class TestTrailState:
+    def test_trail_disabled_by_default(self):
+        v = CartPoleView()
+        assert v._trail_enabled is False
+
+    def test_trail_max_pts_positive(self):
+        v = CartPoleView()
+        assert v._trail_max_pts > 0
+
+    def test_toggle_trail_enables(self):
+        v = CartPoleView()
+        v.toggle_trail()
+        assert v._trail_enabled is True
+
+    def test_toggle_trail_disables(self):
+        v = CartPoleView()
+        v._trail_enabled = True
+        v.toggle_trail()
+        assert v._trail_enabled is False
+
+    def test_trail_positions_empty_on_init(self):
+        v = CartPoleView()
+        assert len(v._trail_positions) == 0
+
+    def test_append_trail_position_stores_point(self):
+        v = CartPoleView()
+        v._append_trail_position(np.array([1.0, 0.0, 0.5]))
+        assert len(v._trail_positions) == 1
+
+    def test_trail_positions_respect_max_pts(self):
+        v = CartPoleView()
+        for i in range(v._trail_max_pts + 10):
+            v._append_trail_position(np.array([float(i), 0.0, 0.0]))
+        assert len(v._trail_positions) <= v._trail_max_pts

--- a/tests/simulators/test_simview.py
+++ b/tests/simulators/test_simview.py
@@ -15,6 +15,7 @@ import pytest
 pytest.importorskip(
     "matplotlib.backends.backend_qtagg",
     reason="Qt backend not available — skip SimView tests",
+    exc_type=ImportError,
 )
 
 from synapsys.algorithms.lqr import lqr

--- a/tests/simulators/test_simview_visual.py
+++ b/tests/simulators/test_simview_visual.py
@@ -15,6 +15,7 @@ import pytest
 pytest.importorskip(
     "PySide6.QtWidgets",
     reason="PySide6 / Qt not installed — skip visual SimView tests",
+    exc_type=ImportError,
 )
 
 from PySide6.QtWidgets import QMainWindow


### PR DESCRIPTION
## Summary

- **`info["failed"]`** — `SimulatorBase.step()` now includes a `failed` key via an overridable `failed(x)` hook; `CartPoleSim` triggers when `|p|>4.8m` or `|θ|>π/3`; `InvertedPendulumSim` triggers when `|θ|>π/2`
- **`linearised=True`** — `CartPoleSim` supports a linearised dynamics mode (Lagrangian → linear model around upright), toggled at construction
- **`PlantAgent` + `SimulatorBase`** — `PlantAgent` now accepts `Union[StateSpace, SimulatorBase]`; pass `dt=` when using a nonlinear simulator
- **`CartPole2DView`** — new lightweight matplotlib-only 2D animation class with auto-LQR, pluggable controller, `simulate()` / `animate(save=...)` / `run()` API
- **Camera presets** — `SimViewBase` gains `CAMERA_PRESETS` dict (`iso`/`top`/`side`/`follow`) and `set_camera_preset(name)` method
- **Trajectory trail** — `SimViewBase` gains `toggle_trail()`, `_append_trail_position()`, and `_trail_enabled`/`_trail_max_pts` state

## Test plan

- [ ] All 541 tests pass (`pytest` pre-commit hook green)
- [ ] 100% coverage enforced by pre-commit hook
- [ ] `mypy` strict passes
- [ ] `ruff` lint/format clean
- [ ] `CartPole2DView().simulate()` returns stabilising trajectory with default LQR
- [ ] `CartPole2DView(controller=...).simulate()` calls custom controller
- [ ] `PlantAgent("p", sim, None, sync, dt=0.01)` runs without error
- [ ] `set_camera_preset("top")` updates `_cam_pos` on any SimView instance
- [ ] `toggle_trail()` flips `_trail_enabled` and clears positions on disable