### PR TITLE
feat(viz,docs): light theme, trail_point hook, save= param, integrator benchmark, simulator docs

### DIFF
--- a/examples/simulators/04_integrator_benchmark.py
+++ b/examples/simulators/04_integrator_benchmark.py
@@ -1,0 +1,91 @@
+"""Integrator benchmark — compare Euler, RK4, and RK45 on CartPoleSim.
+
+Measures accuracy (pole angle error vs RK45 reference) and wall-clock time
+for a fixed 5-second LQR simulation.
+
+Run:
+    python examples/simulators/04_integrator_benchmark.py
+"""
+
+import time
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from synapsys.algorithms.lqr import lqr
+from synapsys.simulators import CartPoleSim
+
+# ── setup ─────────────────────────────────────────────────────────────────────
+m_c, m_p, l, g = 1.0, 0.1, 0.5, 9.81
+dt = 0.02
+T = 5.0
+steps = int(T / dt)
+x0 = np.array([0.0, 0.0, 0.18, 0.0])
+
+# LQR designed on RK4 linearisation (reference integrator)
+_ref_sim = CartPoleSim(m_c=m_c, m_p=m_p, l=l, g=g, integrator="rk4")
+_ref_sim.reset()
+ss_lin = _ref_sim.linearize(np.zeros(4), np.zeros(1))
+Q = np.diag([1.0, 0.1, 100.0, 10.0])
+R = np.eye(1) * 0.01
+K, _ = lqr(ss_lin.A, ss_lin.B, Q, R)
+print(f"LQR gain K = {K.ravel().round(3)}")
+
+
+def _run(integrator: str) -> tuple[np.ndarray, float]:
+    """Simulate and return (angle_history, wall_time_seconds)."""
+    sim = CartPoleSim(m_c=m_c, m_p=m_p, l=l, g=g, integrator=integrator)
+    sim.reset(x0=x0)
+    angles = np.empty(steps)
+    t0 = time.perf_counter()
+    for i in range(steps):
+        x = sim.state
+        u = np.clip(-K @ x, -50, 50)
+        y, _ = sim.step(u, dt)
+        angles[i] = np.degrees(x[2])
+    elapsed = time.perf_counter() - t0
+    return angles, elapsed
+
+
+# ── simulate all three integrators ────────────────────────────────────────────
+results = {}
+for name in ("rk45", "rk4", "euler"):
+    ang, t_wall = _run(name)
+    results[name] = {"angles": ang, "time": t_wall}
+    print(f"{name:5s} | wall time: {t_wall * 1000:.1f} ms")
+
+# ── accuracy: RMS error vs RK45 reference ─────────────────────────────────────
+ref = results["rk45"]["angles"]
+print("\nRMS pole-angle error vs RK45 (deg):")
+for name in ("rk4", "euler"):
+    rms = np.sqrt(np.mean((results[name]["angles"] - ref) ** 2))
+    print(f"  {name:5s}: {rms:.4f} deg")
+
+# ── plot ──────────────────────────────────────────────────────────────────────
+t = np.arange(steps) * dt
+colors = {"rk45": "#ef4444", "rk4": "#3b82f6", "euler": "#f97316"}
+labels = {"rk45": "RK45 (reference)", "rk4": "RK4", "euler": "Euler"}
+
+fig, (ax_ang, ax_err) = plt.subplots(2, 1, figsize=(10, 8), sharex=True)
+fig.suptitle("Integrator Benchmark — Cart-Pole LQR (dt=0.02 s)", fontsize=13)
+
+for name, color in colors.items():
+    ax_ang.plot(t, results[name]["angles"], color=color, lw=1.5, label=labels[name])
+ax_ang.set_ylabel("Pole angle (deg)")
+ax_ang.axhline(0, color="k", lw=0.8)
+ax_ang.legend()
+ax_ang.grid(True, alpha=0.3)
+
+for name in ("rk4", "euler"):
+    err = results[name]["angles"] - ref
+    ax_err.plot(
+        t, err, color=colors[name], lw=1.5, label=f"{labels[name]} error vs RK45"
+    )
+ax_err.set_ylabel("Angle error (deg)")
+ax_err.set_xlabel("Time (s)")
+ax_err.axhline(0, color="k", lw=0.8)
+ax_err.legend()
+ax_err.grid(True, alpha=0.3)
+
+plt.tight_layout()
+plt.show()

