### PR TITLE
docs: add PT-BR translations for simulator pages v0.2.7

### DIFF
--- a/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/guide/simulators/cartpole.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/guide/simulators/cartpole.md
@@ -1,0 +1,148 @@
+---
+id: simulators-cartpole
+title: Simulador Cart-Pole
+sidebar_label: Cart-Pole
+sidebar_position: 4
+---
+
+# Simulador Cart-Pole
+
+`CartPoleSim` implementa o cart-pole Lagrangiano clássico: um carrinho deslizando
+sobre um trilho sem atrito com um pêndulo invertido acoplado no pivô.
+
+---
+
+## Modelo físico
+
+**Estados:** `x = [p, ṗ, θ, θ̇]`
+- `p` — posição do carrinho (m)
+- `ṗ` — velocidade do carrinho (m/s)
+- `θ` — ângulo da haste em relação à vertical (rad, θ=0 → equilibrado)
+- `θ̇` — velocidade angular da haste (rad/s)
+
+**Entrada:** `u = [F]` — força horizontal no carrinho (N)
+
+**Saída:** `y = [p, θ]` — observação parcial (sem velocidades)
+
+**Dinâmica não-linear (Lagrangiana):**
+
+```
+Δ  = m_c + m_p · sin²(θ)
+p̈  = [F + m_p · sin(θ) · (l · θ̇² − g · cos(θ))] / Δ
+θ̈  = [g · sin(θ) − p̈ · cos(θ)] / l
+```
+
+---
+
+## Construção
+
+```python
+from synapsys.simulators import CartPoleSim
+
+sim = CartPoleSim(
+    m_c=1.0,            # massa do carrinho (kg)
+    m_p=0.1,            # massa da ponta da haste (kg)
+    l=0.5,              # comprimento da haste (m)
+    g=9.81,             # gravidade (m/s²)
+    integrator="rk4",   # "euler", "rk4" ou "rk45"
+    noise_std=0.0,       # ruído de sensor
+    disturbance_std=0.0, # perturbação na entrada
+    linearised=False,    # True → usar dinâmica linearizada
+)
+```
+
+---
+
+## Modo linearizado
+
+Para ângulos pequenos, a dinâmica não-linear simplifica para um sistema linear.
+Passe `linearised=True` para usar essa aproximação:
+
+```python
+sim_nl = CartPoleSim(linearised=False)   # não-linear completo
+sim_l  = CartPoleSim(linearised=True)    # aproximação linear
+
+# Próximo a θ=0 ambos se comportam de forma idêntica (atol ≈ 1e-4 para dt=0,01 s)
+```
+
+---
+
+## Estabilização por LQR
+
+```python
+import numpy as np
+from synapsys.algorithms.lqr import lqr
+
+sim = CartPoleSim()
+sim.reset()
+ss = sim.linearize(np.zeros(4), np.zeros(1))
+
+Q = np.diag([1.0, 0.1, 100.0, 10.0])   # penaliza fortemente o ângulo
+R = np.eye(1) * 0.01
+K, _ = lqr(ss.A, ss.B, Q, R)
+
+sim.reset(x0=np.array([0.0, 0.0, 0.15, 0.0]))
+for _ in range(500):
+    x = sim.state
+    u = np.clip(-K @ x, -50, 50)
+    y, info = sim.step(u, dt=0.02)
+    if info["failed"]:
+        break
+```
+
+---
+
+## Animação 2D com matplotlib
+
+```python
+from synapsys.viz import CartPole2DView
+
+# LQR automático
+CartPole2DView().run()
+
+# Controlador customizado
+CartPole2DView(controller=lambda x: np.clip(-K @ x, -50, 50)).run()
+
+# Simulação sem display
+hist = CartPole2DView(dt=0.02, duration=5.0).simulate()
+print(hist["angle"][-1])   # ângulo final da haste (rad)
+
+# Salvar animação
+view = CartPole2DView()
+anim = view.animate(save="cartpole.gif")
+```
+
+---
+
+## Detecção de falha
+
+O simulador sinaliza falha quando o sistema sai da região segura:
+
+| Condição | Valor |
+|---|---|
+| Carrinho fora dos limites | `\|p\| > 4,8 m` |
+| Haste caiu | `\|θ\| > π/3 rad (≈ 60°)` |
+
+```python
+y, info = sim.step(u, dt)
+if info["failed"]:
+    print("Episódio encerrado — reiniciando")
+    sim.reset()
+```
+
+---
+
+## Atualização de parâmetros thread-safe
+
+```python
+import threading
+
+def controlador_lento():
+    while True:
+        sim.set_params(m_c=2.0)   # seguro a partir de qualquer thread
+
+t = threading.Thread(target=controlador_lento, daemon=True)
+t.start()
+```
+
+Chaves aceitas: `m_c`, `m_p`, `l`, `g`.

--- a/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/guide/simulators/inverted-pendulum.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/guide/simulators/inverted-pendulum.md
@@ -1,0 +1,92 @@
+---
+id: simulators-inverted-pendulum
+title: Simulador Pêndulo Invertido
+sidebar_label: Pêndulo Invertido
+sidebar_position: 3
+---
+
+# Simulador Pêndulo Invertido
+
+`InvertedPendulumSim` implementa um pêndulo invertido não-linear em pivô fixo —
+o sistema intrinsecamente instável mais simples e um benchmark clássico para
+projeto de controladores.
+
+---
+
+## Modelo físico
+
+**Estados:** `x = [θ, θ̇]`
+- `θ` — ângulo em relação à vertical (rad, θ=0 → equilibrado)
+- `θ̇` — velocidade angular (rad/s)
+
+**Entrada:** `u = [τ]` — torque no pivô (N·m)
+
+**Saída:** `y = [θ]` — ângulo da haste apenas
+
+**Dinâmica não-linear:**
+
+```
+I = m · l²
+θ̈ = (g/l) · sin(θ) − (b/I) · θ̇ + τ/I
+```
+
+**Polo instável** (b=0): `λ_instável = +√(g/l)`
+
+---
+
+## Construção
+
+```python
+from synapsys.simulators import InvertedPendulumSim
+
+sim = InvertedPendulumSim(
+    m=1.0,              # massa do pêndulo (kg)
+    l=1.0,              # comprimento do pêndulo (m)
+    g=9.81,             # gravidade (m/s²)
+    b=0.0,              # coeficiente de atrito (N·m·s/rad)
+    integrator="rk4",
+    noise_std=0.0,
+    disturbance_std=0.0,
+)
+```
+
+---
+
+## Estabilização por LQR
+
+```python
+import numpy as np
+from synapsys.algorithms.lqr import lqr
+
+sim = InvertedPendulumSim(m=1.0, l=1.0, g=9.81, b=0.1)
+sim.reset()
+ss = sim.linearize(np.zeros(2), np.zeros(1))
+
+K, _ = lqr(ss.A, ss.B, np.diag([10.0, 1.0]), np.eye(1))
+
+sim.reset(x0=np.array([0.1, 0.0]))
+for _ in range(1000):
+    x = sim.state
+    u = -K @ x
+    y, info = sim.step(u, dt=0.01)
+    if info["failed"]:
+        break
+```
+
+---
+
+## Detecção de falha
+
+`info["failed"]` é `True` quando `|θ| > π/2 rad` (haste ultrapassou a horizontal).
+
+---
+
+## Utilitários
+
+```python
+# Polo instável em malha aberta (teórico)
+sim.unstable_pole()   # ≈ √(g/l)
+
+# Atualização de parâmetros thread-safe
+sim.set_params(b=0.5)   # aceitos: m, l, g, b
+```

--- a/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/guide/simulators/mass-spring-damper.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/guide/simulators/mass-spring-damper.md
@@ -1,0 +1,88 @@
+---
+id: simulators-msd
+title: Simulador Massa-Mola-Amortecedor
+sidebar_label: Massa-Mola-Amortecedor
+sidebar_position: 2
+---
+
+# Simulador Massa-Mola-Amortecedor
+
+`MassSpringDamperSim` é o simulador de segunda ordem mais simples — um sistema linear
+MMA de 1-DOF. É sempre estável para parâmetros positivos e serve como ponto de entrada
+para compreender o `SimulatorBase`.
+
+---
+
+## Modelo físico
+
+**Estados:** `x = [q, q̇]`
+- `q` — deslocamento em relação ao repouso (m)
+- `q̇` — velocidade (m/s)
+
+**Entrada:** `u = [F]` — força aplicada (N)
+
+**Saída:** `y = [q]` — posição apenas
+
+**Dinâmica:**
+
+```
+m·q̈ + c·q̇ + k·q = F
+```
+
+---
+
+## Construção
+
+```python
+from synapsys.simulators import MassSpringDamperSim
+
+sim = MassSpringDamperSim(
+    m=1.0,              # massa (kg)
+    c=0.5,              # coeficiente de amortecimento (N·s/m)
+    k=2.0,              # rigidez da mola (N/m)
+    integrator="rk4",
+    noise_std=0.0,
+    disturbance_std=0.0,
+)
+```
+
+---
+
+## Resposta ao degrau
+
+```python
+import numpy as np
+
+sim = MassSpringDamperSim()
+sim.reset()
+
+history = []
+for _ in range(300):
+    y, _ = sim.step(np.array([1.0]), dt=0.05)  # força constante
+    history.append(y[0])
+
+# deslocamento em regime permanente = F / k = 1,0 / 2,0 = 0,5 m
+print(f"Regime permanente: {history[-1]:.4f} m")
+```
+
+---
+
+## Validação da linearização
+
+Como o MMA já é linear, `linearize()` deve retornar as matrizes analíticas conhecidas:
+
+```python
+ss = sim.linearize(np.zeros(2), np.zeros(1))
+# A = [[0, 1], [-k/m, -c/m]]
+# B = [[0], [1/m]]
+# C = [[1, 0]]
+# D = [[0]]
+```
+
+---
+
+## Atualização de parâmetros thread-safe
+
+```python
+sim.set_params(m=2.0, k=5.0)   # aceitos: m, c, k
+```