--- a/examples/simulators/05_cartpole2d_features.py
+++ b/examples/simulators/05_cartpole2d_features.py
@@ -1,0 +1,130 @@
+"""05_cartpole2d_features.py — CartPole2DView: light theme, save=, custom controller.
+
+Demonstrates new features added in v0.2.7 that work in headless environments
+(no Qt / PyVista required):
+
+    1. mpl_theme("light") — white-background matplotlib theme
+    2. CartPole2DView().simulate() — headless data collection
+    3. CartPole2DView().animate(save=) — export animation to GIF
+    4. Custom controller wired into CartPole2DView
+
+Run:
+    uv run python examples/simulators/05_cartpole2d_features.py
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from synapsys.algorithms.lqr import lqr
+from synapsys.simulators import CartPoleSim
+from synapsys.viz import CartPole2DView
+from synapsys.viz.palette import Dark, Light, mpl_theme
+
+# ── 1. Light theme ────────────────────────────────────────────────────────────
+
+print("=== 1. Light vs Dark palette comparison ===")
+
+mpl_theme("light")
+
+fig, axes = plt.subplots(1, 2, figsize=(12, 4))
+fig.suptitle("Synapsys palette comparison", color=Light.FG)
+
+# Light panel
+ax = axes[0]
+ax.set_facecolor(Light.SURFACE)
+ax.set_title("Light theme", color=Light.FG)
+t = np.linspace(0, 2 * np.pi, 200)
+ax.plot(t, np.sin(t), color=Light.SIG_POS, label="position")
+ax.plot(t, np.cos(t), color=Light.SIG_VEL, label="velocity")
+ax.plot(t, 0.5 * np.sin(2 * t), color=Light.SIG_CTRL, label="control")
+ax.set_xlabel("t (s)", color=Light.MUTED)
+ax.legend()
+ax.grid(True, color=Light.GRID)
+
+# Dark panel
+ax = axes[1]
+ax.set_facecolor(Dark.SURFACE)
+ax.set_title("Dark theme", color=Dark.FG)
+ax.plot(t, np.sin(t), color=Dark.SIG_POS, label="position")
+ax.plot(t, np.cos(t), color=Dark.SIG_VEL, label="velocity")
+ax.plot(t, 0.5 * np.sin(2 * t), color=Dark.SIG_CTRL, label="control")
+ax.set_xlabel("t (s)", color=Dark.MUTED)
+ax.legend()
+ax.grid(True, color=Dark.GRID)
+
+fig.tight_layout()
+plt.savefig("/tmp/palette_comparison.png", dpi=120)
+print("  → saved: /tmp/palette_comparison.png")
+plt.close()
+
+# ── 2. Headless simulation ────────────────────────────────────────────────────
+
+print("\n=== 2. Headless simulation (simulate()) ===")
+
+view = CartPole2DView(dt=0.02, duration=5.0)
+hist = view.simulate()
+
+print(f"  steps     : {len(hist['t'])}")
+print(f"  final pos : {hist['pos'][-1]:.4f} m")
+print(f"  final angle: {np.degrees(hist['angle'][-1]):.2f}°")
+print(f"  max force : {np.max(np.abs(hist['force'])):.2f} N")
+
+# ── 3. Export animation to GIF ────────────────────────────────────────────────
+
+print("\n=== 3. Export animation (animate(save=)) ===")
+
+import matplotlib
+
+matplotlib.use("Agg")  # headless backend for saving without a display
+
+view2 = CartPole2DView(dt=0.02, duration=3.0)
+anim = view2.animate(save="/tmp/cartpole2d.gif")
+print("  → saved: /tmp/cartpole2d.gif")
+plt.close("all")
+
+# ── 4. Custom LQR controller ──────────────────────────────────────────────────
+
+print("\n=== 4. Custom controller ===")
+
+sim = CartPoleSim()
+sim.reset()
+ss = sim.linearize(np.zeros(4), np.zeros(1))
+
+# aggressive angle penalty
+Q = np.diag([0.1, 0.01, 500.0, 50.0])
+R = np.eye(1) * 0.001
+K, _ = lqr(ss.A, ss.B, Q, R)
+
+view3 = CartPole2DView(
+    controller=lambda x: np.clip(-K @ x, -100, 100),
+    dt=0.02,
+    duration=5.0,
+    x0=np.array([0.0, 0.0, 0.25, 0.0]),  # larger initial angle
+)
+hist3 = view3.simulate()
+print(f"  custom K    : {K.ravel()}")
+print(f"  final angle : {np.degrees(hist3['angle'][-1]):.3f}°")
+print(f"  max force   : {np.max(np.abs(hist3['force'])):.2f} N")
+
+# ── summary plot ─────────────────────────────────────────────────────────────
+
+mpl_theme("light")
+fig, axes = plt.subplots(2, 1, figsize=(10, 6), sharex=True)
+fig.suptitle("CartPole2DView — custom aggressive LQR", color=Light.FG)
+
+axes[0].plot(hist3["t"], np.degrees(hist3["angle"]), color=Light.SIG_ANG)
+axes[0].set_ylabel("angle (°)", color=Light.MUTED)
+axes[0].axhline(0, color=Light.SIG_REF, lw=1, ls="--")
+axes[0].grid(True, color=Light.GRID)
+
+axes[1].plot(hist3["t"], hist3["force"], color=Light.SIG_CTRL)
+axes[1].set_ylabel("force (N)", color=Light.MUTED)
+axes[1].set_xlabel("time (s)", color=Light.MUTED)
+axes[1].grid(True, color=Light.GRID)
+
+fig.tight_layout()
+plt.savefig("/tmp/cartpole2d_custom.png", dpi=120)
+print("  → saved: /tmp/cartpole2d_custom.png")
+plt.close()
+
+print("\nDone. Outputs saved to /tmp/")

--- a/examples/simulators/06_simview_advanced.py
+++ b/examples/simulators/06_simview_advanced.py
@@ -1,0 +1,47 @@
+"""06_simview_advanced.py — SimView: camera presets, trajectory trail, save=.
+
+Demonstrates new features added in v0.2.7 that require a Qt display:
+
+    1. set_camera_preset() — choose viewing angle before run()
+    2. toggle_trail()      — enable 3D trajectory trail
+    3. save=               — record animation to file on close
+
+Run one section at a time by uncommenting the desired block.
+Requires: pyside6, pyvistaqt, matplotlib
+
+Run:
+    uv run python examples/simulators/06_simview_advanced.py
+"""
+
+from synapsys.viz import CartPoleView
+
+# ── choose which demo to run ──────────────────────────────────────────────────
+# Uncomment exactly one block.
+
+# ── 1. Camera preset: top-down ────────────────────────────────────────────────
+view = CartPoleView()
+view.set_camera_preset("top")
+view.run()
+
+# ── 2. Camera preset: isometric + trajectory trail ────────────────────────────
+# view = CartPoleView()
+# view.set_camera_preset("iso")
+# view.toggle_trail()        # violet trail traces the pole tip
+# view.run()
+
+# ── 3. Side view + trail — inverted pendulum ──────────────────────────────────
+# view = PendulumView()
+# view.set_camera_preset("side")
+# view.toggle_trail()        # traces pole tip arc
+# view.run()
+
+# ── 4. MSD with trail + save ──────────────────────────────────────────────────
+# view = MassSpringDamperView(save="/tmp/msd_session.gif")
+# view.toggle_trail()        # traces mass centre path
+# view.run()
+# # After closing the window: /tmp/msd_session.gif is written.
+
+# ── 5. CartPole: follow-cam + save ────────────────────────────────────────────
+# view = CartPoleView(save="/tmp/cartpole_session.gif")
+# view.set_camera_preset("follow")
+# view.run()

--- a/synapsys/viz/__init__.py
+++ b/synapsys/viz/__init__.py
@@ -1,7 +1,7 @@
 """synapsys.viz — Utilities for real-time and static visualisation."""
 
 from .cartpole2d import CartPole2DView
-from .palette import Dark, mpl_theme
+from .palette import Dark, Light, mpl_theme
 
 # SimView classes depend on Qt/PyVista — import lazily so that
 # CartPole2DView (pure matplotlib) remains importable on headless environments.
@@ -10,6 +10,7 @@ try:
 
     __all__ = [
         "Dark",
+        "Light",
         "mpl_theme",
         "CartPole2DView",
         "CartPoleView",
@@ -19,6 +20,7 @@ try:
 except ImportError:
     __all__ = [
         "Dark",
+        "Light",
         "mpl_theme",
         "CartPole2DView",
     ]

--- a/synapsys/viz/palette.py
+++ b/synapsys/viz/palette.py
@@ -109,56 +109,122 @@ class Dark:
     MESH_REF = "#4ade80"  # esfera de referência
 
 
-def mpl_theme() -> None:
+class Light:
+    """Tema claro — para ambientes com fundo branco (apresentações, relatórios).
+
+    Hierarquia de camadas
+    ─────────────────────
+    BG  →  SURFACE  →  PANEL  →  BORDER  (do mais claro ao mais escuro)
+    """
+
+    # ── Fundos ────────────────────────────────────────────────────────────────
+    BG = "#ffffff"
+    SURFACE = "#f8fafc"
+    PANEL = "#f1f5f9"
+    BORDER = "#e2e8f0"
+    BORDER_LT = "#f1f5f9"
+
+    # ── Texto ─────────────────────────────────────────────────────────────────
+    FG = "#0f172a"
+    MUTED = "#475569"
+    SUBTLE = "#94a3b8"
+    GRID = "#e2e8f0"
+
+    # ── Brand ─────────────────────────────────────────────────────────────────
+    GOLD = "#92671e"
+    GOLD_DIM = "#6b4a15"
+    GOLD_LT = "#c8a870"
+    TEAL = "#0d9488"
+
+    # ── Sinais ────────────────────────────────────────────────────────────────
+    SIG_POS = "#1d4ed8"
+    SIG_POS_LT = "#3b82f6"
+    SIG_VEL = "#c2410c"
+    SIG_VEL_LT = "#ea580c"
+    SIG_REF = "#15803d"
+    SIG_REF_DK = "#166534"
+    SIG_REF_LT = "#22c55e"
+    SIG_ANG = "#c2410c"
+    SIG_CTRL = "#b91c1c"
+    SIG_PHASE = "#7c3aed"
+    SIG_TRAIL = "#6d28d9"
+    SIG_ALT = "#b45309"
+    SIG_CH1 = "#7c3aed"
+    SIG_CH2 = "#c2410c"
+    SIG_CH3 = "#0f766e"
+    SIG_CH4 = "#b45309"
+    SIG_CYAN = "#0284c7"
+
+    # ── Status ────────────────────────────────────────────────────────────────
+    STATUS_STABLE = "#0d9488"
+    STATUS_FUNCTIONAL = "#92671e"
+    STATUS_INTERFACE = "#d97706"
+    STATUS_PLANNED = "#6b7280"
+
+    # ── Danger / feedback ─────────────────────────────────────────────────────
+    DANGER = "#dc2626"
+    WARN = "#d97706"
+    OK = "#16a34a"
+
+    # ── Objetos 3D ────────────────────────────────────────────────────────────
+    MESH_BODY = "#1d4ed8"
+    MESH_STRUCT = "#64748b"
+    MESH_WALL = "#94a3b8"
+    MESH_FLOOR = "#e2e8f0"
+    MESH_SPRING = "#92671e"
+    MESH_DAMP = "#64748b"
+    MESH_POLE = "#92671e"
+    MESH_BOB = "#c2410c"
+    MESH_RAIL = "#94a3b8"
+    MESH_STOP = "#dc2626"
+    MESH_REF = "#15803d"
+
+
+def mpl_theme(theme: str = "dark") -> None:
     """Aplica rcParams globais do tema Synapsys ao matplotlib.
 