--- a/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/guide/simulators/overview.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/guide/simulators/overview.md
@@ -1,0 +1,114 @@
+---
+id: simulators-overview
+title: Simuladores Físicos — Visão Geral
+sidebar_label: Visão Geral
+sidebar_position: 1
+---
+
+# Simuladores Físicos
+
+`synapsys.simulators` fornece simuladores físicos contínuos e não-lineares com uma
+interface unificada para projeto de controladores, testes e aprendizado por reforço.
+
+---
+
+## Simuladores disponíveis
+
+| Classe | Sistema | Estados | Entradas | Saídas |
+|---|---|---|---|---|
+| `MassSpringDamperSim` | MMA linear 1-DOF | `[q, q̇]` | `[F]` | `[q]` |
+| `InvertedPendulumSim` | Pêndulo não-linear em pivô fixo | `[θ, θ̇]` | `[τ]` | `[θ]` |
+| `CartPoleSim` | Cart-pole Lagrangiano | `[p, ṗ, θ, θ̇]` | `[F]` | `[p, θ]` |
+
+---
+
+## Interface comum
+
+Todo simulador herda de `SimulatorBase` e expõe a mesma API:
+
+```python
+from synapsys.simulators import CartPoleSim
+
+sim = CartPoleSim()
+y = sim.reset()                   # reset → observação inicial
+y, info = sim.step(u, dt=0.02)    # avança um passo
+ss  = sim.linearize(x0, u0)      # linearização numérica → StateSpace
+```
+
+### Dicionário `info` do `step()`
+
+```python
+y, info = sim.step(u, dt=0.02)
+info["x"]       # estado completo após o passo
+info["t_step"]  # tempo de integração (= dt)
+info["failed"]  # True quando o sistema saiu da região segura
+```
+
+---
+
+## Integradores
+
+Todos os simuladores suportam três métodos de integração numérica, selecionáveis na construção:
+
+| Método | Precisão | Velocidade | Uso recomendado |
+|---|---|---|---|
+| `"euler"` | Baixa | Mais rápido | dt muito pequeno (≤ 1 ms), loops internos de RL |
+| `"rk4"` | Alta | Rápido | Padrão — bom equilíbrio |
+| `"rk45"` | Muito alta | Mais lento | Referência / validação |
+
+```python
+sim = CartPoleSim(integrator="rk4")   # padrão
+sim = CartPoleSim(integrator="euler") # mais rápido
+```
+
+---
+
+## Ruído e perturbações
+
+```python
+sim = InvertedPendulumSim(noise_std=0.01, disturbance_std=0.05)
+```
+
+- `noise_std` — ruído gaussiano adicionado a cada observação (modelo de ruído de sensor)
+- `disturbance_std` — ruído gaussiano injetado na entrada de controle (ruído de processo)
+
+---
+
+## Atualização de parâmetros thread-safe
+
+Todos os simuladores suportam alterações de parâmetros em tempo real a partir de outra thread:
+
+```python
+sim.set_params(m=0.5)     # InvertedPendulumSim
+sim.set_params(m_c=2.0)   # CartPoleSim
+```
+
+---
+
+## Detecção de falha
+
+```python
+y, info = sim.step(u, dt)
+if info["failed"]:
+    sim.reset()
+```
+
+| Simulador | Condição de falha |
+|---|---|
+| `CartPoleSim` | `\|p\| > 4,8 m` ou `\|θ\| > π/3 rad` |
+| `InvertedPendulumSim` | `\|θ\| > π/2 rad` |
+| `MassSpringDamperSim` | nunca (sempre estável) |
+
+---
+
+## Linearização
+
+Todo simulador expõe `linearize(x0, u0)`, que retorna um `StateSpace` contínuo
+via diferenças finitas centrais — pronto para projeto LQR:
+
+```python
+from synapsys.algorithms.lqr import lqr
+
+ss = sim.linearize(np.zeros(4), np.zeros(1))
+K, _ = lqr(ss.A, ss.B, Q, R)
+```


### PR DESCRIPTION
Add PT-BR translations missing from v0.2.7 snapshot: overview, mass-spring-damper, inverted-pendulum, cartpole.