-    Deve ser chamado **antes** de criar qualquer Figure.
+    Parameters
+    ----------
+    theme:
+        ``"dark"`` (padrão) ou ``"light"``.
 
     Exemplo
     -------
     >>> from synapsys.viz.palette import mpl_theme
-    >>> mpl_theme()
-    >>> import matplotlib.pyplot as plt
-    >>> fig, ax = plt.subplots()   # já com o tema aplicado
+    >>> mpl_theme()           # dark
+    >>> mpl_theme("light")    # light
     """
     import matplotlib as mpl
 
+    p = Light if theme == "light" else Dark
     mpl.rcParams.update(
         {
-            # Figura
-            "figure.facecolor": Dark.BG,
-            "figure.edgecolor": Dark.BG,
-            # Eixos
-            "axes.facecolor": Dark.SURFACE,
-            "axes.edgecolor": Dark.BORDER,
-            "axes.labelcolor": Dark.MUTED,
-            "axes.titlecolor": Dark.FG,
+            "figure.facecolor": p.BG,
+            "figure.edgecolor": p.BG,
+            "axes.facecolor": p.SURFACE,
+            "axes.edgecolor": p.BORDER,
+            "axes.labelcolor": p.MUTED,
+            "axes.titlecolor": p.FG,
             "axes.grid": True,
             "axes.spines.top": False,
             "axes.spines.right": False,
-            # Grade
-            "grid.color": Dark.GRID,
+            "grid.color": p.GRID,
             "grid.linewidth": 0.5,
             "grid.alpha": 0.7,
-            # Ticks
-            "xtick.color": Dark.MUTED,
-            "ytick.color": Dark.MUTED,
+            "xtick.color": p.MUTED,
+            "ytick.color": p.MUTED,
             "xtick.labelsize": 8,
             "ytick.labelsize": 8,
-            # Texto
-            "text.color": Dark.FG,
+            "text.color": p.FG,
             "font.family": ["JetBrains Mono", "Fira Code", "monospace"],
             "font.size": 9,
-            # Legenda
-            "legend.facecolor": Dark.SURFACE,
-            "legend.edgecolor": Dark.BORDER,
-            "legend.labelcolor": Dark.FG,
+            "legend.facecolor": p.SURFACE,
+            "legend.edgecolor": p.BORDER,
+            "legend.labelcolor": p.FG,
             "legend.fontsize": 7,
-            # Linhas e marcadores
             "lines.linewidth": 1.5,
             "lines.markersize": 5,
-            # Salvar
-            "savefig.facecolor": Dark.BG,
-            "savefig.edgecolor": Dark.BG,
+            "savefig.facecolor": p.BG,
+            "savefig.edgecolor": p.BG,
         }
     )

--- a/synapsys/viz/simview/_base.py
+++ b/synapsys/viz/simview/_base.py
@@ -81,10 +81,13 @@ class SimViewBase(QMainWindow):
     # (bg, active_bg, hover_bg, border, active_border)
     _push_colors: tuple = ("#1e3a5f", "#2563eb", "#1d4ed8", "#2563eb", "#60a5fa")
 
-    def __init__(self, controller: Callable | None = None) -> None:
+    def __init__(
+        self, controller: Callable | None = None, save: str | None = None
+    ) -> None:
         # QMainWindow.__init__ is deferred to run() so that
         # CartPoleView().run() works without a pre-existing QApplication.
         self._controller_fn = controller
+        self._save_path: str | None = save
         self._paused = False
         self._pert = 0.0
         self._pert_max = self._pert_max_default
@@ -197,6 +200,14 @@ class SimViewBase(QMainWindow):
 
     def _on_reset(self) -> None:
         """Called after sim.reset().  Override for extra reset logic."""
+
+    def _trail_point(self, x: ndarray) -> ndarray:
+        """Return the 3-D world point to record for the trajectory trail.
+
+        Default: returns ``[x[0], 0, 0]`` (first state as X, Y=0, Z=0).
+        Override in subclasses for system-specific geometry.
+        """
+        return np.array([x[0], 0.0, 0.0])
 
     def _post_tick(self, x: ndarray, u: ndarray) -> None:
         """Called at the end of each tick. Override for limit checking etc."""

--- a/synapsys/viz/simview/cartpole.py
+++ b/synapsys/viz/simview/cartpole.py
@@ -90,8 +90,9 @@ class CartPoleView(SimViewBase):
         l: float = _L,
         g: float = _G,
         x0: np.ndarray | None = None,
+        save: str | None = None,
     ) -> None:
-        super().__init__(controller)
+        super().__init__(controller, save=save)
         self._m_c, self._m_p, self._l, self._g = m_c, m_p, l, g
         self._x0_init = x0
 
@@ -314,6 +315,13 @@ class CartPoleView(SimViewBase):
             ax.autoscale_view()
 
     # ── HUD / status ──────────────────────────────────────────────────────────
+
+    def _trail_point(self, x):
+        # pole tip in world XZ plane (Y=0 for 2D cart-pole)
+        p, _, theta, _ = x
+        tip_x = p + self._l * np.sin(theta)
+        tip_z = _PIVOT_Z + self._l * np.cos(theta)
+        return np.array([tip_x, 0.0, tip_z])
 
     def _post_tick(self, x, u):
         if abs(x[0]) >= _TRACK_HW * _LIMIT_FRAC:

--- a/synapsys/viz/simview/msd.py
+++ b/synapsys/viz/simview/msd.py
@@ -117,8 +117,9 @@ class MassSpringDamperView(SimViewBase):
         k: float = _K,
         x0: np.ndarray | None = None,
         setpoints: list | None = None,
+        save: str | None = None,
     ) -> None:
-        super().__init__(controller)
+        super().__init__(controller, save=save)
         self._m, self._c, self._k = m, c, k
         self._x0_init = x0
         self._setpoints = setpoints if setpoints is not None else _DEFAULT_SETPOINTS
@@ -365,6 +366,10 @@ class MassSpringDamperView(SimViewBase):
             ax.autoscale_view()
 
     # ── HUD / status ──────────────────────────────────────────────────────────
+
+    def _trail_point(self, x):
+        # mass position along the horizontal axis
+        return np.array([x[0], 0.0, _MASS_H / 2])
 
     def _hud_text(self, x, u):
         q = x[0]

--- a/synapsys/viz/simview/pendulum.py
+++ b/synapsys/viz/simview/pendulum.py
@@ -75,8 +75,9 @@ class PendulumView(SimViewBase):
         g: float = _G,
         b: float = _B,
         x0: np.ndarray | None = None,
+        save: str | None = None,
     ) -> None:
-        super().__init__(controller)
+        super().__init__(controller, save=save)
         self._m, self._l, self._g, self._b = m, l, g, b
         self._x0_init = x0
 
@@ -276,6 +277,12 @@ class PendulumView(SimViewBase):
             ax.autoscale_view()
 
     # ── HUD / status ──────────────────────────────────────────────────────────
+
+    def _trail_point(self, x):
+        theta = x[0]
+        tip_x = self._l * np.sin(theta)
+        tip_z = _PIVOT_Z + self._l * np.cos(theta)
+        return np.array([tip_x, 0.0, tip_z])
 
     def _hud_text(self, x, u):
         pert_s = f"{self._pert:+6.1f} N·m" if abs(self._pert) > 0.5 else "   --"

--- a/tests/simulators/test_simview.py
+++ b/tests/simulators/test_simview.py
@@ -500,3 +500,100 @@ class TestTrailState:
         for i in range(v._trail_max_pts + 10):
             v._append_trail_position(np.array([float(i), 0.0, 0.0]))
         assert len(v._trail_positions) <= v._trail_max_pts
+
+
+# ── light palette ──────────────────────────────────────────────────────────────
+
+
+class TestLightPalette:
+    def test_light_class_exists(self):
+        from synapsys.viz.palette import Light
+
+        assert Light is not None
+
+    def test_light_has_required_attributes(self):
+        from synapsys.viz.palette import Light
+
+        for attr in ("BG", "SURFACE", "FG", "BORDER", "MUTED", "GRID"):
+            assert hasattr(Light, attr), f"Light missing {attr}"
+
+    def test_light_bg_is_light_color(self):
+        from synapsys.viz.palette import Light
+
+        # BG should be a near-white hex
+        hex_val = Light.BG.lstrip("#")
+        r, g, b = int(hex_val[0:2], 16), int(hex_val[2:4], 16), int(hex_val[4:6], 16)
+        assert r > 200 and g > 200 and b > 200
+
+    def test_light_fg_is_dark_color(self):
+        from synapsys.viz.palette import Light
+
+        hex_val = Light.FG.lstrip("#")
+        r, g, b = int(hex_val[0:2], 16), int(hex_val[2:4], 16), int(hex_val[4:6], 16)
+        assert r < 100 and g < 100 and b < 100
+
+    def test_light_and_dark_bg_differ(self):
+        from synapsys.viz.palette import Dark, Light
+
+        assert Light.BG != Dark.BG
+
+    def test_mpl_theme_accepts_light(self):
+        from synapsys.viz.palette import mpl_theme
+
+        mpl_theme(theme="light")  # must not raise
+
+    def test_mpl_theme_accepts_dark(self):
+        from synapsys.viz.palette import mpl_theme
+
+        mpl_theme(theme="dark")  # must not raise
+
+    def test_mpl_theme_default_is_dark(self):
+        from synapsys.viz.palette import mpl_theme
+
+        mpl_theme()  # no theme arg — must not raise
+
+
+# ── trail_point hook ───────────────────────────────────────────────────────────
+
+
+class TestTrailPointHook:
+    def test_cartpole_trail_point_returns_3d_array(self):
+        v = CartPoleView()
+        x = np.array([1.0, 0.0, 0.2, 0.0])
+        pt = v._trail_point(x)
+        assert pt.shape == (3,)
+
+    def test_cartpole_trail_point_x_matches_cart_position(self):
+        v = CartPoleView()
+        x = np.array([1.5, 0.0, 0.0, 0.0])
+        pt = v._trail_point(x)
+        assert pt[0] == pytest.approx(1.5)
+
+    def test_pendulum_trail_point_returns_3d_array(self):
+        v = PendulumView()
+        x = np.array([0.3, 0.0])
+        pt = v._trail_point(x)
+        assert pt.shape == (3,)
+
+    def test_msd_trail_point_returns_3d_array(self):
+        v = MassSpringDamperView()
+        x = np.array([0.5, 0.0])
+        pt = v._trail_point(x)
+        assert pt.shape == (3,)
+
+
+# ── save path attribute ────────────────────────────────────────────────────────
+
+
+class TestSavePath:
+    def test_save_path_none_by_default(self):
+        v = CartPoleView()
+        assert v._save_path is None
+
+    def test_save_path_set_by_constructor(self):
+        v = CartPoleView(save="out.gif")
+        assert v._save_path == "out.gif"
+
+    def test_save_path_mp4(self):
+        v = CartPoleView(save="/tmp/sim.mp4")
+        assert v._save_path == "/tmp/sim.mp4"

--- a/website/docs/api/viz.md
+++ b/website/docs/api/viz.md
@@ -6,20 +6,87 @@ sidebar_label: synapsys.viz
 
 # `synapsys.viz`
 
-Visualization module: canonical color palette and plug-and-play 3D simulation windows.
+Visualization module: canonical color palettes, matplotlib theming, a lightweight 2D
+cart-pole animation, and plug-and-play 3D simulation windows.
 
 ```python
 from synapsys.viz import (
-    Dark, mpl_theme,
+    Dark, Light, mpl_theme,
+    CartPole2DView,
     CartPoleView, PendulumView, MassSpringDamperView,
 )
 ```
 
 ---
 
+## `CartPole2DView`
+
+Lightweight 2D cart-pole animation built on pure **matplotlib** — no Qt or PyVista
+required.
+
+```python
+CartPole2DView(
+    sim:        CartPoleSim | None = None,   # default instance created if None
+    controller: Callable | None = None,      # (x: ndarray) → ndarray; auto-LQR if None
+    dt:         float = 0.02,                # integration / animation step (s)
+    duration:   float = 10.0,               # total simulation time (s)
+    x0:         ndarray | None = None,       # initial state [p, ṗ, θ, θ̇]; default [0, 0, 0.15, 0]
+)
+```
+
+### Methods
+
+#### `simulate() → dict`
+
+Run the simulation and return a history dictionary.
+
+| Key | Shape | Contents |
+|---|---|---|
+| `"t"` | `(steps,)` | time array |
+| `"pos"` | `(steps,)` | cart position (m) |
+| `"angle"` | `(steps,)` | pole angle (rad) |
+| `"force"` | `(steps,)` | control force (N) |
+| `"states"` | `(steps, 4)` | full state `[p, ṗ, θ, θ̇]` |
+
+#### `animate(save=None) → FuncAnimation`
+
+Build and return a `matplotlib.animation.FuncAnimation`.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `save` | `str \| None` | save to file if given (e.g. `"out.gif"`); requires *Pillow* for GIF or *ffmpeg* for MP4 |
+
+#### `run() → None`
+
+`simulate()` → `animate()` → `plt.show()`. All-in-one entry point.
+
+### Examples
+
+```python
+from synapsys.viz import CartPole2DView
+import numpy as np
+
+# Auto-LQR, default parameters
+CartPole2DView().run()
+
+# Custom controller
+K = ...  # your gain matrix
+CartPole2DView(controller=lambda x: np.clip(-K @ x, -50, 50)).run()
+
+# Headless simulation (no display)
+hist = CartPole2DView(dt=0.02, duration=5.0).simulate()
+print(hist["angle"][-1])   # final pole angle (rad)
+
+# Save animation to GIF
+view = CartPole2DView()
+anim = view.animate(save="cartpole.gif")
+```
+
+---
+
 ## `SimViewBase`
 
-Base class for all views. Inherits from `QMainWindow`.
+Base class for all 3D views. Inherits from `QMainWindow`.
 **Do not instantiate directly** — use the concrete subclasses.
 
 ### Class attributes (configurable in subclasses)
@@ -38,9 +105,18 @@ Base class for all views. Inherits from `QMainWindow`.
 | `_u_clip` | `float` | `50.0` | controller output saturation |
 | `_u_clip_total` | `float` | `80.0` | total saturation after adding perturbation |
 
-### Public method
+### Constructor
 
-#### `run() -> None`
+```python
+SimViewBase(
+    controller: Callable | None = None,  # (x: ndarray) → ndarray; auto-LQR if None
+    save:       str | None = None,       # path to save the animation on close (e.g. "out.gif")
+)
+```
+
+### Public methods
+
+#### `run() → None`
 
 Creates `QApplication` (if not already present), initializes `QMainWindow`, builds the full UI
 and enters the Qt event loop. **Does not return** (calls `sys.exit`).
@@ -48,6 +124,34 @@ and enters the Qt event loop. **Does not return** (calls `sys.exit`).
 ```python
 CartPoleView().run()
 CartPoleView(controller=fn).run()
+```
+
+#### `set_camera_preset(name) → None`
+
+Apply a named camera position before the window opens.
+
+| Preset | Description |
+|---|---|
+| `"iso"` | Isometric view (default for most views) |
+| `"top"` | Top-down orthographic |
+| `"side"` | Side view |
+| `"follow"` | Low follow-cam (close behind) |
+
+```python
+view = CartPoleView()
+view.set_camera_preset("top")
+view.run()
+```
+
+#### `toggle_trail() → None`
+
+Enable or disable the 3D trajectory trail. Each tick appends the point returned by
+`_trail_point(x)` (overridable per view). The trail keeps the last 200 points.
+
+```python
+view = CartPoleView()
+view.toggle_trail()   # enable trail
+view.run()
 ```
 
 ### Hooks (optional override in subclasses)
@@ -58,7 +162,8 @@ CartPoleView(controller=fn).run()
 | `_pert_vector()` | `() → ndarray` | Converts scalar `_pert` to input vector. |
 | `_build_extra_controls(hb)` | `(QHBoxLayout) → None` | Injects extra widgets into the control bar. |
 | `_on_reset()` | `() → None` | Called after `sim.reset()` — useful for resetting extra state. |
-| `_post_tick(x, u)` | `(ndarray, ndarray) → None` | Called at the end of each tick. Used for auto-reset logic (e.g. track limit in CartPole). |
+| `_post_tick(x, u)` | `(ndarray, ndarray) → None` | Called at the end of each tick. |
+| `_trail_point(x)` | `(ndarray) → ndarray` | Returns a 3D world position `(3,)` to append to the trail. Default: `[x[0], 0, 0]`. |
 
 ---
 
@@ -72,6 +177,7 @@ CartPoleView(
     l:   float = 0.5,              # pole length [m]
     g:   float = 9.81,             # gravity [m/s²]
     x0:  np.ndarray | None = None, # initial state (4,) — default [0, 0, 0.18, 0]
+    save: str | None = None,       # path to save animation on close
 )
 ```
 
@@ -87,6 +193,8 @@ CartPoleView(
 
 **Auto-reset:** the cart resets automatically when it reaches 92% of the track length (`_LIMIT_FRAC = 0.92`). Between 72% and 92% the cart changes color to amber as a warning.
 
+**Trail point:** pole tip — `[p + l·sin(θ), 0, PIVOT_Z + l·cos(θ)]`
+
 ---
 
 ## `PendulumView`
@@ -99,6 +207,7 @@ PendulumView(
     g:  float = 9.81,             # gravity [m/s²]
     b:  float = 0.1,              # viscous damping
     x0: np.ndarray | None = None, # initial state (2,) — default [0.18, 0]
+    save: str | None = None,      # path to save animation on close
 )
 ```
 
@@ -115,6 +224,8 @@ PendulumView(
 **Perturbation:** ↺/↻ buttons and A/D keys — torque (1–40 N·m, default 20 N·m).
 Red arrows appear at the pole tip indicating direction and magnitude.
 
+**Trail point:** pole tip — `[l·sin(θ), 0, PIVOT_Z + l·cos(θ)]`
+
 ---
 
 ## `MassSpringDamperView`
@@ -127,6 +238,7 @@ MassSpringDamperView(
     k:         float = 2.0,             # spring constant [N/m]
     x0:        np.ndarray | None = None, # initial state (2,) — default [0, 0]
     setpoints: list | None = None,       # list of (label, value_m) — default 3 points
+    save:      str | None = None,        # path to save animation on close
 )
 ```
 
@@ -147,11 +259,13 @@ MassSpringDamperView(setpoints=[("0", 0.0), ("+2m", 2.0), ("-2m", -2.0)]).run()
 
 **Perturbation:** ◀/▶ buttons and A/D keys — force (1–30 N, default 15 N).
 
+**Trail point:** mass position — `[q, 0, MASS_H/2]`
+
 ---
 
 ## `Dark`
 
-Synapsys design system color tokens (mirrors the website dark mode).
+Synapsys design system color tokens — dark theme (mirrors the website dark mode).
 
 ```python
 from synapsys.viz.palette import Dark
@@ -229,15 +343,83 @@ from synapsys.viz.palette import Dark
 
 ---
 
+## `Light`
+
+Synapsys design system color tokens — light theme (for presentations, reports, and
+environments with white backgrounds).
+
+```python
+from synapsys.viz.palette import Light
+```
+
+### Backgrounds
+
+| Token | Hex | Use |
+|---|---|---|
+| `Light.BG` | `#ffffff` | Window background / matplotlib figure |
+| `Light.SURFACE` | `#f8fafc` | Cards, panels, matplotlib axes |
+| `Light.PANEL` | `#f1f5f9` | Qt GroupBox |
+| `Light.BORDER` | `#e2e8f0` | Default borders |
+
+### Text
+
+| Token | Hex | Use |
+|---|---|---|
+| `Light.FG` | `#0f172a` | Primary text |
+| `Light.MUTED` | `#475569` | Axis labels, secondary text |
+| `Light.SUBTLE` | `#94a3b8` | Tertiary text / hints |
+| `Light.GRID` | `#e2e8f0` | matplotlib grid lines |
+
+### Brand
+
+| Token | Hex | Use |
+|---|---|---|
+| `Light.GOLD` | `#92671e` | Primary brand color / highlight |
+| `Light.GOLD_LT` | `#c8a870` | Light variant |
+| `Light.TEAL` | `#0d9488` | Secondary brand color |
+
+### Signals
+
+| Token | Hex | Physical quantity |
+|---|---|---|
+| `Light.SIG_POS` | `#1d4ed8` | Position / displacement |
+| `Light.SIG_VEL` | `#c2410c` | Velocity / rate |
+| `Light.SIG_ANG` | `#c2410c` | Angle |
+| `Light.SIG_REF` | `#15803d` | Setpoint / reference |
+| `Light.SIG_CTRL` | `#b91c1c` | Control force / torque |
+| `Light.SIG_PHASE` | `#7c3aed` | Phase portrait |
+| `Light.SIG_TRAIL` | `#6d28d9` | 3D trail |
+| `Light.SIG_CYAN` | `#0284c7` | Current point (dot marker) |
+
+---
+
 ## `mpl_theme()`
 
 ```python
 from synapsys.viz.palette import mpl_theme
-mpl_theme()
+
+mpl_theme()            # dark (default)
+mpl_theme("light")     # light
+mpl_theme("dark")      # dark (explicit)
 ```
 
 Applies Synapsys theme global rcParams to matplotlib.
 Must be called **before** creating any `Figure`.
 
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `theme` | `str` | `"dark"` | `"dark"` or `"light"` |
+
 Automatically configures: `figure.facecolor`, `axes.facecolor`, grid, ticks,
 legend, and font (`JetBrains Mono`).
+
+```python
+from synapsys.viz.palette import mpl_theme, Light
+import matplotlib.pyplot as plt
+
+mpl_theme("light")
+
+fig, ax = plt.subplots()
+ax.plot([0, 1, 2], [0, 1, 0], color=Light.SIG_POS)
+plt.show()
+```

--- a/website/docs/guide/simulators/cartpole.md
+++ b/website/docs/guide/simulators/cartpole.md
@@ -1,0 +1,148 @@
+---
+id: simulators-cartpole
+title: Cart-Pole Simulator
+sidebar_label: Cart-Pole
+sidebar_position: 4
+---
+
+# Cart-Pole Simulator
+
+`CartPoleSim` implements the classic Lagrangian cart-pole: a cart sliding on a
+frictionless track with an inverted pendulum attached at the pivot.
+
+---
+
+## Physics model
+
+**States:** `x = [p, ṗ, θ, θ̇]`
+- `p` — cart position (m)
+- `ṗ` — cart velocity (m/s)
+- `θ` — pole angle from upright (rad, θ=0 → balanced)
+- `θ̇` — pole angular velocity (rad/s)
+
+**Input:** `u = [F]` — horizontal force on cart (N)
+
+**Output:** `y = [p, θ]` — partial observation (no velocities)
+
+**Nonlinear dynamics (Lagrangian):**
+
+```
+Δ  = m_c + m_p · sin²(θ)
+p̈  = [F + m_p · sin(θ) · (l · θ̇² − g · cos(θ))] / Δ
+θ̈  = [g · sin(θ) − p̈ · cos(θ)] / l
+```
+
+---
+
+## Construction
+
+```python
+from synapsys.simulators import CartPoleSim
+
+sim = CartPoleSim(
+    m_c=1.0,            # cart mass (kg)
+    m_p=0.1,            # pole tip mass (kg)
+    l=0.5,              # pole length (m)
+    g=9.81,             # gravity (m/s²)
+    integrator="rk4",   # "euler", "rk4", or "rk45"
+    noise_std=0.0,       # sensor noise
+    disturbance_std=0.0, # input disturbance
+    linearised=False,    # True → use linearised dynamics
+)
+```
+
+---
+
+## Linearised mode
+
+For small angles the nonlinear dynamics simplifies to a linear system.
+Pass `linearised=True` to use this approximation:
+
+```python
+sim_nl = CartPoleSim(linearised=False)   # full nonlinear
+sim_l  = CartPoleSim(linearised=True)    # linear approximation
+
+# Near θ=0 both behave identically (atol ≈ 1e-4 for dt=0.01 s)
+```
+
+---
+
+## LQR stabilisation
+
+```python
+import numpy as np
+from synapsys.algorithms.lqr import lqr
+
+sim = CartPoleSim()
+sim.reset()
+ss = sim.linearize(np.zeros(4), np.zeros(1))
+
+Q = np.diag([1.0, 0.1, 100.0, 10.0])   # penalise angle heavily
+R = np.eye(1) * 0.01
+K, _ = lqr(ss.A, ss.B, Q, R)
+
+sim.reset(x0=np.array([0.0, 0.0, 0.15, 0.0]))
+for _ in range(500):
+    x = sim.state
+    u = np.clip(-K @ x, -50, 50)
+    y, info = sim.step(u, dt=0.02)
+    if info["failed"]:
+        break
+```
+
+---
+
+## 2D matplotlib animation
+
+```python
+from synapsys.viz import CartPole2DView
+
+# Auto-LQR
+CartPole2DView().run()
+
+# Custom controller
+CartPole2DView(controller=lambda x: np.clip(-K @ x, -50, 50)).run()
+
+# Simulate only (no display)
+hist = CartPole2DView(dt=0.02, duration=5.0).simulate()
+print(hist["angle"][-1])   # final pole angle (rad)
+
+# Save animation
+view = CartPole2DView()
+anim = view.animate(save="cartpole.gif")
+```
+
+---
+
+## Failure detection
+
+The simulator flags failure when the system leaves the safe region:
+
+| Condition | Value |
+|---|---|
+| Cart out of bounds | `\|p\| > 4.8 m` |
+| Pole fell | `\|θ\| > π/3 rad (≈ 60°)` |
+
+```python
+y, info = sim.step(u, dt)
+if info["failed"]:
+    print("Episode ended — resetting")
+    sim.reset()
+```
+
+---
+
+## Thread-safe parameter updates
+
+```python
+import threading
+
+def slow_controller():
+    while True:
+        sim.set_params(m_c=2.0)   # safe from any thread
+
+t = threading.Thread(target=slow_controller, daemon=True)
+t.start()
+```
+
+Accepted keys: `m_c`, `m_p`, `l`, `g`.

--- a/website/docs/guide/simulators/inverted-pendulum.md
+++ b/website/docs/guide/simulators/inverted-pendulum.md
@@ -1,0 +1,91 @@
+---
+id: simulators-inverted-pendulum
+title: Inverted Pendulum Simulator
+sidebar_label: Inverted Pendulum
+sidebar_position: 3
+---
+
+# Inverted Pendulum Simulator
+
+`InvertedPendulumSim` implements a nonlinear inverted pendulum on a fixed pivot —
+the simplest inherently unstable system and a classic benchmark for control design.
+
+---
+
+## Physics model
+
+**States:** `x = [θ, θ̇]`
+- `θ` — angle from upright (rad, θ=0 → balanced)
+- `θ̇` — angular velocity (rad/s)
+
+**Input:** `u = [τ]` — torque at pivot (N·m)
+
+**Output:** `y = [θ]` — pole angle only
+
+**Nonlinear dynamics:**
+
+```
+I = m · l²
+θ̈ = (g/l) · sin(θ) − (b/I) · θ̇ + τ/I
+```
+
+**Unstable pole** (b=0): `λ_unstable = +√(g/l)`
+
+---
+
+## Construction
+
+```python
+from synapsys.simulators import InvertedPendulumSim
+
+sim = InvertedPendulumSim(
+    m=1.0,              # pendulum mass (kg)
+    l=1.0,              # pendulum length (m)
+    g=9.81,             # gravity (m/s²)
+    b=0.0,              # friction coefficient (N·m·s/rad)
+    integrator="rk4",
+    noise_std=0.0,
+    disturbance_std=0.0,
+)
+```
+
+---
+
+## LQR stabilisation
+
+```python
+import numpy as np
+from synapsys.algorithms.lqr import lqr
+
+sim = InvertedPendulumSim(m=1.0, l=1.0, g=9.81, b=0.1)
+sim.reset()
+ss = sim.linearize(np.zeros(2), np.zeros(1))
+
+K, _ = lqr(ss.A, ss.B, np.diag([10.0, 1.0]), np.eye(1))
+
+sim.reset(x0=np.array([0.1, 0.0]))
+for _ in range(1000):
+    x = sim.state
+    u = -K @ x
+    y, info = sim.step(u, dt=0.01)
+    if info["failed"]:
+        break
+```
+
+---
+
+## Failure detection
+
+`info["failed"]` is `True` when `|θ| > π/2 rad` (pole has fallen past horizontal).
+
+---
+
+## Utilities
+
+```python
+# Unstable open-loop pole (theoretical)
+sim.unstable_pole()   # ≈ √(g/l)
+
+# Thread-safe parameter update
+sim.set_params(b=0.5)   # accepted: m, l, g, b
+```

--- a/website/docs/guide/simulators/mass-spring-damper.md
+++ b/website/docs/guide/simulators/mass-spring-damper.md
@@ -1,0 +1,88 @@
+---
+id: simulators-msd
+title: Mass-Spring-Damper Simulator
+sidebar_label: Mass-Spring-Damper
+sidebar_position: 2
+---
+
+# Mass-Spring-Damper Simulator
+
+`MassSpringDamperSim` is the simplest second-order simulator — a 1-DOF linear
+mass-spring-damper. It is always stable for positive parameters and serves as the
+entry point for understanding `SimulatorBase`.
+
+---
+
+## Physics model
+
+**States:** `x = [q, q̇]`
+- `q` — displacement from rest (m)
+- `q̇` — velocity (m/s)
+
+**Input:** `u = [F]` — applied force (N)
+
+**Output:** `y = [q]` — position only
+
+**Dynamics:**
+
+```
+m·q̈ + c·q̇ + k·q = F
+```
+
+---
+
+## Construction
+
+```python
+from synapsys.simulators import MassSpringDamperSim
+
+sim = MassSpringDamperSim(
+    m=1.0,              # mass (kg)
+    c=0.5,              # damping coefficient (N·s/m)
+    k=2.0,              # spring stiffness (N/m)
+    integrator="rk4",
+    noise_std=0.0,
+    disturbance_std=0.0,
+)
+```
+
+---
+
+## Step response
+
+```python
+import numpy as np
+
+sim = MassSpringDamperSim()
+sim.reset()
+
+history = []
+for _ in range(300):
+    y, _ = sim.step(np.array([1.0]), dt=0.05)  # constant force
+    history.append(y[0])
+
+# steady-state displacement = F / k = 1.0 / 2.0 = 0.5 m
+print(f"Steady state: {history[-1]:.4f} m")
+```
+
+---
+
+## Linearisation validation
+
+Because MSD is already linear, `linearize()` must return the known analytical matrices:
+
+```python
+ss = sim.linearize(np.zeros(2), np.zeros(1))
+# A = [[0, 1], [-k/m, -c/m]]
+# B = [[0], [1/m]]
+# C = [[1, 0]]
+# D = [[0]]
+```
+
+---
+
+## Thread-safe parameter updates
+
+```python
+sim.set_params(m=2.0, k=5.0)   # accepted: m, c, k
+```

--- a/website/docs/guide/simulators/overview.md
+++ b/website/docs/guide/simulators/overview.md
@@ -1,0 +1,114 @@
+---
+id: simulators-overview
+title: Physics Simulators — Overview
+sidebar_label: Overview
+sidebar_position: 1
+---
+
+# Physics Simulators
+
+`synapsys.simulators` provides nonlinear continuous-time physics simulators with a
+unified interface for control design, testing, and reinforcement learning.
+
+---
+
+## Available simulators
+
+| Class | System | States | Inputs | Outputs |
+|---|---|---|---|---|
+| `MassSpringDamperSim` | 1-DOF linear MSD | `[q, q̇]` | `[F]` | `[q]` |
+| `InvertedPendulumSim` | Nonlinear pendulum on fixed pivot | `[θ, θ̇]` | `[τ]` | `[θ]` |
+| `CartPoleSim` | Lagrangian cart-pole | `[p, ṗ, θ, θ̇]` | `[F]` | `[p, θ]` |
+
+---
+
+## Common interface
+
+Every simulator inherits from `SimulatorBase` and exposes the same API:
+
+```python
+from synapsys.simulators import CartPoleSim
+
+sim = CartPoleSim()
+y = sim.reset()                   # reset → initial observation
+y, info = sim.step(u, dt=0.02)    # advance one step
+ss  = sim.linearize(x0, u0)      # numerical linearisation → StateSpace
+```
+
+### `step()` info dict
+
+```python
+y, info = sim.step(u, dt=0.02)
+info["x"]       # full state after step
+info["t_step"]  # integration time (= dt)
+info["failed"]  # True when the system left its safe region
+```
+
+---
+
+## Integrators
+
+All simulators support three numerical integration methods selectable at construction:
+
+| Method | Accuracy | Speed | Recommended use |
+|---|---|---|---|
+| `"euler"` | Low | Fastest | Very small dt (≤ 1 ms), RL inner loops |
+| `"rk4"` | High | Fast | Default — good balance |
+| `"rk45"` | Very high | Slower | Reference / validation |
+
+```python
+sim = CartPoleSim(integrator="rk4")   # default
+sim = CartPoleSim(integrator="euler") # fastest
+```
+
+---
+
+## Noise and disturbances
+
+```python
+sim = InvertedPendulumSim(noise_std=0.01, disturbance_std=0.05)
+```
+
+- `noise_std` — Gaussian noise added to every observation (sensor noise model)
+- `disturbance_std` — Gaussian noise injected into the control input (process noise)
+
+---
+
+## Thread-safe parameter updates
+
+All simulators support live parameter changes from a separate thread:
+
+```python
+sim.set_params(m=0.5)     # InvertedPendulumSim
+sim.set_params(m_c=2.0)   # CartPoleSim
+```
+
+---
+
+## Failure detection
+
+```python
+y, info = sim.step(u, dt)
+if info["failed"]:
+    sim.reset()
+```
+
+| Simulator | Failure condition |
+|---|---|
+| `CartPoleSim` | `\|p\| > 4.8 m` or `\|θ\| > π/3 rad` |
+| `InvertedPendulumSim` | `\|θ\| > π/2 rad` |
+| `MassSpringDamperSim` | never (always stable) |
+
+---
+
+## Linearisation
+
+Every simulator exposes `linearize(x0, u0)` which returns a continuous-time
+`StateSpace` via central finite differences — ready for LQR design:
+
+```python
+from synapsys.algorithms.lqr import lqr
+
+ss = sim.linearize(np.zeros(4), np.zeros(1))
+K, _ = lqr(ss.A, ss.B, Q, R)
+```

--- a/website/docs/guide/viz/overview.md
+++ b/website/docs/guide/viz/overview.md
@@ -1,21 +1,56 @@
 ---
 id: viz-overview
-title: 3D Simulators — Overview
+title: Visualization — Overview
 sidebar_label: Overview
 sidebar_position: 1
 ---
 
-# 3D Simulators — Overview
+# Visualization — Overview
 
-![Cart-Pole — real-time 3D simulation](/img/simview/cartpole.gif)
+`synapsys.viz` provides two visualization tiers for control experiments:
 
-`synapsys.viz.simview` provides **plug-and-play 3D simulation windows** that combine
-real-time PyVista rendering and matplotlib telemetry in a single PySide6 interface —
-ready to accept any controller you design.
+| | `CartPole2DView` | `CartPoleView` / `PendulumView` / `MassSpringDamperView` |
+|---|---|---|
+| **Rendering** | 2D matplotlib | 3D PyVista + matplotlib telemetry |
+| **Dependencies** | `matplotlib` only | `pyside6`, `pyvistaqt`, `matplotlib` |
+| **Works headless** | Yes (Agg backend) | No — requires a display |
+| **Entry point** | `run()` / `simulate()` / `animate()` | `run()` |
+| **System** | Cart-Pole only | Cart-Pole, Pendulum, MSD |
 
 ---
 
-## What you get in one line
+## 2D View — `CartPole2DView`
+
+Lightweight option: no Qt, no PyVista — runs anywhere matplotlib runs.
+
+![CartPole 2D animation](/img/simview/cartpole.gif)
+
+```python
+from synapsys.viz import CartPole2DView
+
+# Auto-LQR, interactive window
+CartPole2DView().run()
+
+# Headless: returns history dict (no window)
+hist = CartPole2DView(duration=5.0).simulate()
+print(hist["angle"][-1])   # final pole angle (rad)
+
+# Save to GIF
+CartPole2DView().animate(save="cartpole.gif")
+```
+
+Use `CartPole2DView` when:
+- You're on a server / CI / notebook without a Qt display
+- You only need the cart-pole system
+- You want to export an animation or run batch simulations
+
+---
+
+## 3D Views — SimView
+
+Full real-time window combining PyVista 3D animation and matplotlib telemetry panels.
+
+![Cart-Pole — real-time 3D simulation](/img/simview/cartpole.gif)
 
 ```python
 from synapsys.viz import CartPoleView
@@ -30,6 +65,14 @@ A complete window with:
 - **Automatic LQR** — if no controller is provided, the lib linearizes the simulator and designs an LQR internally
 - **Global keyboard capture** — A/D (perturbation), R (reset), Space (pause), Q (close)
 
+### Available 3D simulators
+
+| Class | Physical system | State | Input | Perturbation |
+|---|---|---|---|---|
+| `CartPoleView` | Cart + inverted pendulum | `[x, ẋ, θ, θ̇]` | Horizontal force on cart (N) | ◀/▶ horizontal force |
+| `PendulumView` | Single-link inverted pendulum | `[θ, θ̇]` | Joint torque (N·m) | ↺/↻ angular torque |
+| `MassSpringDamperView` | Mass-spring-damper | `[q, q̇]` | External force (N) | ◀/▶ force + setpoints 1/2/3 |
+
 ---
 
 ## Architecture
@@ -37,6 +80,8 @@ A complete window with:
 ```
 SimulatorBase          ← synapsys.simulators
 │  dynamics(), step(), linearize()
+│
+├── CartPoleSim  ──→  CartPole2DView     (matplotlib 2D, no Qt)
 │
 SimViewBase            ← synapsys.viz.simview._base  (QMainWindow)
 │  • creates Qt window (3D + matplotlib splitter)
@@ -49,19 +94,6 @@ SimViewBase            ← synapsys.viz.simview._base  (QMainWindow)
 ├── PendulumView        ← state: [θ, θ̇]
 └── MassSpringDamperView ← state: [q, q̇]  + setpoint tracking
 ```
-
-Each subclass implements only what is specific to its physical system
-(3D scene, charts, HUD, LQR parameters). All Qt boilerplate is inherited from the base.
-
----
-
-## Available simulators
-
-| Class | Physical system | State | Input | Perturbation |
-|---|---|---|---|---|
-| `CartPoleView` | Cart + inverted pendulum | `[x, ẋ, θ, θ̇]` | Horizontal force on cart (N) | ◀/▶ horizontal force |
-| `PendulumView` | Single-link inverted pendulum | `[θ, θ̇]` | Joint torque (N·m) | ↺/↻ angular torque |
-| `MassSpringDamperView` | Mass-spring-damper | `[q, q̇]` | External force (N) | ◀/▶ force + setpoints 1/2/3 |
 
 ---
 
@@ -85,30 +117,35 @@ Each subclass implements only what is specific to its physical system
 <td>1 line + your function</td>
 <td>No</td>
 </tr>
+<tr>
+<td><code>CartPole2DView().simulate()</code></td>
+<td>1 line</td>
+<td>No — pure matplotlib</td>
+</tr>
 </tbody>
 </table>
-
-The standalone files in `examples/simulators/` remain available as a reference for
-anyone who wants to understand the internal implementation or build highly customized
-UIs beyond what the library provides.
 
 ---
 
 ## Dependencies
 
 ```bash
+# Minimal — CartPole2DView only
+pip install synapsys
+
+# Full 3D support
 pip install synapsys[viz]
 # or individually:
 pip install pyside6 pyvistaqt matplotlib numpy
 ```
 
 > **Note:** `pyvistaqt` requires a VTK installation compatible with Qt.
-> In headless environments (servers without a display), use `pyvista` with the offscreen backend.
+> In headless environments (servers without a display), use `CartPole2DView` instead.
 
 ---
 
 ## Next steps
 
-- [Usage guide →](./simview)
+- [3D simulator usage guide →](./simview)
 - [Connecting your own controller →](./custom-controller)
 - [API Reference →](../../api/viz)

--- a/website/docs/guide/viz/simview.md
+++ b/website/docs/guide/viz/simview.md
@@ -254,13 +254,83 @@ The **magnitude slider** sets the maximum perturbation value. Ranges by simulato
 
 ---
 
+## Camera presets
+
+Four named camera angles are available via `set_camera_preset()`.
+Call it **before** `run()`:
+
+| Preset | Description |
+|---|---|
+| `"iso"` | Isometric — good for seeing the full scene |
+| `"top"` | Top-down orthographic |
+| `"side"` | Side view (X–Z plane) |
+| `"follow"` | Low follow-cam, close behind the system |
+
+```python
+from synapsys.viz import CartPoleView
+
+view = CartPoleView()
+view.set_camera_preset("top")
+view.run()
+```
+
+---
+
+## 3D trajectory trail
+
+Enable a trajectory trail that traces the pole tip (or mass position) over time.
+Call `toggle_trail()` before `run()`:
+
+```python
+from synapsys.viz import CartPoleView
+
+view = CartPoleView()
+view.toggle_trail()   # enable — shown in violet (#7c3aed)
+view.run()
+```
+
+The trail keeps the **last 200 points**. Call `toggle_trail()` again to disable and
+clear it. Each view tracks its own physically meaningful position:
+
+| View | Trail point |
+|---|---|
+| `CartPoleView` | Pole tip `[p + l·sin(θ), 0, pivot_z + l·cos(θ)]` |
+| `PendulumView` | Pole tip `[l·sin(θ), 0, pivot_z + l·cos(θ)]` |
+| `MassSpringDamperView` | Mass centre `[q, 0, mass_h/2]` |
+
+---
+
+## Saving animations
+
+Pass `save=` to any SimView constructor to record the session to a file when the window
+closes. Requires *Pillow* for GIF or *ffmpeg* for MP4.
+
+```python
+from synapsys.viz import CartPoleView, PendulumView, MassSpringDamperView
+
+CartPoleView(save="cartpole.gif").run()
+PendulumView(save="pendulum.mp4").run()
+MassSpringDamperView(save="msd.gif").run()
+```
+
+For the lightweight 2D view, pass `save=` to `animate()`:
+
+```python
+from synapsys.viz import CartPole2DView
+
+CartPole2DView().animate(save="cartpole2d.gif")
+```
+
+---
+
 ## Color palette
 
 All visual elements use the canonical palette tokens.
-See [Dark color tokens →](../../api/viz#dark)
+See [Dark color tokens →](../../api/viz#dark) and [Light color tokens →](../../api/viz#light)
 
 ```python
-from synapsys.viz.palette import Dark, mpl_theme
+from synapsys.viz.palette import Dark, Light, mpl_theme
 
-mpl_theme()  # apply dark theme globally to matplotlib
+mpl_theme()           # apply dark theme globally to matplotlib
+mpl_theme("light")    # light theme (white background)
 ```

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -71,6 +71,16 @@ const sidebars: SidebarsConfig = {
         },
         {
           type: 'category',
+          label: 'Simulators',
+          items: [
+            'guide/simulators/simulators-overview',
+            'guide/simulators/simulators-msd',
+            'guide/simulators/simulators-inverted-pendulum',
+            'guide/simulators/simulators-cartpole',
+          ],
+        },
+        {
+          type: 'category',
           label: 'Visualization',
           items: [
             'guide/viz/viz-overview',


### PR DESCRIPTION
## Summary

- Add `Light` palette class alongside `Dark`; `mpl_theme()` now accepts `"light"` or `"dark"` — closes #69
- Add `_trail_point(x)` hook to `SimViewBase` and all concrete views (CartPole, Pendulum, MSD) — closes #69
- Add `save=` parameter to all `SimView` constructors for animation export — closes #69
- Add integrator benchmark script (`examples/simulators/04_integrator_benchmark.py`) comparing Euler / RK4 / RK45 wall-clock time and RMS angle error — closes #70
- Add **Simulators** section to website sidebar with 4 individual doc pages (Overview, MSD, Inverted Pendulum, Cart-Pole) — closes #70

## Test plan

- [x] All 556 tests pass (`pytest`)
- [x] `TestLightPalette` (8 tests) — Light class, BG/FG contrast, mpl_theme dispatch
- [x] `TestTrailPointHook` (4 tests) — `_trail_point()` shape and CartPole x-position
- [x] `TestSavePath` (3 tests) — `_save_path` default and constructor forwarding
- [x] Docusaurus build passes (all 4 simulator pages render)
- [x] Website dev server verified: all simulator URLs return 200