### PR TITLE
docs: complete PT-BR translations for v0.2.7

### DIFF
--- a/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/api/agents.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/api/agents.md
@@ -1,0 +1,133 @@
+---
+id: agents
+title: synapsys.agents
+sidebar_position: 4
+---
+
+# synapsys.agents
+
+Multi-agent infrastructure for distributed control simulation.
+
+## Performative (Enum)
+
+FIPA ACL performatives: `INFORM`, `REQUEST`, `AGREE`, `REFUSE`, `FAILURE`, `SUBSCRIBE`.
+
+## ACLMessage
+
+Structured message for inter-agent communication.
+
+```python
+ACLMessage(
+    performative: Performative,
+    sender: str,
+    receiver: str,
+    content: dict,
+)
+```
+
+| Method | Description |
+|--------|-------------|
+| `reply(performative, content) -> ACLMessage` | Creates a reply message swapping sender/receiver |
+
+## SyncMode (Enum)
+
+- `WALL_CLOCK` — real-time execution, sleeps between ticks
+- `LOCK_STEP` — advances only when `tick()` is called externally
+
+## SyncEngine
+
+Controls simulation time for an agent.
+
+```python
+SyncEngine(mode: SyncMode = SyncMode.WALL_CLOCK, dt: float = 0.01)
+```
+
+| Property / Method | Description |
+|---|---|
+| `mode` | The `SyncMode` this engine is running in |
+| `dt` | Step size in seconds |
+| `k` *(property)* | Current discrete step counter |
+| `t` *(property)* | Simulation time in seconds: `k × dt` |
+| `elapsed` *(property)* | Wall-clock seconds since the engine was created or last reset |
+| `tick()` | Advances `k` by 1; blocks in `WALL_CLOCK` mode to maintain real-time pacing |
+| `reset()` | Resets `k` to 0 and restarts the wall-clock reference |
+
+## BaseAgent
+
+Abstract base class. Subclass and override `setup()`, `step()`, and `teardown()`.
+
+| Method | Description |
+|--------|-------------|
+| `start(blocking=True)` | Starts the simulation loop in the **current thread** (`True`) or a background daemon thread (`False`) |
+| `stop()` | Signals the agent to stop after the current tick |
+
+## PlantAgent
+
+Simulates a discrete `StateSpace` plant in real time.
+
+```python
+PlantAgent(
+    name: str,
+    plant: StateSpace,
+    transport: TransportStrategy,
+    sync: SyncEngine,
+    channel_y: str = "y",   # channel name for plant output
+    channel_u: str = "u",   # channel name for control input
+    x0: np.ndarray | None = None,
+)
+```
+
+## ControllerAgent
+
+Applies a control law in real time.
+
+```python
+ControllerAgent(
+    name: str,
+    control_law: Callable[[np.ndarray], np.ndarray],
+    transport: TransportStrategy,
+    sync: SyncEngine,
+    channel_y: str = "y",   # channel name to read measurements from
+    channel_u: str = "u",   # channel name to write control commands to
+)
+```
+
+## HardwareAgent
+
+Bridges a physical (or mock) hardware device into the transport layer.
+Replaces `PlantAgent` in a HIL (Hardware-in-the-Loop) setup — the real
+device becomes the plant.
+
+```python
+HardwareAgent(
+    name: str,
+    hardware: HardwareInterface,
+    transport: TransportStrategy,
+    sync: SyncEngine,
+    channel_y: str = "y",      # channel to publish sensor measurements
+    channel_u: str = "u",      # channel to read actuator commands from
+    timeout_ms: float = 100.0, # per-call hardware I/O timeout
+)
+```
+
+Each tick: reads `y` from hardware → writes `y` to transport → reads `u` from
+transport → writes `u` to hardware. On `TimeoutError`, the last known `y`/`u`
+are held (Zero-Order Hold) and a warning is logged.
+
+```python
+from synapsys.hw import MockHardwareInterface
+from synapsys.agents import HardwareAgent, SyncEngine, SyncMode
+from synapsys.transport import SharedMemoryTransport
+
+hw    = MockHardwareInterface(n_inputs=1, n_outputs=1)
+bus   = SharedMemoryTransport("hil_bus", {"y": 1, "u": 1}, create=True)
+sync  = SyncEngine(SyncMode.WALL_CLOCK, dt=0.01)
+agent = HardwareAgent("hw_plant", hw, bus, sync)
+
+with hw:
+    agent.start(blocking=False)
+```
+
+## Source
+
+See [`synapsys/agents/`](https://github.com/synapsys-lab/synapsys/tree/main/synapsys/agents) on GitHub.

--- a/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/api/algorithms.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/api/algorithms.md
@@ -1,0 +1,62 @@
+---
+id: algorithms
+title: synapsys.algorithms
+sidebar_position: 3
+---
+
+# synapsys.algorithms
+
+Control algorithm implementations ready for use in agents or standalone scripts.
+
+## PID
+
+Discrete-time PID controller with output saturation and back-calculation anti-windup.
+
+### Constructor
+
+```python
+PID(
+    Kp: float,
+    Ki: float = 0.0,
+    Kd: float = 0.0,
+    dt: float = 0.01,
+    u_min: float = -inf,
+    u_max: float = inf,
+)
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `Kp` | Proportional gain |
+| `Ki` | Integral gain |
+| `Kd` | Derivative gain |
+| `dt` | Sample time in seconds |
+| `u_min`, `u_max` | Output saturation limits |
+
+### Methods
+
+| Method | Description |
+|--------|-------------|
+| `compute(setpoint, measurement) -> float` | Computes the control signal for one timestep |
+| `reset()` | Clears the integrator and previous error |
+
+## lqr
+
+Solves the infinite-horizon Linear Quadratic Regulator problem.
+
+```python
+lqr(A, B, Q, R) -> tuple[np.ndarray, np.ndarray]
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `A` | System matrix $(n \times n)$ |
+| `B` | Input matrix $(n \times m)$ |
+| `Q` | State cost matrix $(n \times n)$, positive semi-definite |
+| `R` | Control cost matrix $(m \times m)$, positive definite |
+
+**Returns:** `(K, P)` where `K` is the optimal gain and `P` is the Riccati solution.
+
+## Source
+
+See [`synapsys/algorithms/`](https://github.com/synapsys-lab/synapsys/tree/main/synapsys/algorithms) on GitHub.

--- a/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/api/core.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/api/core.md
@@ -1,0 +1,75 @@
+---
+id: core
+title: synapsys.core — LTI Math Engine
+sidebar_position: 2
+---
+
+# synapsys.core — LTI Math Engine
+
+The mathematical core of Synapsys. All LTI system representations live here.
+
+## LTIModel (Abstract Base Class)
+
+Base class for all LTI systems. Defines the common interface.
+
+| Method | Description |
+|--------|-------------|
+| `poles()` | Returns the system poles as a NumPy array |
+| `zeros()` | Returns the system zeros as a NumPy array |
+| `is_stable()` | `True` if all poles satisfy the stability criterion |
+| `evaluate(s_or_z)` | Evaluates the transfer function at a given complex point |
+| `step(t=None, n=200)` | Step response — `n` applies to discrete systems only |
+| `bode(omega=None)` | Returns `(omega [rad/s], mag [dB], phase [deg])` |
+| `simulate(t, u)` | Batch simulation for an arbitrary input array |
+
+## TransferFunction
+
+Represents a SISO LTI system as a ratio of polynomials: $G(s) = N(s)/D(s)$.
+
+| Attribute / Method | Description |
+|---|---|
+| `num` | Numerator coefficients (NumPy array, highest power first) |
+| `den` | Denominator coefficients (NumPy array, highest power first) |
+| `dt` | Sample time (`0.0` = continuous) |
+| `is_discrete` | `True` when `dt > 0` |
+| `order` | Degree of the denominator polynomial |
+| `evaluate(s)` | Evaluate $G(s)$ or $H(z)$ at a complex point |
+| `feedback(sensor=None)` | Closed-loop $T = G\,/\,(1 + G H)$ with negative feedback |
+| `to_state_space()` | Converts to `StateSpace` (controllable canonical form) |
+| `c2d(dt, method='zoh')` | Discretises (equivalent to `c2d()` API call) |
+| `evolve(x, u)` | One discrete step — requires `is_discrete == True` |
+| `simulate(t, u)` | Batch simulation for arbitrary input |
+| `__mul__`, `__add__`, `__truediv__`, `__neg__` | Block algebra operators |
+
+:::note
+`feedback(sensor=None)` uses only the `sensor` parameter — there is no `sign`
+argument. Positive feedback must be implemented manually.
+:::
+
+## StateSpace
+
+Represents an LTI system via $(A, B, C, D)$ matrices.
+
+| Attribute / Method | Description |
+|---|---|
+| `A, B, C, D` | System matrices (NumPy arrays) |
+| `dt` | Sample time (`0.0` = continuous) |
+| `n_states`, `n_inputs`, `n_outputs` | System dimensions |
+| `is_discrete` | `True` when `dt > 0` |
+| `evaluate(s_or_z)` | Evaluate the transfer matrix at a complex point |
+| `bode(omega=None)` | Returns `(omega [rad/s], mag [dB], phase [deg])` |
+| `evolve(x, u)` | One discrete step — raises `RuntimeError` if continuous |
+| `simulate(t, u)` | Batch simulation for arbitrary input |
+| `to_transfer_function()` | Converts to `TransferFunction` |
+| `c2d(dt, method='zoh')` | Discretises the continuous system |
+| `__mul__`, `__add__`, `__neg__` | Block algebra operators |
+
+:::warning
+`evolve(x, u)` requires a **discrete** system. Call `c2d()` first if your model
+is continuous. It does **not** mutate internal state — callers must store
+`x_next` between steps.
+:::
+
+## Source
+
+See [`synapsys/core/`](https://github.com/synapsys-lab/synapsys/tree/main/synapsys/core) on GitHub.

--- a/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/api/hw.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/api/hw.md
@@ -1,0 +1,86 @@
+---
+id: hw
+title: synapsys.hw — Hardware Abstraction
+sidebar_position: 6
+---
+
+# synapsys.hw — Hardware Abstraction
+
+Hardware abstraction layer for connecting Synapsys agents to physical devices (FPGAs, microcontrollers, PLCs) or in-process stubs for testing.
+
+## HardwareInterface (Abstract Base Class)
+
+Pluggable interface for bridging real hardware into the transport layer.
+All concrete implementations must subclass `HardwareInterface` and implement
+the four abstract methods below.
+
+```python
+from synapsys.hw import HardwareInterface
+```
+
+| Property / Method | Description |
+|---|---|
+| `n_inputs` *(property)* | Number of actuator channels (columns of `u`) |
+| `n_outputs` *(property)* | Number of sensor channels (rows of `y`) |
+| `connect() -> None` | Opens the hardware connection |
+| `disconnect() -> None` | Closes the hardware connection |
+| `read_outputs(timeout_ms=100) -> np.ndarray` | Reads sensor data from hardware |
+| `write_inputs(u, timeout_ms=100) -> None` | Sends actuator command to hardware |
+
+`HardwareInterface` also implements the context manager protocol (`__enter__` /
+`__exit__`), so `with hw:` automatically calls `connect()` and `disconnect()`.
+
+## MockHardwareInterface
+
+In-process hardware stub for unit-testing and HIL demos **without physical
+devices**.
+
+```python
+from synapsys.hw import MockHardwareInterface
+```
+
+```python
+MockHardwareInterface(
+    n_inputs: int,
+    n_outputs: int,
+    plant_fn: Callable[[np.ndarray], np.ndarray] | None = None,
+    latency_ms: float = 0.0,
+)
+```
+
+| Parameter | Description |
+|---|---|
+| `n_inputs` | Number of actuator channels |
+| `n_outputs` | Number of sensor channels |
+| `plant_fn` | `f(u) -> y` called on every `write_inputs`. Defaults to `y = u` when dimensions match, otherwise zeros |
+| `latency_ms` | Artificial round-trip delay for jitter-tolerance testing |
+
+**Example — first-order discrete plant:**
+
+```python
+from synapsys.hw import MockHardwareInterface
+import numpy as np
+
+state = [0.0]
+def plant_fn(u):
+    state[0] = 0.9 * state[0] + 0.1 * u[0]
+    return np.array([state[0]])
+
+hw = MockHardwareInterface(n_inputs=1, n_outputs=1, plant_fn=plant_fn)
+with hw:
+    hw.write_inputs(np.array([1.0]))
+    y = hw.read_outputs()   # → approx [0.1]
+```
+
+## Planned implementations (v0.5)
+
+| Class | Hardware |
+|-------|----------|
+| `SerialHardwareInterface` | ESP32, STM32 via UART |
+| `OPCUAHardwareInterface` | PLCs, industrial SCADA (OPC-UA) |
+| `FPGAHardwareInterface` | FPGA/FPAA low-latency co-simulation |
+| `ROSTransport` | ROS 2 robotics bridge |
+
+## Source
+
+See [`synapsys/hw/`](https://github.com/synapsys-lab/synapsys/tree/main/synapsys/hw) on GitHub.

--- a/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/api/matlab-compat.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/api/matlab-compat.md
@@ -1,0 +1,50 @@
+---
+id: matlab-compat
+title: synapsys.api — MATLAB-Compatible Layer
+sidebar_position: 1
+---
+
+# synapsys.api — MATLAB-Compatible Layer
+
+High-level functions that mirror MATLAB syntax, delegating to the core classes.
+
+:::note
+This module is the recommended entry point for most users.
+:::
+
+## Functions
+
+| Function | MATLAB equivalent | Description |
+|----------|------------------|-------------|
+| `tf(num, den, dt=0)` | `tf(num, den)` | Create a `TransferFunction` |
+| `ss(A, B, C, D, dt=0)` | `ss(A, B, C, D)` | Create a `StateSpace` |
+| `c2d(sys, dt, method='zoh')` | `c2d(sys, dt)` | Discretise a continuous system |
+| `step(sys, T=None)` | `step(sys)` | Step response — returns `(t, y)` |
+| `bode(sys, w=None)` | `bode(sys)` | Returns `(omega [rad/s], mag [dB], phase [deg])` |
+| `feedback(G, H=None)` | `feedback(G, H)` | Closed-loop $T = G/(1+GH)$ with negative feedback |
+
+### `c2d` discretisation methods
+
+| `method` | Description |
+|----------|-------------|
+| `'zoh'` | Zero-Order Hold (default) — exact for piecewise-constant inputs |
+| `'bilinear'` | Tustin / trapezoidal approximation |
+| `'euler'` | Forward Euler (explicit) — fast but conditionally stable |
+| `'backward_diff'` | Backward Euler (implicit) — unconditionally stable |
+
+## Example
+
+```python
+from synapsys.api import tf, c2d, step, bode, feedback
+
+G = tf([1], [1, 2, 1])          # G(s) = 1/(s+1)^2
+T = feedback(G)                  # closed-loop
+Gd = c2d(G, dt=0.05)            # ZOH discretisation
+
+t, y = step(T)                   # step response
+w, mag, phase = bode(G)          # Bode data
+```
+
+## Source
+
+See [`synapsys/api/matlab_compat.py`](https://github.com/synapsys-lab/synapsys/blob/main/synapsys/api/matlab_compat.py) on GitHub.

--- a/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/api/transport.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/api/transport.md
@@ -1,0 +1,65 @@
+---
+id: transport
+title: synapsys.transport
+sidebar_position: 5
+---
+
+# synapsys.transport
+
+Transport strategy implementations for inter-process communication.
+
+## TransportStrategy (Abstract Base Class)
+
+All transports implement this interface:
+
+| Method | Description |
+|--------|-------------|
+| `write(channel: str, data: np.ndarray) -> None` | Writes data to a named channel |
+| `read(channel: str) -> np.ndarray` | Reads data from a named channel |
+| `close() -> None` | Releases resources |
+
+## SharedMemoryTransport
+
+Zero-copy transport using OS shared memory. Best for processes on the same machine.
+
+```python
+SharedMemoryTransport(
+    name: str,
+    channels: dict[str, int],
+    create: bool = False,
+)
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `name` | OS shared memory block identifier |
+| `channels` | Dict mapping channel name to number of float64 values |
+| `create` | `True` for the owner process (allocates memory) |
+
+:::warning
+Only the `create=True` instance calls `unlink()` on close. All other instances call only `close()`.
+:::
+
+## ZMQTransport
+
+PUB/SUB asynchronous transport over a network.
+
+```python
+ZMQTransport(address: str, mode: Literal["pub", "sub"])
+```
+
+## ZMQReqRepTransport {#zmqrepreptransport}
+
+Synchronous REQ/REP transport for lock-step simulation over a network.
+
+```python
+ZMQReqRepTransport(address: str, mode: Literal["server", "client"])
+```
+
+:::warning[Order matters]
+Server must call `read()` before `write()`. Client must call `write()` before `read()`. Mismatched order causes deadlock.
+:::
+
+## Source
+
+See [`synapsys/transport/`](https://github.com/synapsys-lab/synapsys/tree/main/synapsys/transport) on GitHub.

--- a/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/api/utils.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/api/utils.md
@@ -1,0 +1,119 @@
+---
+id: utils
+title: synapsys.utils — Matrix Helpers
+sidebar_position: 7
+---
+
+# synapsys.utils — Matrix Helpers
+
+Ergonomic utilities for building NumPy arrays and state-space matrices by name,
+reducing boilerplate when defining LTI models.
+
+```python
+from synapsys.utils import mat, col, row, StateEquations
+# or
+from synapsys import mat, col, row, StateEquations
+```
+
+## mat
+
+Creates a 2-D NumPy array from nested Python lists.
+
+```python
+mat(data: list[list[float]]) -> np.ndarray
+```
+
+```python
+A = mat([[0, 1], [-2, -3]])   # shape (2, 2)
+```
+
+## col
+
+Creates a column vector (shape `(n, 1)`) from a flat list or 1-D array.
+
+```python
+col(data: list[float] | np.ndarray) -> np.ndarray
+```
+
+```python
+B = col([0, 1])   # shape (2, 1)
+```
+
+## row
+
+Creates a row vector (shape `(1, n)`) from a flat list or 1-D array.
+
+```python
+row(data: list[float] | np.ndarray) -> np.ndarray
+```
+
+```python
+C = row([1, 0])   # shape (1, 2)
+```
+
+## StateEquations
+
+Fluent builder that constructs **A** and **B** matrices by declaring each
+differential equation by the names of its state and input variables.
+Eliminates manual index management for multi-state models.
+
+### Constructor
+
+```python
+StateEquations(
+    states: list[str],   # names of state variables
+    inputs: list[str],   # names of input variables
+)
+```
+
+### Methods
+
+| Method | Description |
+|--------|-------------|
+| `eq(state, **coeffs)` | Declares one equation. Keys matching a state name go to **A**; keys matching an input name go to **B** |
+| `output(*state_names)` | Builds a **C** matrix that selects the named states as outputs |
+
+### Properties
+
+| Property | Description |
+|----------|-------------|
+| `A` | System matrix $(n \times n)$ as `np.ndarray` |
+| `B` | Input matrix $(n \times m)$ as `np.ndarray` |
+| `states` | Ordered list of state variable names |
+| `inputs` | Ordered list of input variable names |
+
+### Example — 2-DOF mass-spring-damper
+
+State vector $\mathbf{x} = [x_1, x_2, v_1, v_2]^\top$, input $F$:
+
+```python
+from synapsys.utils import StateEquations
+from synapsys.api import ss, c2d
+
+m, c, k = 1.0, 0.1, 2.0
+
+eqs = (
+    StateEquations(states=["x1", "x2", "v1", "v2"], inputs=["F"])
+    .eq("x1", v1=1)
+    .eq("x2", v2=1)
+    .eq("v1", x1=-2*k/m, x2=k/m,  v1=-c/m)
+    .eq("v2", x1=k/m,  x2=-2*k/m, v2=-c/m, F=k/m)
+)
+
+# Build a StateSpace model directly from A and B
+C = eqs.output("x1", "x2")   # select positions as outputs
+plant = ss(eqs.A, eqs.B, C, [[0, 0]])
+plant_d = c2d(plant, dt=0.01)
+```
+
+:::tip
+`StateEquations` pairs naturally with `synapsys.algorithms.lqr`:
+```python
+from synapsys.algorithms import lqr
+K, P = lqr(eqs.A, eqs.B, Q, R)
+```
+:::
+
+## Source
+
+See [`synapsys/utils/`](https://github.com/synapsys-lab/synapsys/tree/main/synapsys/utils) on GitHub.

--- a/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/api/viz.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/api/viz.md
@@ -1,0 +1,243 @@
+---
+id: viz
+title: synapsys.viz
+sidebar_label: synapsys.viz
+---
+
+# `synapsys.viz`
+
+Módulo de visualização: paleta de cores canônica e janelas de simulação 3D plug-and-play.
+
+```python
+from synapsys.viz import (
+    Dark, mpl_theme,
+    CartPoleView, PendulumView, MassSpringDamperView,
+)
+```
+
+---
+
+## `SimViewBase`
+
+Classe base de todas as views. Herda de `QMainWindow`.
+**Não instanciar diretamente** — use as subclasses concretas.
+
+### Atributos de classe (configuráveis nas subclasses)
+
+| Atributo | Tipo | Padrão | Descrição |
+|---|---|---|---|
+| `_title` | `str` | `"Synapsys Simulator"` | Título da janela Qt |
+| `_mpl_title` | `str` | `"Telemetria"` | Título do painel matplotlib |
+| `_dt` | `float` | `0.02` | Passo de simulação em segundos |
+| `_hist_len` | `int` | `500` | Comprimento do deque de histórico |
+| `_mpl_skip` | `int` | `3` | Renderizar matplotlib a cada N ticks |
+| `_pert_max_default` | `float` | `20.0` | Magnitude padrão da perturbação |
+| `_slider_range` | `tuple` | `(1, 50)` | Faixa do slider de magnitude |
+| `_slider_unit` | `str` | `"N"` | Unidade exibida no label do slider |
+| `_splitter_w` | `tuple` | `(770, 630)` | Largura inicial dos painéis (3D, mpl) |
+| `_u_clip` | `float` | `50.0` | Saturação do controlador |
+| `_u_clip_total` | `float` | `80.0` | Saturação após adição da perturbação |
+
+### Método público
+
+#### `run() -> None`
+
+Cria `QApplication` (se não existir), inicializa `QMainWindow`, constrói a UI
+completa e entra no event loop Qt. **Não retorna** (chama `sys.exit`).
+
+```python
+CartPoleView().run()
+CartPoleView(controller=fn).run()
+```
+
+### Hooks (override opcional nas subclasses)
+
+| Método | Assinatura | Descrição |
+|---|---|---|
+| `_lqr_u(x)` | `(ndarray) → ndarray` | Lei de controle LQR. Padrão: `−K@x`. Override para setpoint tracking. |
+| `_pert_vector()` | `() → ndarray` | Converte `_pert` escalar para vetor de entrada. |
+| `_build_extra_controls(hb)` | `(QHBoxLayout) → None` | Injeta widgets extras na barra de controles. |
+| `_on_reset()` | `() → None` | Chamado após `sim.reset()` — útil para resetar estado extra. |
+| `_post_tick(x, u)` | `(ndarray, ndarray) → None` | Chamado ao final de cada tick. Usado para lógica de auto-reset (ex: limite do trilho no CartPole). |
+
+---
+
+## `CartPoleView`
+
+```python
+CartPoleView(
+    controller: Callable | None = None,
+    m_c: float = 1.0,              # massa do carrinho [kg]
+    m_p: float = 0.1,              # massa do bob [kg]
+    l:   float = 0.5,              # comprimento da haste [m]
+    g:   float = 9.81,             # gravidade [m/s²]
+    x0:  np.ndarray | None = None, # estado inicial (4,) — padrão [0,0,0.18,0]
+)
+```
+
+**Sistema:** carrinho sobre trilho com pêndulo invertido articulado.
+
+**Estado:** `x = [posição carrinho (m), velocidade (m/s), ângulo θ (rad), vel. angular (rad/s)]`
+
+**Entrada:** força horizontal no carrinho (N).
+
+**LQR padrão:** `Q = diag([1, 0.1, 100, 10])`, `R = 0.01·I`
+
+**Perturbação:** botões ◀/▶ e teclas A/D — força horizontal (1–80 N, padrão 30 N).
+
+**Auto-reset:** o carrinho é resetado automaticamente ao atingir 92% do comprimento do trilho (`_LIMIT_FRAC = 0.92`). Entre 72% e 92% o carrinho muda de cor para âmbar como aviso.
+
+---
+
+## `PendulumView`
+
+```python
+PendulumView(
+    controller: Callable | None = None,
+    m:  float = 1.0,              # massa do bob [kg]
+    l:  float = 1.0,              # comprimento da haste [m]
+    g:  float = 9.81,             # gravidade [m/s²]
+    b:  float = 0.1,              # amortecimento viscoso
+    x0: np.ndarray | None = None, # estado inicial (2,) — padrão [0.18, 0]
+)
+```
+
+**Sistema:** pêndulo invertido de 1 elo com base fixa.
+
+**Estado:** `x = [ângulo θ (rad), velocidade angular θ̇ (rad/s)]`
+
+**Entrada:** torque na junta (N·m).
+
+**Polo instável:** `λ = +√(g/l)` ≈ `+3.13 rad/s` nos parâmetros padrão.
+
+**LQR padrão:** `Q = diag([80, 5])`, `R = I`
+
+**Perturbação:** botões ↺/↻ e teclas A/D — torque (1–40 N·m, padrão 20 N·m).
+Setas vermelhas aparecem na ponta da haste indicando direção e magnitude.
+
+---
+
+## `MassSpringDamperView`
+
+```python
+MassSpringDamperView(
+    controller: Callable | None = None,
+    m:         float = 1.0,              # massa [kg]
+    c:         float = 0.5,              # amortecimento [N·s/m]
+    k:         float = 2.0,              # constante da mola [N/m]
+    x0:        np.ndarray | None = None, # estado inicial (2,) — padrão [0, 0]
+    setpoints: list | None = None,       # lista de (label, valor_m) — padrão 3 pontos
+)
+```
+
+**Sistema:** massa-mola-amortecedor 1D com rastreamento de setpoint.
+
+**Estado:** `x = [posição q (m), velocidade q̇ (m/s)]`
+
+**Entrada:** força externa (N).
+
+**LQR com feed-forward:** `u = −K·(x − x_ref) + k·sp`
+
+**Setpoints padrão:** `[("0 m", 0.0), ("+1.5 m", 1.5), ("−1.5 m", -1.5)]` (botões ou teclas 1/2/3).
+Setpoints customizados:
+
+```python
+MassSpringDamperView(setpoints=[("0", 0.0), ("+2m", 2.0), ("-2m", -2.0)]).run()
+```
+
+**Perturbação:** botões ◀/▶ e teclas A/D — força (1–30 N, padrão 15 N).
+
+---
+
+## `Dark`
+
+Classe de tokens de cor do design system Synapsys (espelho do website dark mode).
+
+```python
+from synapsys.viz.palette import Dark
+```
+
+### Fundos
+
+| Token | Hex | Uso |
+|---|---|---|
+| `Dark.BG` | `#111111` | Fundo da janela / figura matplotlib |
+| `Dark.SURFACE` | `#1a1a1a` | Cards, painéis, eixos matplotlib |
+| `Dark.PANEL` | `#1e1e1e` | GroupBox Qt |
+| `Dark.BORDER` | `#2e2e2e` | Bordas padrão |
+| `Dark.BORDER_LT` | `#222222` | Borda sutil |
+
+### Texto
+
+| Token | Hex | Uso |
+|---|---|---|
+| `Dark.FG` | `#e2e8f0` | Texto principal |
+| `Dark.MUTED` | `#999999` | Labels de eixo, texto secundário |
+| `Dark.SUBTLE` | `#666666` | Texto terciário / dicas |
+| `Dark.GRID` | `#2e2e2e` | Linhas de grade matplotlib |
+
+### Marca
+
+| Token | Hex | Uso |
+|---|---|---|
+| `Dark.GOLD` | `#c8a870` | Cor primária / destaque |
+| `Dark.GOLD_DIM` | `#987040` | Variante escura |
+| `Dark.GOLD_LT` | `#d8b880` | Variante clara |
+| `Dark.TEAL` | `#0d9488` | Cor secundária |
+
+### Estado / alerta
+
+| Token | Hex | Uso |
+|---|---|---|
+| `Dark.DANGER` | `#ef4444` | Erro, limite atingido, perturbação ativa |
+| `Dark.WARN` | `#f59e0b` | Aviso (ex: carrinho se aproximando do limite) |
+| `Dark.OK` | `#22c55e` | Estabilizado / ok |
+
+### Sinais
+
+| Token | Hex | Grandeza física |
+|---|---|---|
+| `Dark.SIG_POS` | `#3b82f6` | Posição / deslocamento |
+| `Dark.SIG_POS_LT` | `#60a5fa` | Posição (variante clara / segundo canal) |
+| `Dark.SIG_VEL` | `#f97316` | Velocidade / taxa |
+| `Dark.SIG_VEL_LT` | `#fb923c` | Velocidade (variante clara) |
+| `Dark.SIG_ANG` | `#f97316` | Ângulo |
+| `Dark.SIG_REF` | `#22c55e` | Setpoint / referência |
+| `Dark.SIG_REF_DK` | `#16a34a` | Referência (variante escura — linha tracejada) |
+| `Dark.SIG_REF_LT` | `#4ade80` | Referência (variante clara — checked/active) |
+| `Dark.SIG_CTRL` | `#ef4444` | Força / torque de controle |
+| `Dark.SIG_PHASE` | `#a78bfa` | Retrato de fase |
+| `Dark.SIG_TRAIL` | `#7c3aed` | Trilha 3D |
+| `Dark.SIG_ALT` | `#facc15` | Altitude z |
+| `Dark.SIG_CYAN` | `#38bdf8` | Ponto atual (dot marker) |
+
+### Objetos 3D
+
+| Token | Hex | Objeto |
+|---|---|---|
+| `Dark.MESH_BODY` | `#2563eb` | Corpo principal (massa, carrinho) |
+| `Dark.MESH_POLE` | `#c8a870` | Haste / braço |
+| `Dark.MESH_BOB` | `#f97316` | Bob / ponta da haste |
+| `Dark.MESH_SPRING` | `#c8a870` | Mola |
+| `Dark.MESH_DAMP` | `#64748b` | Amortecedor |
+| `Dark.MESH_STRUCT` | `#334155` | Estrutura / base |
+| `Dark.MESH_WALL` | `#334155` | Parede de ancoragem |
+| `Dark.MESH_FLOOR` | `#1a1a1a` | Chão / plano |
+| `Dark.MESH_RAIL` | `#475569` | Trilho |
+| `Dark.MESH_STOP` | `#ef4444` | Batente final |
+| `Dark.MESH_REF` | `#4ade80` | Esfera de referência (setpoint) |
+
+---
+
+## `mpl_theme()`
+
+```python
+from synapsys.viz.palette import mpl_theme
+mpl_theme()
+```
+
+Aplica rcParams globais do tema Synapsys ao matplotlib.
+Deve ser chamado **antes** de criar qualquer `Figure`.
+
+Configura automaticamente: `figure.facecolor`, `axes.facecolor`, grade, ticks,
+legenda e fonte (`JetBrains Mono`).

--- a/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/architecture.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/architecture.md
@@ -1,0 +1,105 @@
+---
+id: architecture
+title: Arquitetura
+sidebar_position: 3
+---
+
+# Arquitetura
+
+O Synapsys é construído em **seis camadas**. Cada camada tem uma única responsabilidade e depende apenas das camadas abaixo. Isso significa que você pode usar o núcleo matemático isoladamente sem tocar na infraestrutura de agentes, ou trocar o transporte sem alterar nenhuma lógica de controle.
+
+## Diagrama de camadas
+
+```mermaid
+%%{init: {'theme': 'dark'}}%%
+flowchart TB
+    subgraph UserAPI["1. API Pública — synapsys.api"]
+        direction LR
+        UI1["matlab_compat.py\ntf(), ss(), c2d(), step(), bode()"]
+        UI2["agent_api.py\nPlantAgent(), ControllerAgent()"]
+    end
+
+    subgraph CoreMath["2. Núcleo Matemático — synapsys.core"]
+        direction TB
+        M1["LTIModel (ABC)"]
+        M2["StateSpace"]
+        M3["TransferFunction"]
+        M5["TransferFunctionMatrix"]
+        M4["NumPy / SciPy solvers"]
+        M1 --> M2
+        M1 --> M3
+        M1 --> M5
+        M2 --> M4
+        M3 --> M4
+        M5 --> M3
+    end
+
+    subgraph ControlLogic["3. Algoritmos — synapsys.algorithms"]
+        direction LR
+        C1["Clássico: PID, LQR"]
+        C2["Avançado: MPC, Adaptativo (planejado)"]
+        C3["Reconfiguração em tempo real (planejado)"]
+    end
+
+    subgraph MAS["4. Sistema Multiagente — synapsys.agents"]
+        direction TB
+        A1["FIPA ACL Messages\nINFORM, REQUEST, ..."]
+        A2["SyncEngine\nWALL_CLOCK / LOCK_STEP"]
+        A3["BaseAgent -> PlantAgent, ControllerAgent"]
+    end
+
+    subgraph Transport["5. Transporte — synapsys.transport"]
+        direction TB
+        T1{"TransportStrategy (ABC)"}
+        T2["SharedMemoryTransport\nLatência zero-copy"]
+        T3["ZMQTransport / ZMQReqRepTransport\nRede TCP"]
+        T1 --> T2
+        T1 --> T3
+    end
+
+    subgraph Hardware["6. Hardware — synapsys.hw"]
+        direction LR
+        H1["HardwareInterface (ABC)"]
+        H2["FPGA / FPAA (planejado)"]
+        H3["Microcontroladores (planejado)"]
+    end
+
+    UserAPI ==> CoreMath
+    UserAPI ==> MAS
+    CoreMath ==> ControlLogic
+    MAS ==> Transport
+    Transport -.-> Hardware
+    ControlLogic -.-> MAS
+```
+
+## Decisões de projeto
+
+### Separação API / Motor matemático
+
+A camada `synapsys.api` é apenas um wrapper de conveniência. Toda a matemática vive em `synapsys.core`. Isso permite que a API evolua sem tocar no núcleo numérico.
+
+### Operator overloading nas classes LTI
+
+`G1 * G2` (série), `G1 + G2` (paralelo) e `G.feedback()` permitem compor sistemas com álgebra de blocos natural:
+
+```python
+T = (C * G).feedback()   # malha fechada: C em série com G
+```
+
+`TransferFunctionMatrix` estende essa álgebra para plantas MIMO: `*` realiza multiplicação matricial (série) e `+` é elemento a elemento (paralelo). Simulação e análise delegam para uma realização mínima em `StateSpace` construída de forma lazy por `to_state_space()`.
+
+### Padrão Strategy no transporte
+
+`PlantAgent` e `ControllerAgent` não sabem **como** os dados são enviados. Eles chamam `transport.write()` e `transport.read()`. A implementação concreta é injetada na construção — sem mudar lógica de controle.
+
+### Ciclo de vida do transporte
+
+O transporte é **gerenciado pelo chamador**, não pelo agente. O agente nunca chama `transport.close()`. Isso evita double-free quando múltiplos agentes compartilham visões do mesmo bloco de memória.
+
+### Contínuo vs Discreto
+
+`StateSpace(A, B, C, D, dt=0)` é contínuo. `dt > 0` é discreto. O mesmo objeto suporta ambos:
+
+- `is_stable()` usa `Re(poles) < 0` para contínuo e `|poles| < 1` para discreto
+- `step()` delega para `scipy.signal.step` ou `scipy.signal.dstep` automaticamente
+- `evolve(x, u)` executa `x(k+1) = Ax + Bu` passo a passo para simulação em tempo real

--- a/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/examples/advanced/custom-signals.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/examples/advanced/custom-signals.md
@@ -1,0 +1,110 @@
+---
+format: md
+id: custom-signals
+title: Custom Signal Injection
+sidebar_position: 1
+---
+
+# Custom Signal Injection (MIL / Batch Simulation)
+
+**File:** `examples/advanced/01_custom_signals/01_custom_signals.py`
+
+---
+
+## What this example shows
+
+How to feed **any arbitrary waveform** into an LTI model and observe the output — without real-time constraints. This is **Model-in-the-Loop (MIL)** simulation: everything runs in software, as fast as the CPU allows.
+
+The example also visually demonstrates the **principle of superposition**: the response to a combined input equals the sum of individual responses.
+
+---
+
+## Theory
+
+### MIL vs SIL vs HIL
+
+| Mode | Plant | Controller | Real-time |
+|---|---|---|---|
+| **MIL** | Math model | Math model | No — runs at CPU speed |
+| **SIL** | Math model (real-time) | Real software | Yes |
+| **HIL** | Real hardware | Real software | Yes |
+
+MIL is ideal for batch testing, parameter sweeps, and signal analysis.
+
+### Principle of Superposition
+
+For any linear system $G(s)$:
+
+$$
+G(u_1 + u_2) = G(u_1) + G(u_2)
+$$
+
+This example combines:
+1. A **1.5 Hz sine wave** — simulating periodic mechanical vibration
+2. A **step of amplitude 2 at $t=5\,\text{s}$** — simulating a sudden load change
+
+---
+
+## System used
+
+$$
+G(s) = \frac{10}{s^2 + 5s + 10} \qquad \omega_n = \sqrt{10} \approx 3.16\,\text{rad/s},\quad \zeta \approx 0.79
+$$
+
+Well-damped (close to critically damped) — attenuates the sine and responds smoothly to the step.
+
+---
+
+## Result
+
+![Custom signal injection: input sine+step and output](/img/examples/02_custom_signals.png)
+
+**Top panel:** the combined input $u(t)$ = sine + step. The vertical line marks $t=5\,\text{s}$ when the step is injected.
+
+**Bottom panel:** the plant output $y(t)$. The DC level shifts upward after $t=5\,\text{s}$ while the oscillation from the sine continues — superposition in action.
+
+---
+
+## Code
+
+```python
+import numpy as np
+from synapsys.api import tf
+import matplotlib.pyplot as plt
+
+G = tf([10], [1, 5, 10])
+
+t = np.linspace(0, 10, 1000)
+
+# 1.5 Hz mechanical vibration
+u_sine = np.sin(2 * np.pi * 1.5 * t)
+
+# Step disturbance at t = 5 s
+u_step = np.where(t >= 5, 2.0, 0.0)
+
+# Superposition
+u_total = u_sine + u_step
+
+t_out, y_out = G.simulate(t, u_total)
+
+plt.plot(t_out, u_total, label="Input u(t)")
+plt.plot(t_out, y_out, label="Output y(t)", linewidth=2)
+plt.legend()
+plt.show()
+```
+
+### Key API calls
+
+| Call | What it does |
+|---|---|
+| `tf(num, den)` | Builds the LTI transfer function |
+| `G.simulate(t, u)` | Computes output for arbitrary input array `u` over time `t` via `scipy.signal.lsim` |
+| `np.where(cond, a, b)` | Vectorised conditional — creates the step signal efficiently |
+
+---
+
+## How to run
+
+```bash
+uv run python examples/advanced/01_custom_signals/01_custom_signals.py
+```

--- a/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/examples/advanced/digital-twin.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/examples/advanced/digital-twin.md
@@ -1,0 +1,140 @@
+---
+format: md
+id: digital-twin
+title: Digital Twin
+sidebar_position: 5
+---
+
+# Digital Twin with Anomaly Detection
+
+**File:** `examples/advanced/05_digital_twin/05_digital_twin.py`
+
+---
+
+## What this example shows
+
+The **Digital Twin** pattern: a virtual model of a physical system runs in parallel, fed with the same control inputs. When the physical system starts behaving differently from the model (due to wear or damage), the divergence metric triggers an alert.
+
+---
+
+## Architecture
+
+```mermaid
+%%{init: {'theme': 'dark'}}%%
+flowchart TB
+    U["u(t) — same input to both"]
+
+    subgraph Physical["Physical Plant (may drift)"]
+        PP["PlantAgent\n pole: s=-1 → s=-2 after 3s"]
+    end
+
+    subgraph Virtual["Virtual Twin (nominal model)"]
+        VP["plant_nominal.evolve()\n pole: s=-1 (fixed)"]
+    end
+
+    subgraph Monitor["Divergence Monitor (main thread)"]
+        DIV["divergence = |y_physical − y_virtual|"]
+        ALERT["🔴 ALERT if > threshold"]
+    end
+
+    U --> PP
+    U --> VP
+    PP -->|y_physical| DIV
+    VP -->|y_virtual| DIV
+    DIV --> ALERT
+```
+
+---
+
+## Theory
+
+### Why digital twins detect wear
+
+At $t=0$, both plant and twin have the same dynamics. The controller drives them to the same setpoint.
+
+At $t=3\,\text{s}$ (wear injection), the physical plant's pole shifts:
+
+$$
+\text{Nominal: } G(s) = \frac{1}{s+1} \quad\longrightarrow\quad \text{Worn: } G(s) = \frac{1}{s+2}
+$$
+
+The worn plant responds **twice as fast** but to a **different magnitude**. The twin, still using $G(s) = \frac{1}{s+1}$, diverges from the physical output. The divergence metric:
+
+$$
+\delta(t) = |y_{\text{physical}}(t) - y_{\text{virtual}}(t)|
+$$
+
+grows past the alert threshold $\delta_{\text{thr}} = 0.15$ within a few ticks of the wear event.
+
+### Virtual twin evolution
+
+The twin evolves **in the main thread** via `evolve()`, synchronised with each bus read:
+
+```python
+# Read physical output from bus
+y_physical = monitor.read("y")[0]
+u_current  = monitor.read("u")[0]
+
+# Step the twin with the SAME u
+x_virtual, y_virtual_arr = plant_nominal.evolve(
+    x_virtual, np.array([u_current])
+)
+```
+
+This guarantees that both the physical and virtual outputs are computed with the same `u(t)` — the only difference is the internal model.
+
+---
+
+## Wear injection — hot swap
+
+The plant model is swapped at runtime without stopping the controller or the bus:
+
+```python
+if elapsed >= DRIFT_AT:
+    plant_agent.stop()                              # graceful shutdown
+    plant_agent = PlantAgent("worn", drifted_model, ...)
+    plant_agent.start(blocking=False)               # restart with new model
+```
+
+The bus, controller, and virtual twin continue uninterrupted.
+
+---
+
+## Result
+
+![Digital twin: physical vs virtual, divergence metric, control signal](/img/examples/05_digital_twin.png)
+
+**Panel 1 — Physical vs Virtual:** outputs are identical until $t=3\,\text{s}$, then diverge.
+
+**Panel 2 — Anomaly Detection:** the red fill shows ticks where $\delta(t) > 0.15$. The alert zone grows steadily after the wear event.
+
+**Panel 3 — Control signal:** the PID compensates more aggressively post-wear because the plant dynamics have changed.
+
+---
+
+## Real-world applications
+
+| Domain | Physical system | Wear signature |
+|---|---|---|
+| Industrial | Pump or motor | Increased damping, reduced efficiency |
+| Aerospace | Control surface | Actuator stiffness change |
+| Structural | Bridge or building | Natural frequency shift |
+| Process control | Heat exchanger | Fouling increases thermal resistance |
+
+---
+
+## How to run
+
+Single terminal — runs for 8 seconds then plots:
+
+```bash
+uv run python examples/advanced/05_digital_twin/05_digital_twin.py
+```
+
+Expected terminal output:
+```
+[t=3.00s] ⚠  Wear injected: plant pole drifted -1 → -2
+[t=3.05s] 🔴 ALERT: divergence = 0.18 > 0.15
+...
+Simulation complete. N ticks with divergence > 0.15.
+```

--- a/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/examples/advanced/quadcopter-mimo.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/examples/advanced/quadcopter-mimo.md
@@ -1,0 +1,406 @@
+---
+format: md
+id: quadcopter-mimo
+title: Quadricóptero MIMO Neural-LQR 3D
+sidebar_position: 6
+---
+
+# Quadricóptero MIMO — Controlador Neural-LQR com Animação 3D em Tempo Real
+
+**Arquivos:** `examples/advanced/06_quadcopter_mimo/`
+
+---
+
+## O que este exemplo demonstra
+
+Uma simulação em tempo real completa de um **quadricóptero com 12 estados** controlado por um **Neural-LQR informado pela física** — visualizado simultaneamente em uma cena 3D com PyVista e uma janela de telemetria matplotlib ao vivo. Antes da simulação começar, uma **GUI de configuração em tkinter** permite escolher a trajetória de referência, ajustar seus parâmetros e definir a duração da simulação.
+
+| Conceito | Detalhe |
+|---|---|
+| **Modelagem LTI MIMO** | Modelo hover linearizado com 12 estados, construído com `synapsys.api.ss()` |
+| **LQR MIMO** | `synapsys.algorithms.lqr()` em uma planta 12 estados / 4 entradas |
+| **Neural-LQR residual** | `δu = −K·e + MLP(e)` — resíduo zerado na inicialização → começa no LQR ótimo |
+| **Yaw alinhado à direção** | O drone rotaciona para apontar na direção do movimento — $\psi_\text{ref} = \text{atan2}(\dot{y}, \dot{x})$ |
+| **GUI de configuração** | Dialog tkinter: tempo de simulação, altitude, trajetória de referência e seus parâmetros |
+| **PyVista 3D** | Animação da pose do drone + rastro de trajetória a 50 Hz |
+| **Telemetria matplotlib** | Rastreamento de posição, ângulos de Euler, entradas de controle — ao vivo a 10 Hz |
+
+---
+
+## Modelo físico — hover linearizado
+
+Um quadricóptero possui dinâmica altamente não-linear, mas na vizinhança do **hover** (velocidade zero, atitude nivelada) uma expansão de Taylor de primeira ordem fornece um modelo **LTI** útil válido para pequenas perturbações (|φ|, |θ| ≤ 15°).
+
+### Vetores de estado e entrada
+
+$$
+\mathbf{x} =
+\begin{bmatrix}
+x & y & z & \varphi & \theta & \psi &
+\dot{x} & \dot{y} & \dot{z} & p & q & r
+\end{bmatrix}^\top \in \mathbb{R}^{12}
+$$
+
+$$
+\delta\mathbf{u} =
+\begin{bmatrix}
+\delta F & \tau_\varphi & \tau_\theta & \tau_\psi
+\end{bmatrix}^\top \in \mathbb{R}^{4}
+$$
+
+onde $(\varphi, \theta, \psi)$ são rolagem, arfagem e guinada; $(p, q, r)$ são as taxas angulares no corpo; e $\delta\mathbf{u}$ representa **desvios do equilíbrio hover** (em hover $F = mg$).
+
+### Matrizes A e B linearizadas
+
+A equação de estado $\dot{\mathbf{x}} = A\mathbf{x} + B\,\delta\mathbf{u}$ no hover é:
+
+$$
+A =
+\begin{bmatrix}
+0_{3\times 3} & 0_{3\times 3} & I_{3\times 3} & 0_{3\times 3} \\
+0_{3\times 3} & 0_{3\times 3} & 0_{3\times 3} & I_{3\times 3} \\
+0 & 0 & 0 & g & 0 & 0 & 0_{3\times 6} \\
+0 & 0 & 0 & -g & 0 & 0 & 0_{3\times 6} \\
+0_{6\times 12}
+\end{bmatrix}
+$$
+
+Os termos de acoplamento gravitacional são $A_{6,4} = +g$ (aceleração frontal pela arfagem $\theta$) e $A_{7,3} = -g$ (aceleração lateral pela rolagem $\varphi$):
+
+```
+ẍ = +g·θ     (arfagem para frente → acelera em x)
+ÿ = −g·φ     (rolagem à direita → acelera em −y)
+```
+
+A matriz de entrada mapeia cada canal de controle para seu efeito dinâmico:
+
+$$
+B =
+\begin{bmatrix}
+0_{8 \times 4} \\
+1/m & 0 & 0 & 0 \\
+0 & 1/I_{xx} & 0 & 0 \\
+0 & 0 & 1/I_{yy} & 0 \\
+0 & 0 & 0 & 1/I_{zz}
+\end{bmatrix}
+$$
+
+Parâmetros físicos (quadricóptero racing de 500 mm):
+
+| Símbolo | Valor | Significado |
+|---|---|---|
+| $m$ | 0,500 kg | Massa total |
+| $I_{xx} = I_{yy}$ | 4,856 × 10⁻³ kg·m² | Inércia de rolagem / arfagem |
+| $I_{zz}$ | 8,801 × 10⁻³ kg·m² | Inércia de guinada |
+| $\ell$ | 0,175 m | Braço centro-motor |
+
+O modelo em tempo contínuo é construído com `synapsys.api.ss()` e discretizado a 100 Hz com `synapsys.api.c2d()` pelo método zero-order-hold (ZOH):
+
+```python
+from synapsys.api import ss, c2d
+
+A, B, C, D = build_matrices()   # de quadcopter_dynamics.py
+sys_c = ss(A, B, C, D)          # sistema LTI em tempo contínuo
+sys_d = c2d(sys_c, dt=0.01)     # discretização ZOH a 100 Hz
+```
+
+---
+
+## Projeto LQR
+
+O **Regulador Linear Quadrático** minimiza o custo de horizonte infinito:
+
+$$
+J = \int_0^\infty \bigl(\mathbf{e}^\top Q\,\mathbf{e} + \delta\mathbf{u}^\top R\,\delta\mathbf{u}\bigr)\,dt
+$$
+
+onde $\mathbf{e} = \mathbf{x} - \mathbf{x}_\text{ref}$ é o erro de rastreamento. A matriz de ganho ótima $K$ é encontrada resolvendo a **Equação de Riccati Algébrica** (ARE):
+
+$$
+A^\top P + PA - PBR^{-1}B^\top P + Q = 0
+\quad\Rightarrow\quad K = R^{-1}B^\top P
+$$
+
+Matrizes de peso usadas neste exemplo:
+
+```python
+Q = diag([20, 20, 30,    # x, y, z       — erros de posição
+           3,  3,  8,    # φ, θ, ψ       — atitude (guinada com mais peso)
+           2,  2,  4,    # ẋ, ẏ, ż       — velocidade linear
+          0.5, 0.5, 1])  # p, q, r       — taxas angulares
+
+R = diag([0.5, 3.0, 3.0, 5.0])   # δF, τφ, τθ, τψ
+```
+
+```python
+from synapsys.algorithms import lqr
+
+K, P = lqr(A, B, Q, R)
+# K.shape == (4, 12)
+# Todos os autovalores em malha fechada têm Re < 0  ✓
+```
+
+O $K \in \mathbb{R}^{4 \times 12}$ resultante produz um sistema em **malha fechada** $A - BK$ com todos os autovalores no semiplano esquerdo (Re < 0), confirmando estabilidade assintótica.
+
+---
+
+## Controlador Neural-LQR
+
+### Arquitetura residual
+
+O controlador estende o LQR com um termo residual aprendível:
+
+$$
+\delta\mathbf{u} = \underbrace{-K\,\mathbf{e}}_{\text{base LQR}} + \underbrace{\text{MLP}(\mathbf{e})}_{\text{resíduo}}
+$$
+
+A MLP tem arquitetura **12 → 64 → 32 → 4** com ativações Tanh. Na inicialização, os **pesos e vieses da camada de saída são zerados**, de modo que a rede começa como LQR puro — o resíduo pode ser treinado depois via RL ou imitação sem alterar nenhuma API.
+
+```python
+class NeuralLQR(nn.Module):
+    def __init__(self, K_np):
+        super().__init__()
+        self.register_buffer("K", torch.tensor(K_np, dtype=torch.float32))
+        self.residual = nn.Sequential(
+            nn.Linear(12, 64), nn.Tanh(),
+            nn.Linear(64, 32), nn.Tanh(),
+            nn.Linear(32,  4),            # ← zerado na inicialização
+        )
+        with torch.no_grad():
+            nn.init.zeros_(self.residual[4].weight)
+            nn.init.zeros_(self.residual[4].bias)
+
+    def forward(self, e):
+        return -(e @ self.K.T) + self.residual(e)
+```
+
+### Por que esse design?
+
+| Propriedade | Benefício |
+|---|---|
+| **Estabilidade em t = 0** | A base LQR é provadamente estável; o resíduo não acrescenta nada até ser treinado |
+| **Fine-tuning suave** | RL ou IL pode ajustar o resíduo sem desestabilizar o loop |
+| **Fallback interpretável** | Remova/zere a MLP → reverte ao LQR ótimo conhecido a qualquer momento |
+
+---
+
+## Trajetórias de referência
+
+Três trajetórias de referência estão disponíveis via GUI de configuração:
+
+### Figura-8 — Lemniscata de Bernoulli
+
+$$
+x_\text{ref}(t) = \frac{A\cos(\omega t)}{1 + \sin^2(\omega t)}, \qquad
+y_\text{ref}(t) = \frac{A\sin(\omega t)\cos(\omega t)}{1 + \sin^2(\omega t)}, \qquad
+z_\text{ref} = z_h
+$$
+
+Padrão: $A = 0,8$ m, $\omega = 0,35$ rad/s.
+
+### Círculo
+
+$$
+x_\text{ref}(t) = R\cos(\omega t), \qquad
+y_\text{ref}(t) = R\sin(\omega t), \qquad
+z_\text{ref} = z_h
+$$
+
+Padrão: $R = 1,0$ m, $\omega = 0,30$ rad/s.
+
+### Hover (estático)
+
+$$
+\mathbf{x}_\text{ref} = [0,\; 0,\; z_h,\; 0, \ldots, 0]^\top
+$$
+
+As três trajetórias compartilham a fase de decolagem: o drone sobe do chão até a altitude hover $z_h$ durante os primeiros $t_\text{hover}$ segundos antes de iniciar o rastreamento.
+
+---
+
+## Controle de yaw alinhado à direção
+
+Durante o rastreamento de trajetória, o drone **rotaciona automaticamente para encarar a direção em que está se movendo**. A cada passo de simulação, o yaw desejado é calculado a partir do vetor de velocidade atual:
+
+$$
+\psi_\text{ref}(t) = \text{atan2}\!\left(\dot{y}(t),\, \dot{x}(t)\right)
+$$
+
+Essa referência é injetada diretamente em `x_ref[5]` antes do cálculo do erro LQR, de modo que a matriz de ganho $K$ existente trata a correção de yaw sem nenhuma mudança estrutural.
+
+Dois casos extremos são tratados explicitamente:
+
+| Condição | Comportamento |
+|---|---|
+| Velocidade $\|\dot{x}, \dot{y}\| < 0.08$ m/s (próximo ao hover) | Mantém o yaw atual — evita comandos ruidosos quando a velocidade é pouco confiável |
+| Erro de yaw cruza $\pm 180°$ | Erro normalizado para $[-\pi, \pi]$ — impede wind-up através da descontinuidade |
+
+```python
+def _yaw_ref_from_velocity(vx, vy, psi_current, min_speed=0.08):
+    if np.hypot(vx, vy) < min_speed:
+        return psi_current      # mantém heading próximo ao hover
+    return np.arctan2(vy, vx)
+
+# Dentro do loop de simulação:
+x_ref[5] = _yaw_ref_from_velocity(x[6], x[7], x[5])
+e = x - x_ref
+e[5] = _wrap_angle(e[5])        # normaliza para [-π, π]
+```
+
+O resultado é claramente visível na animação 3D: o **nariz do drone sempre aponta na tangente da trajetória** ao percorrer o figura-8 ou o círculo.
+
+---
+
+## Arquitetura
+
+```mermaid
+%%{init: {'theme': 'dark'}}%%
+flowchart TD
+    GUI["GUI tkinter de Configuração\ntempo / altitude / trajetória\nparâmetros"]
+    GUI -->|SimConfig| MAIN
+
+    subgraph SIM["sim_thread  (100 Hz)"]
+        PLANT["sys_d.evolve(x, δu)\nmodelo discretizado ZOH"]
+        CTRL["NeuralLQR\n−K·e + MLP(e)"]
+        REF["get_ref(t, cfg)\nfig8 / círculo / hover"]
+        YAW["_yaw_ref_from_velocity\nψ_ref = atan2(ẏ, ẋ)"]
+        CTRL -->|δu| PLANT
+        PLANT -->|x| CTRL
+        PLANT -->|ẋ, ẏ, ψ| YAW
+        REF -->|x_ref| YAW
+        YAW -->|x_ref com ψ_ref| CTRL
+    end
+
+    subgraph BUFS["Deques thread-safe"]
+        S["_states  TRAIL_LEN"]
+        R["_refs    N_steps"]
+        U["_inputs  N_steps"]
+        T["_times   N_steps"]
+    end
+
+    SIM -->|append| BUFS
+
+    subgraph MAIN["thread principal  (loop de atualização)"]
+        PV["PyVista  50 Hz\npose do drone + rastro + HUD"]
+        MPL["matplotlib  10 Hz\nxy / z / ângulos / δu"]
+    end
+
+    BUFS -->|snapshot leitura| MAIN
+```
+
+Todos os dados fluem de `sim_thread` para **buffers `collections.deque` thread-safe** protegidos por um único `threading.Lock`. A thread principal lê snapshots sem bloquear a simulação.
+
+---
+
+## GUI de Configuração
+
+Ao iniciar o script, um **dialog tkinter** aparece antes de qualquer janela de simulação:
+
+| Seção | Controles |
+|---|---|
+| **Tempo de Simulação** | Duração total (s), fase hover de decolagem (s), altitude hover (m) |
+| **Trajetória de Referência** | Botões de rádio: Figura-8 / Círculo / Hover |
+| **Parâmetros Figura-8** | Slider de amplitude (0,2–2,0 m), velocidade angular (0,1–0,8 rad/s) |
+| **Parâmetros Círculo** | Slider de raio (0,2–3,0 m), velocidade angular (0,1–0,8 rad/s) |
+
+Clicar em **Run Simulation** fecha o dialog, valida a configuração e inicia as janelas de simulação e visualização. **Cancel** sai sem executar.
+
+---
+
+## Visualização
+
+### Janela PyVista 3D (50 Hz)
+
+![Animação 3D em tempo real do quadricóptero rastreando a trajetória figura-8 — malha do drone, rastro e curva de referência](/img/examples/06_quadcopter_3d.gif)
+
+- **Malha do drone** — corpo em configuração X (caixa), 4 braços (cilindros) e 4 rotores (discos); pose atualizada via `actor.user_matrix` a partir da matriz de rotação $R = R_z R_y R_x$ calculada com `scipy.spatial.transform.Rotation`
+- **Rastro da trajetória** — últimas `TRAIL_LEN = 500` posições como `pv.PolyData` polyline, atualizado in-place
+- **Curva de referência** — prévia estática da trajetória escolhida renderizada no início
+- **Overlay HUD** — texto ao vivo mostrando modo, tempo, posição, ângulos de Euler, velocidades
+
+### Janela de telemetria matplotlib (10 Hz)
+
+![Telemetria ao vivo: trajetória x-y vista de cima, altitude z(t), ângulos de Euler e entradas de controle](/img/examples/06_quadcopter_telemetry.gif)
+
+| Painel | Conteúdo |
+|---|---|
+| **Superior esquerdo** | Trajetória $x$–$y$ vista de cima vs. curva de referência |
+| **Superior direito** | Altitude $z(t)$ vs. linha de referência |
+| **Meio** | Ângulos de Euler $\varphi$, $\theta$, $\psi$ em graus |
+| **Inferior** | Desvios de controle $\delta F$, $\tau_\varphi$, $\tau_\theta$, $\tau_\psi$ |
+
+Ambas as janelas rodam na **mesma thread principal** usando `pv.Plotter(interactive_update=True)` e `plt.ion()`, evitando crashes de GUI entre threads. A simulação roda em uma thread daemon dedicada.
+
+---
+
+## Como executar
+
+**Instalar dependências:**
+
+```bash
+pip install synapsys[viz] torch matplotlib
+```
+
+**Executar a simulação standalone:**
+
+```bash
+cd examples/advanced/06_quadcopter_mimo
+python 06b_neural_lqr_3d.py
+```
+
+1. A GUI de configuração tkinter abre — ajuste os parâmetros e clique em **Run Simulation**
+2. Uma janela de telemetria matplotlib abre com 4 painéis ao vivo
+3. Uma janela PyVista 3D abre com a animação do drone
+4. Feche qualquer janela ou pressione **Ctrl+C** para parar
+
+**Exportar GIFs (sem necessidade de display):**
+
+```bash
+# Padrão: 20 s, 15 fps 3D + 7 fps telemetria → diretório atual
+python 06b_neural_lqr_3d.py --save
+
+# Personalizado: 30 s, fps customizados, pasta de saída
+python 06b_neural_lqr_3d.py --save --fps 20 --mpl-fps 8 --out ./resultados
+```
+
+Salva `quadcopter_3d.gif` (~1,8 MB) e `quadcopter_telemetry.gif` (~4 MB) em menos de 2 minutos. Requer `pip install imageio`.
+
+**Variante SIL de dois processos (opcional):**
+
+```bash
+# Terminal 1 — iniciar a planta linearizada em memória compartilhada
+python 06a_quadcopter_plant.py
+
+# Terminal 2 — conectar um controlador externo via SharedMemoryTransport
+```
+
+:::tip[Estendendo o Neural-LQR]
+A sub-rede `NeuralLQR.residual` (12→64→32→4, Tanh) começa em zero — não faz nada até ser treinada. Substitua os pesos zerados por pesos treinados via PPO, SAC ou DDPG e o restante do exemplo permanece idêntico. As chamadas de API `synapsys` (`ss()`, `c2d()`, `lqr()`, `evolve()`) não mudam.
+:::
+
+:::tip[Adicionando feedforward de velocidade]
+A referência atual prescreve apenas posição. Para manobras agressivas, adicione um feedforward de velocidade cinematicamente consistente ($\dot{x}_\text{ref}$, $\dot{y}_\text{ref}$) ao estado de referência — isso reduz significativamente o erro de rastreamento durante a fase figura-8.
+:::
+
+:::warning[Limites da linearização]
+O modelo hover é válido apenas para $|\varphi|, |\theta| \leq 15°$. Manobras agressivas que ultrapassem esse envelope causarão divergência. Para voo em envelope completo, substitua o modelo LTI por um modelo não-linear (ex.: equações de Euler-Lagrange) e use linearização por realimentação ou NMPC.
+:::
+
+---
+
+## Referência de arquivos
+
+| Arquivo | Propósito |
+|---|---|
+| `quadcopter_dynamics.py` | Constantes físicas, `build_matrices()`, `figure8_ref()`, pesos LQR |
+| `06a_quadcopter_plant.py` | Planta SIL de dois processos via `PlantAgent` + `SharedMemoryTransport` |
+| `06b_neural_lqr_3d.py` | Simulação standalone: GUI de config, Neural-LQR, PyVista 3D, matplotlib |
+
+### Chamadas chave da API synapsys
+
+| Chamada | O que faz |
+|---|---|
+| `ss(A, B, C, D)` | Constrói um objeto `StateSpace` em tempo contínuo |
+| `c2d(sys_c, dt)` | Discretiza para `StateSpace` discreto ZOH |
+| `sys_d.evolve(x, u)` | Atualização de estado de um passo: retorna $(x_{k+1},\, y_k)$ |
+| `lqr(A, B, Q, R)` | Resolve a ARE, retorna matriz de ganho $K$ e matriz de custo $P$ |

--- a/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/examples/advanced/realtime-oscilloscope.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/examples/advanced/realtime-oscilloscope.md
@@ -1,0 +1,115 @@
+---
+id: realtime-oscilloscope
+title: Real-Time Oscilloscope
+sidebar_position: 4
+---
+
+# Real-Time Oscilloscope with Sinusoidal Reference
+
+**File:** `examples/advanced/04_realtime_oscilloscope/04_realtime_matplotlib.py`
+
+---
+
+## What this example shows
+
+The most complete self-contained real-time simulation in Synapsys. Three concurrent roles — plant, controller, and oscilloscope — run simultaneously without blocking each other.
+
+The control objective is **sinusoidal reference tracking**: the setpoint is a time-varying signal and the PID must keep the output following it continuously.
+
+---
+
+## Architecture
+
+```mermaid
+%%{init: {'theme': 'dark'}}%%
+flowchart TB
+    subgraph Main["Single process (3 threads/roles)"]
+        TA["Thread A\nPlantAgent\n50 Hz"]
+        TB["Thread B\nControllerAgent (PID)\n50 Hz"]
+        TM["Main thread\nOscilloscope\n30 Hz display"]
+    end
+
+    SHM["Shared Memory\nscope_demo"]
+
+    TA -->|write y| SHM
+    SHM -->|read u| TA
+    TB -->|write u| SHM
+    SHM -->|read y| TB
+    SHM -.->|read y, u| TM
+```
+
+The plant and controller run in **background threads** (`blocking=False`). The main thread drives the `FuncAnimation` loop.
+
+---
+
+## Sinusoidal reference
+
+$$
+r(t) = 3 + 2\sin(2\pi \cdot 0.2 \cdot t)
+$$
+
+A 0.2 Hz (5-second period) sinusoid with DC offset 3. The PID must compute `u(t)` at every tick so that `y(t) ≈ r(t)` despite plant dynamics introducing a phase lag.
+
+The reference is evaluated from wall-clock time via a **closure**:
+
+```python
+t_start = time.monotonic()
+
+def law(y):
+    r = SP_OFFSET + SP_AMP * np.sin(2 * np.pi * SP_FREQ * (time.monotonic() - t_start))
+    return np.array([pid.compute(setpoint=r, measurement=y[0])])
+```
+
+Each call to `law(y)` reads the current time, computes `r(t)`, and feeds it to the PID — no external coordination needed.
+
+---
+
+## Rolling window oscilloscope
+
+```python
+WINDOW = 200   # samples (200 × 0.02 s = 4 s visible)
+buf_t = deque([0.0] * WINDOW, maxlen=WINDOW)
+buf_y = deque([0.0] * WINDOW, maxlen=WINDOW)
+```
+
+`deque(maxlen=N)` automatically discards the oldest sample when a new one is appended. The x-axis scrolls forward:
+
+```python
+x_min = max(0.0, now - WINDOW * DT)
+x_max = x_min + WINDOW * DT
+ax.set_xlim(x_min, x_max)
+```
+
+---
+
+## PID tuning
+
+```python
+pid = PID(Kp=6.0, Ki=2.0, dt=DT, u_min=-15.0, u_max=15.0)
+```
+
+| Parameter | Value | Rationale |
+|---|---|---|
+| `Kp` | 6.0 | Fast proportional response for sinusoidal tracking |
+| `Ki` | 2.0 | Eliminates the phase-lag-induced steady-state error |
+| `u_min/max` | ±15 | Anti-windup saturation |
+
+---
+
+## Result
+
+![Real-time oscilloscope: PID tracking sinusoidal reference](/img/examples/04_realtime_oscilloscope.png)
+
+`y(t)` (blue) tracks `r(t)` (dashed) with a small phase lag introduced by the plant dynamics. `u(t)` (orange) oscillates as the PID continuously compensates — amplitude grows when tracking error grows (bottom of the sine) and shrinks when the error is small.
+
+---
+
+## How to run
+
+Single terminal — everything runs in-process:
+
+```bash
+uv run python examples/advanced/04_realtime_oscilloscope/04_realtime_matplotlib.py
+```
+
+The oscilloscope window opens immediately. Close it to stop the simulation.

--- a/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/examples/advanced/realtime-scope.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/examples/advanced/realtime-scope.md
@@ -1,0 +1,93 @@
+---
+id: realtime-scope
+title: Real-Time Scope (Terminal)
+sidebar_position: 3
+---
+
+# Real-Time Headless Scope
+
+**File:** `examples/advanced/03_realtime_scope/03_realtime_scope.py`
+
+---
+
+## What this example shows
+
+A **read-only bus monitor** that attaches to an existing shared memory bus and displays live signal values in the terminal — no GUI required. It demonstrates the **observer pattern**: any number of monitors can attach to the bus without affecting the closed-loop simulation.
+
+---
+
+## Architecture
+
+```mermaid
+%%{init: {'theme': 'dark'}}%%
+flowchart LR
+    P["PlantAgent\n(02a)"]
+    C["ControllerAgent\n(02b)"]
+    SHM["Shared Memory\nsil_bus"]
+    MON["Monitor\n(this script)\nread-only"]
+
+    P -->|write y| SHM
+    SHM -->|read u| P
+    C -->|write u| SHM
+    SHM -->|read y| C
+    SHM -.->|read y, u| MON
+```
+
+The dashed line indicates the monitor **never writes** to the bus — it is completely transparent to the simulation.
+
+---
+
+## Use cases
+
+- **Debugging over SSH** — no display server needed
+- **Logging** — redirect stdout to a file: `script.py >> log.txt`
+- **Sanity checking** before launching a full matplotlib oscilloscope
+- **CI pipelines** — verify signals are non-zero without a GUI
+
+---
+
+## Code
+
+```python
+from synapsys.transport import SharedMemoryTransport
+import time, sys
+
+monitor = SharedMemoryTransport("sil_bus", {"y": 1, "u": 1}, create=False)
+start_time = time.time()
+
+while True:
+    y = monitor.read("y")[0]
+    u = monitor.read("u")[0]
+    elapsed = time.time() - start_time
+
+    sys.stdout.write(
+        f"\r[t={elapsed:6.2f}s] y(t): {y:8.4f} | u(t): {u:8.4f}"
+    )
+    sys.stdout.flush()
+    time.sleep(0.05)   # 20 Hz display rate
+```
+
+### How the in-place update works
+
+`\r` (carriage return) moves the cursor to the beginning of the current line without advancing to the next line. Combined with `sys.stdout.flush()`, this creates a continuously updating single line — the classic terminal oscilloscope effect.
+
+`time.sleep(0.05)` sets a 20 Hz display rate. The actual simulation runs at 100 Hz — the monitor samples it at a lower rate, which is sufficient for visual inspection.
+
+---
+
+## How to run
+
+Requires the plant and controller already running:
+
+```bash
+# Terminal 1
+uv run python examples/advanced/02_sil_ai_controller/02a_sil_plant.py
+
+# Terminal 2
+uv run python examples/advanced/02_sil_ai_controller/02b_sil_ai_controller.py
+
+# Terminal 3 — headless monitor
+uv run python examples/advanced/03_realtime_scope/03_realtime_scope.py
+```
+
+Press `Ctrl+C` to stop the monitor. The plant and controller keep running.

--- a/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/examples/advanced/sil-ai-controller.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/examples/advanced/sil-ai-controller.md
@@ -1,0 +1,205 @@
+---
+format: md
+id: sil-ai-controller
+title: SIL + Neural-LQR Controller
+sidebar_position: 2
+---
+
+# Software-in-the-Loop with Neural-LQR Controller
+
+**Files:** `examples/advanced/02_sil_ai_controller/`
+
+---
+
+## What this example shows
+
+A two-process **SIL (Software-in-the-Loop)** simulation of a **2-DOF mass-spring-damper** where a **PyTorch MLP** — initialized with LQR optimal gains — drives the physical plant running in a separate process via zero-copy shared memory.
+
+| Process | File | Role |
+|---|---|---|
+| Plant | `02a_sil_plant.py` | Runs the 2-DOF physics model in real time |
+| Controller | `02b_sil_ai_controller.py` | PyTorch Neural-LQR + live scientific plot |
+
+---
+
+## Physical model — 2-DOF mass-spring-damper
+
+```
+  [k]         [k]
+──/\/\/──[m₁]──/\/\/──[m₂]──→ F(t)
+  [c]                  [c]
+```
+
+State vector $\mathbf{x} = [x_1,\, x_2,\, \dot{x}_1,\, \dot{x}_2]^\top$ — positions and velocities of both masses. Input: force $F$ applied to $m_2$.
+
+$$
+\dot{\mathbf{x}} =
+\underbrace{\begin{bmatrix}
+0 & 0 & 1 & 0 \\
+0 & 0 & 0 & 1 \\
+-2k/m & k/m & -c/m & 0 \\
+k/m & -2k/m & 0 & -c/m
+\end{bmatrix}}_{A}
+\mathbf{x}
++
+\underbrace{\begin{bmatrix}0\\0\\0\\k/m\end{bmatrix}}_{B}
+F
+$$
+
+Built with `StateEquations` — no manual index management:
+
+```python
+from synapsys.utils import StateEquations
+
+m, c, k = 1.0, 0.1, 2.0
+
+eqs = (
+    StateEquations(states=["x1", "x2", "v1", "v2"], inputs=["F"])
+    .eq("x1", v1=1)
+    .eq("x2", v2=1)
+    .eq("v1", x1=-2*k/m, x2=k/m,  v1=-c/m)
+    .eq("v2", x1=k/m,  x2=-2*k/m, v2=-c/m, F=k/m)
+)
+```
+
+---
+
+## Architecture
+
+```mermaid
+%%{init: {'theme': 'dark'}}%%
+flowchart LR
+    subgraph P1["Process 1 — Plant (02a)"]
+        EQ["StateEquations\nm=1 c=0.1 k=2"]
+        DT["c2d ZOH\nTs = 10 ms"]
+        PA["PlantAgent\nfull-state output"]
+        EQ --> DT --> PA
+    end
+
+    subgraph SHM["Shared Memory: sil_2dof"]
+        S["state 4xfloat64\nx1 x2 v1 v2"]
+        U["u 1xfloat64\nforce F"]
+    end
+
+    subgraph P2["Process 2 — Controller (02b)"]
+        NN["NeuralLQR MLP\n4-32-16-1 Tanh\nLQR-init weights"]
+        BUF["Circular buffers\n6s rolling window"]
+        PLOT["Scientific plot\nFuncAnimation\n4 panels"]
+        NN --> BUF --> PLOT
+    end
+
+    PA -->|write| S
+    U -->|read| PA
+    S -->|read| NN
+    NN -->|write| U
+```
+
+---
+
+## Neural-LQR controller
+
+### Why LQR initialisation?
+
+LQR solves the infinite-horizon optimal control problem:
+
+$$
+\min_{u} \int_0^\infty \left( \mathbf{x}^\top Q\,\mathbf{x} + u^\top R\,u \right) dt
+\quad \Rightarrow \quad u^* = -K\mathbf{x} + N_\text{bar}\,r
+$$
+
+where $K$ is obtained from the **Algebraic Riccati Equation** and $N_\text{bar}$ is the DC feedforward gain for setpoint tracking.
+
+The MLP is initialised so that its output layer directly implements $u = -K\mathbf{x}$. This:
+1. **Guarantees stability at initialisation** — closed-loop poles are analytically placed
+2. **Provides a physically meaningful starting point** for RL fine-tuning
+3. **Demonstrates physics-informed neural network design** for control applications
+
+```python
+from synapsys.algorithms import lqr
+import torch.nn as nn
+
+K, _ = lqr(eqs.A, eqs.B,
+           Q=np.diag([1.0, 10.0, 0.5, 1.0]),
+           R=np.array([[1.0]]))
+# K = [−0.382, 2.227, 0.420, 1.747]
+
+class NeuralLQR(nn.Module):
+    def __init__(self, K, Nbar):
+        super().__init__()
+        self.Nbar = Nbar
+        self.net = nn.Sequential(
+            nn.Linear(4, 32), nn.Tanh(),
+            nn.Linear(32, 16), nn.Tanh(),
+            nn.Linear(16, 1),
+        )
+        with torch.no_grad():
+            nn.init.xavier_uniform_(self.net[0].weight)
+            nn.init.xavier_uniform_(self.net[2].weight)
+            # Physics-informed: output layer ← LQR gains
+            self.net[4].weight.data = torch.tensor(-K.reshape(1, -1))
+            self.net[4].bias.data.zero_()
+
+    def forward(self, x):
+        return self.net(x) + self.Nbar * X2_REF
+```
+
+### Inference in the control loop
+
+```python
+def control_law(state: np.ndarray) -> np.ndarray:
+    with torch.no_grad():
+        t_in = torch.tensor(state, dtype=torch.float32).unsqueeze(0)
+        u = float(model(t_in).squeeze())   # forward pass < 0.1 ms
+    return np.clip(np.array([u]), -U_LIMIT, U_LIMIT)
+```
+
+```
+numpy (4,) → torch.Tensor (1,4) → MLP forward → torch scalar → numpy (1,)
+```
+
+`torch.no_grad()` disables autograd — no gradient tracking during inference.
+
+---
+
+## Real-time scientific plot
+
+The agent runs in a **background thread** (`blocking=False`). The main thread drives a 4-panel `FuncAnimation` plot:
+
+| Panel | Signal | Info |
+|---|---|---|
+| Position (top) | $x_1(t)$, $x_2(t)$ | Tracks setpoint $r = 1.0$ m |
+| Velocities (mid-left) | $\dot{x}_1(t)$, $\dot{x}_2(t)$ | Damping dynamics |
+| Control force (mid-right) | $F(t)$ | Neural-LQR output, ±20 N saturation |
+| Phase portrait (bottom) | $(x_1, x_2)$ trajectory | Convergence to equilibrium |
+
+Data is captured into `collections.deque(maxlen=600)` buffers (6 s window). `deque.append()` is thread-safe under the GIL — no explicit lock needed for reading the animation.
+
+---
+
+## Result
+
+![Neural-LQR 2-DOF simulation — animated: position tracking, velocities, force and phase portrait](/img/examples/03_sil_ai_controller.gif)
+
+$x_2(t)$ converges to the setpoint $r = 1.0$ m with minimal overshoot. The phase portrait shows the trajectory spiralling into the equilibrium point — the hallmark of an underdamped stable system driven by an optimal controller.
+
+---
+
+## How to run
+
+```bash
+# Terminal 1 — start the plant first
+uv run python examples/advanced/02_sil_ai_controller/02a_sil_plant.py
+
+# Terminal 2 — connect the Neural-LQR controller
+uv run python examples/advanced/02_sil_ai_controller/02b_sil_ai_controller.py
+```
+
+A matplotlib window opens with 4 live panels. Close the window to stop.
+
+:::tip[Extending to RL]
+Replace the `NeuralLQR` forward pass with any `nn.Module` trained by PPO, SAC or DDPG. The `ControllerAgent` callback signature (`np.ndarray → np.ndarray`) remains identical — only the model weights change.
+:::
+
+:::tip[Multi-setpoint tracking]
+Change `X2_REF` at runtime, or implement a time-varying reference inside `control_law()`. The MLP's hidden layers can learn non-linear compensation beyond what the linear LQR initialisation provides.
+:::

--- a/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/examples/basic/step-response.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/examples/basic/step-response.md
@@ -1,0 +1,109 @@
+---
+format: md
+id: step-response
+title: Step Response
+sidebar_position: 1
+---
+
+# Step Response of a Second-Order System
+
+**File:** `examples/basic/01_step_response/step_response.py`
+
+---
+
+## What this example shows
+
+The simplest possible Synapsys program: build a transfer function, compute its step response, and plot it. This is the "hello world" of control systems.
+
+---
+
+## Theory
+
+A **transfer function** $G(s)$ represents a linear time-invariant (LTI) system in the Laplace domain:
+
+$$
+G(s) = \frac{Y(s)}{U(s)}
+$$
+
+For a **second-order underdamped system**, the standard form is:
+
+$$
+G(s) = \frac{\omega_n^2}{s^2 + 2\zeta\omega_n s + \omega_n^2}
+$$
+
+| Parameter | Symbol | Effect |
+|---|---|---|
+| Natural frequency | $\omega_n$ | Controls oscillation speed |
+| Damping ratio | $\zeta$ | Controls how fast oscillations decay |
+
+Damping regimes:
+- $\zeta < 1$ — **underdamped**: oscillates before settling
+- $\zeta = 1$ — **critically damped**: fastest non-oscillating response
+- $\zeta > 1$ — **overdamped**: slow, no oscillation
+
+The **step response** is the output when the input switches from 0 to 1 at $t=0$. It is the primary tool for characterising a system's dynamic behaviour.
+
+---
+
+## System used
+
+$$
+G(s) = \frac{100}{s^2 + 10s + 100} \qquad \omega_n = 10,\quad \zeta = 0.5
+$$
+
+With $\zeta = 0.5$ the system is underdamped — it overshoots and oscillates before settling at $y = 1$.
+
+---
+
+## Result
+
+![Step response showing overshoot and settling](/img/examples/01_step_response.png)
+
+The shaded red region marks the **overshoot** (output exceeds the setpoint). The system settles within approximately $0.8\,\text{s}$.
+
+---
+
+## Code
+
+```python
+from synapsys.api.matlab_compat import tf, step
+import matplotlib.pyplot as plt
+
+wn, zeta = 10.0, 0.5
+G = tf([wn**2], [1, 2*zeta*wn, wn**2])
+
+print(G)
+print(f"Poles   : {G.poles()}")
+print(f"Stable  : {G.is_stable()}")
+
+t, y = step(G)
+
+plt.figure()
+plt.plot(t, y, label="y(t)")
+plt.axhline(1.0, color="k", linestyle="--", alpha=0.4, label="setpoint")
+plt.title("Step Response — second-order system")
+plt.xlabel("Time (s)")
+plt.ylabel("y(t)")
+plt.legend()
+plt.grid(True)
+plt.show()
+```
+
+### Key API calls
+
+| Call | What it does |
+|---|---|
+| `tf(num, den)` | Builds a `TransferFunction` from coefficient lists (highest power first) |
+| `G.poles()` | Returns roots of the denominator polynomial |
+| `G.is_stable()` | `True` if all poles have negative real parts |
+| `step(G)` | Computes step response via `scipy.signal.step`; returns `(t, y)` |
+
+---
+
+## How to run
+
+```bash
+uv run python examples/basic/01_step_response/step_response.py
+```
+
+Output: a plot window + `step_response.png` saved to the working directory.

--- a/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/examples/distributed/shared-memory.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/examples/distributed/shared-memory.md
@@ -1,0 +1,106 @@
+---
+id: shared-memory-example
+title: Shared Memory
+sidebar_position: 1
+---
+
+# Distributed Simulation via Shared Memory
+
+**Files:** `examples/distributed/01_shared_memory/`
+
+---
+
+## What this example shows
+
+How to split plant and controller into **two separate processes** communicating via **shared memory IPC** — no network, no sockets, no file I/O. Both processes run on the same machine and the OS maps the same physical memory pages into both address spaces.
+
+---
+
+## Architecture
+
+```mermaid
+%%{init: {'theme': 'dark'}}%%
+flowchart LR
+    subgraph A["Process 1\nplant.py"]
+        P["Discrete plant\ny(k+1) = 0.9y + 0.1u"]
+    end
+
+    subgraph SHM["OS Shared Memory\n'synapsys_demo'"]
+        Y["y  (float64)"]
+        U["u  (float64)"]
+    end
+
+    subgraph B["Process 2\ncontroller.py"]
+        C["PID controller\nSetpoint = 5.0"]
+    end
+
+    P -->|write| Y
+    U -->|read| P
+    C -->|write| U
+    Y -->|read| C
+```
+
+---
+
+## Why two processes?
+
+| Concern | Single process | Two processes |
+|---|---|---|
+| Fault isolation | Controller crash kills plant | Independent — one can restart |
+| Rate independence | Must share a clock | Plant at 20 Hz, controller at 40 Hz |
+| Deployment | Always co-located | Can be on separate machines |
+| Realistic testing | Shared memory, shared state | Mimics real embedded architecture |
+
+---
+
+## Plant (`plant.py`)
+
+```python
+with SharedMemoryTransport(BUS_NAME, CHANNELS, create=True) as bus:
+    bus.write("y", np.array([0.0]))
+    bus.write("u", np.array([0.0]))
+    time.sleep(2.0)   # wait for controller to connect
+
+    for k in range(N_STEPS):
+        u = bus.read("u")[0]
+        y = bus.read("y")[0]
+
+        y_next = 0.9 * y + 0.1 * u   # discrete first-order dynamics
+        bus.write("y", np.array([y_next]))
+        time.sleep(DT)
+```
+
+The plant **creates** the shared memory block (`create=True`). The `with` block ensures the OS resource is released even on crash.
+
+Discrete dynamics: $y(k+1) = 0.9\,y(k) + 0.1\,u(k)$ — equivalent to $G(s)=\tfrac{1}{s+1}$ with ZOH at ~20 Hz.
+
+---
+
+## Controller (`controller.py`)
+
+```python
+with SharedMemoryTransport(BUS_NAME, CHANNELS, create=False) as bus:
+    while True:
+        y = bus.read("y")[0]
+        u = pid.compute(setpoint=5.0, measurement=y)
+        bus.write("u", np.array([u]))
+        time.sleep(DT)    # 40 Hz
+```
+
+The controller **connects** to the existing block (`create=False`). It runs at **40 Hz** — twice the plant rate. Between plant updates, the controller reuses the last `y` value. This demonstrates **rate decoupling**: processes do not need to be synchronised.
+
+PID parameters: `Kp=3.0, Ki=0.5, dt=0.025` — tuned to drive `y` to `setpoint=5.0`.
+
+---
+
+## How to run
+
+```bash
+# Terminal 1 — start plant first
+uv run python examples/distributed/01_shared_memory/plant.py
+
+# Terminal 2 — connect controller (within 2 s)
+uv run python examples/distributed/01_shared_memory/controller.py
+```
+
+You should see `y` converge to `5.0` within the first few steps. The plant runs for 200 steps (~10 s) then exits. Press `Ctrl+C` to stop the controller.

--- a/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/examples/distributed/zmq.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/examples/distributed/zmq.md
@@ -1,0 +1,148 @@
+---
+id: zmq-example
+title: ZeroMQ Network
+sidebar_position: 2
+---
+
+# Distributed Simulation via ZeroMQ
+
+**Files:** `examples/distributed/02_zmq/`
+
+---
+
+## What this example shows
+
+Extends distributed simulation to **network communication** using **ZeroMQ**. The plant and controller can run on **different machines** connected over TCP — a realistic HIL/distributed-control scenario.
+
+---
+
+## Architecture
+
+```mermaid
+%%{init: {'theme': 'dark'}}%%
+flowchart LR
+    subgraph A["Machine A\nplant_zmq.py"]
+        P["ZOH plant\nG(s)=1/(s+1)"]
+        PUB1["PUB :5555"]
+        SUB1["SUB :5556"]
+    end
+
+    subgraph NET["TCP Network"]
+        Y["y(t) →"]
+        U["← u(t)"]
+    end
+
+    subgraph B["Machine B (or same)\ncontroller_zmq.py"]
+        C["PID controller\nSetpoint = 5.0"]
+        SUB2["SUB :5555"]
+        PUB2["PUB :5556"]
+    end
+
+    P --> PUB1 --> NET --> SUB2 --> C
+    C --> PUB2 --> NET --> SUB1 --> P
+```
+
+---
+
+## ZeroMQ PUB/SUB pattern
+
+ZMQ's **Publisher-Subscriber** pattern is ideal for sensor data streaming:
+
+| Feature | Raw TCP | ZMQ PUB/SUB |
+|---|---|---|
+| Reconnection | Manual | Automatic |
+| Multiple subscribers | Complex | Built-in |
+| Message framing | Manual | Built-in |
+| Language support | OS-specific | 40+ languages |
+
+`ZMQTransport` serialises numpy arrays to bytes and uses the channel name as the ZMQ topic prefix.
+
+---
+
+## Plant (`plant_zmq.py`)
+
+```python
+pub = ZMQTransport("tcp://0.0.0.0:5555", mode="pub")   # publish y
+sub = ZMQTransport(f"tcp://{CONTROLLER_HOST}:5556", mode="sub")  # subscribe u
+sub._socket.setsockopt(0x8, 100)   # ZMQ_RCVTIMEO = 100 ms
+
+u = np.array([0.0])
+
+for k in range(N_STEPS):
+    x, y = plant_d.evolve(x, u)
+    pub.write("y", y)
+
+    try:
+        u = sub.read("u")    # non-blocking — raises on timeout
+    except Exception:
+        pass                 # ZOH: keep previous u if controller hasn't sent yet
+```
+
+The **ZOH fallback** (`except: pass`) prevents the plant from stalling if the controller hasn't sent `u` yet — it simply reuses the last value.
+
+---
+
+## Controller (`controller_zmq.py`)
+
+```python
+sub = ZMQTransport(f"tcp://{PLANT_HOST}:5555", mode="sub")
+pub = ZMQTransport("tcp://0.0.0.0:5556", mode="pub")
+
+while True:
+    try:
+        y = sub.read("y")
+        u = pid.compute(setpoint=5.0, measurement=y[0])
+        pub.write("u", np.array([u]))
+    except Exception:
+        pass   # plant not ready yet; retry
+```
+
+The controller runs at **2× the plant rate** (`DT=0.025s` vs `DT=0.05s`). Extra cycles silently skip if no new `y` is available — the controller never blocks.
+
+---
+
+## Deadline-based timing
+
+Both scripts use a **deadline sleep** for accurate timing:
+
+```python
+elapsed = time.monotonic() - t0
+if DT - elapsed > 0:
+    time.sleep(DT - elapsed)
+```
+
+This compensates for computation time: if the step took 2 ms and `DT=50 ms`, it sleeps 48 ms instead of a fixed 50 ms — avoiding drift.
+
+---
+
+## Running on two machines
+
+Change the host variables:
+
+```python
+# On Machine A (plant)
+CONTROLLER_HOST = "192.168.1.42"   # IP of Machine B
+
+# On Machine B (controller)
+PLANT_HOST = "192.168.1.10"        # IP of Machine A
+```
+
+Ensure ports **5555** and **5556** are open in the firewall.
+
+---
+
+## How to run (same machine)
+
+```bash
+# Terminal 1
+uv run python examples/distributed/02_zmq/plant_zmq.py
+
+# Terminal 2
+uv run python examples/distributed/02_zmq/controller_zmq.py
+```
+
+The plant runs for 300 steps (~15 s). Press `Ctrl+C` to stop the controller.
+
+:::warning[Port conflict]
+If a previous run left sockets open, run `fuser -k 5555/tcp 5556/tcp` before starting.
+:::

--- a/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/examples/index.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/examples/index.md
@@ -1,0 +1,53 @@
+---
+id: examples-index
+title: Examples
+sidebar_position: 1
+---
+
+# Examples
+
+A curated set of runnable examples that demonstrate the full capability spectrum of Synapsys — from a single `step()` call to a multi-process Digital Twin with anomaly detection.
+
+Each example lives in its own subfolder under `examples/` and includes a detailed `README.md`.
+
+---
+
+## Basic
+
+| Example | Concepts |
+|---|---|
+| [Step Response](./basic/step-response.md) | Transfer function, `tf()`, `step()`, poles, stability |
+
+## Advanced
+
+| Example | Concepts |
+|---|---|
+| [Custom Signal Injection](./advanced/custom-signals.md) | MIL, superposition, `simulate()`, arbitrary waveforms |
+| [SIL + AI Controller](./advanced/sil-ai-controller.md) | SIL, `PlantAgent`, `ControllerAgent`, PyTorch integration, real-time plot |
+| [Real-Time Scope (Terminal)](./advanced/realtime-scope.md) | Read-only bus monitor, headless display |
+| [Real-Time Oscilloscope](./advanced/realtime-oscilloscope.md) | Three-role architecture, PID, sinusoidal reference, `FuncAnimation` |
+| [Digital Twin](./advanced/digital-twin.md) | Virtual twin, wear injection, divergence metric, anomaly detection |
+| [Quadricóptero MIMO Neural-LQR 3D](./advanced/quadcopter-mimo.md) | LTI MIMO, quadricóptero 12 estados, `lqr()`, MLP residual Neural-LQR, PyVista 3D, GUI de config |
+
+## Distributed
+
+| Example | Concepts |
+|---|---|
+| [Shared Memory](./distributed/shared-memory.md) | Multi-process IPC, bus ownership, rate decoupling |
+| [ZeroMQ Network](./distributed/zmq.md) | PUB/SUB, cross-machine simulation, ZOH fallback |
+
+---
+
+## Running any example
+
+All examples use `uv`:
+
+```bash
+uv run python examples/<path>/<script>.py
+```
+
+Make sure dev dependencies are installed:
+
+```bash
+uv sync --extra dev
+```

--- a/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/getting-started/installation.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/getting-started/installation.md
@@ -1,0 +1,43 @@
+---
+id: installation
+title: Instalação
+sidebar_position: 1
+---
+
+# Instalação
+
+## Requisitos
+
+- Python **3.10** ou superior
+- pip ou [uv](https://docs.astral.sh/uv/) (recomendado)
+
+## Instalar do PyPI
+
+```bash
+pip install synapsys
+```
+
+```bash
+uv add synapsys
+```
+
+## Instalar do código-fonte
+
+```bash
+git clone https://github.com/synapsys-lab/synapsys.git
+cd synapsys
+uv sync --extra dev
+```
+
+## Dependências opcionais
+
+| Extra | Comando | O que adiciona |
+|-------|---------|----------------|
+| `dev` | `uv sync --extra dev` | pytest, ruff, mypy, matplotlib |
+
+## Verificar instalação
+
+```python
+import synapsys
+print(synapsys.__version__)
+```

--- a/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/getting-started/quickstart.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/getting-started/quickstart.md
@@ -1,0 +1,76 @@
+---
+id: quickstart
+title: Início Rápido
+sidebar_position: 2
+---
+
+# Início Rápido
+
+## 1. Analisando um sistema continuo
+
+```python
+from synapsys.api import tf, step, bode, feedback
+import matplotlib.pyplot as plt
+
+# G(s) = wn^2 / (s^2 + 2*zeta*wn*s + wn^2)
+wn, zeta = 10.0, 0.5
+G = tf([wn**2], [1, 2*zeta*wn, wn**2])
+
+print(f"Polos:   {G.poles()}")
+print(f"Estavel: {G.is_stable()}")
+
+t, y = step(G)
+plt.plot(t, y)
+plt.grid(True)
+plt.show()
+```
+
+## 2. Malha fechada com realimentação unitaria negativa
+
+```python
+from synapsys.api import tf, feedback, step
+
+G = tf([10], [1, 1])      # G(s) = 10/(s+1)
+T = feedback(G)            # T = G/(1+G) = 10/(s+11)
+
+print(f"Ganho DC: {T.evaluate(0).real:.4f}")   # 0.9091
+t, y = step(T)
+```
+
+## 3. Discretizar e simular
+
+```python
+from synapsys.api import tf, c2d, step
+
+G = tf([1], [1, 2, 1])      # sistema continuo
+Gd = c2d(G, dt=0.05)         # ZOH, Ts = 50 ms
+
+print(f"Discreto: {Gd.is_discrete}")
+print(f"Estavel:  {Gd.is_stable()}")
+
+t, y = Gd.step(n=200)        # 200 amostras
+```
+
+## 4. Simulação distribuída (mesma máquina)
+
+Execute em dois terminais separados:
+
+```bash
+# Terminal 1 — inicie a planta primeiro
+python examples/distributed/plant.py
+
+# Terminal 2 — depois o controlador
+python examples/distributed/controller.py
+```
+
+A planta expoe seu estado via **memória compartilhada** (zero-copy). O controlador le `y`, calcula `u` com PID e escreve de volta — sem sockets de rede envolvidos.
+
+## 5. Simulação distribuída (máquinas diferentes)
+
+```bash
+# Maquina A — planta
+python examples/distributed/plant_zmq.py
+
+# Maquina B — controlador (configure PLANT_HOST com o IP da Maquina A)
+PLANT_HOST=192.168.1.10 python examples/distributed/controller_zmq.py
+```

--- a/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/guide/agents/concepts.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/guide/agents/concepts.md
@@ -1,0 +1,92 @@
+---
+id: concepts
+title: Simulação Multiagente — Conceitos
+sidebar_position: 1
+---
+
+# Simulação Multiagente — Conceitos
+
+O Synapsys trata cada componente da simulação (planta, controlador, observador) como um **agente independente**. Agentes se comunicam por mensagens, não por chamadas de função — o que permite rodar cada componente em um processo, thread ou máquina separada.
+
+## Por que agentes?
+
+O modelo monolítico (tudo no mesmo script) e simples, mas tem limitações:
+
+- Difícil de testar componentes isoladamente
+- Não escala para sistemas distribuídos (HIL, redes de controladores)
+- Impossível introduzir atraso de rede realista entre planta e controlador
+
+Com agentes:
+
+```
+[ PlantAgent ]  <->  [ SharedMemory / ZMQ ]  <->  [ ControllerAgent ]
+   Processo A              Barramento                  Processo B
+```
+
+## FIPA ACL
+
+O Synapsys usa um subconjunto do padrão **FIPA ACL** (Agent Communication Language) para mensagens estruturadas entre agentes.
+
+```python
+from synapsys.agents import ACLMessage, Performative
+
+msg = ACLMessage(
+    performative=Performative.INFORM,
+    sender="planta",
+    receiver="controlador",
+    content={"y": 3.14},
+)
+
+reply = msg.reply(Performative.REQUEST, content={"u": 1.5})
+```
+
+| Performative | Significado |
+|---|---|
+| `INFORM` | Informa um fato (ex: estado da planta) |
+| `REQUEST` | Solicita uma ação (ex: calcular u) |
+| `AGREE` | Aceita um pedido |
+| `REFUSE` | Recusa um pedido |
+| `FAILURE` | Reporta falha na execucao |
+| `SUBSCRIBE` | Solicita atualizações periodicas |
+
+## Sincronismo
+
+O `SyncEngine` controla como o tempo avanca dentro de cada agente.
+
+```python
+from synapsys.agents import SyncEngine, SyncMode
+
+# Wall-clock: executa em tempo real, com sleep para cadenciar os ticks
+sync = SyncEngine(mode=SyncMode.WALL_CLOCK, dt=0.01)   # 100 Hz
+
+# Lock-step: avanca so quando chamado explicitamente (deterministico)
+sync = SyncEngine(mode=SyncMode.LOCK_STEP, dt=0.01)
+```
+
+### Wall-clock vs lock-step
+
+| | WALL_CLOCK | LOCK_STEP |
+|---|---|---|
+| **Velocidade** | Tempo real (limitado por dt) | Tão rápido quanto possível |
+| **Sincronia** | Cada agente no seu ritmo | Acoplado por barreira externa |
+| **Atraso de rede** | Simulado naturalmente | Transparente |
+| **Reprodutibilidade** | Não-determinístico | Determinístico |
+| **Uso** | Testes de robustez, HIL | Validacao matemática |
+
+## Ciclo de vida do agente
+
+```
+          start()
+             |
+          setup()          <- inicializa recursos
+             |
+    +--------+---------+
+    |  while running:  |
+    |    step()        |   <- um tick da simulacao
+    |    sync.tick()   |   <- avanca o relogio
+    +--------+---------+
+             |
+         teardown()        <- libera recursos
+```
+
+O transporte **não e fechado** pelo agente — seu ciclo de vida e gerenciado pelo código que criou o agente.

--- a/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/guide/agents/controller-agent.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/guide/agents/controller-agent.md
@@ -1,0 +1,60 @@
+---
+id: controller-agent
+title: ControllerAgent
+sidebar_position: 3
+---
+
+# ControllerAgent
+
+`ControllerAgent` aplica uma **lei de controle** em tempo real. Ele le `y` do transporte, chama `control_law(y)` e escreve `u` de volta.
+
+A lei de controle e um `Callable[[np.ndarray], np.ndarray]` — qualquer callable Python, incluindo PID, LQR ou um modelo de IA.
+
+## Exemplos
+
+### Com PID
+
+```python
+import numpy as np
+from synapsys.algorithms import PID
+from synapsys.agents import ControllerAgent, SyncEngine, SyncMode
+from synapsys.transport import SharedMemoryTransport
+
+pid = PID(Kp=3.0, Ki=0.5, dt=0.025, u_min=-10.0, u_max=10.0)
+setpoint = 5.0
+
+law = lambda y: np.array([pid.compute(setpoint=setpoint, measurement=y[0])])
+
+transport = SharedMemoryTransport("minha_simulacao", {"y": 1, "u": 1})
+sync = SyncEngine(SyncMode.WALL_CLOCK, dt=0.025)
+
+ctrl = ControllerAgent("controlador", law, transport, sync)
+ctrl.start(blocking=False)
+```
+
+### Com LQR
+
+```python
+import numpy as np
+from synapsys.algorithms import lqr
+
+K, _ = lqr(A, B, Q, R)
+
+# LQR: u = -K @ x  (aqui y e o estado completo)
+law = lambda y: -(K @ y.reshape(-1, 1)).flatten()
+
+ctrl = ControllerAgent("lqr_ctrl", law, transport, sync)
+```
+
+### Com qualquer callable
+
+```python
+def bang_bang(y: np.ndarray) -> np.ndarray:
+    return np.array([10.0 if y[0] < setpoint else -10.0])
+
+ctrl = ControllerAgent("bang_bang", bang_bang, transport, sync)
+```
+
+## Referência da API
+
+Consulte a referência completa em [synapsys.agents — ControllerAgent](/docs/api/agents).

--- a/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/guide/agents/digital-twins.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/guide/agents/digital-twins.md
@@ -1,0 +1,125 @@
+---
+id: digital-twins
+title: Digital Twins & Custom Signals
+sidebar_position: 5
+---
+
+# Advanced Uses — Digital Twins & Arbitrary Signals
+
+The combination of a clean numerical core and a decoupled transport layer positions Synapsys not just as an educational simulation tool, but as a robust foundation for modern industrial and research applications. 
+
+---
+
+## 1. Digital Twins
+
+A **Digital Twin** requires maintaining a mathematical simulation in persistent synchronization with a real-world physical asset. 
+
+By utilizing the multi-agent transport layer, a `PlantAgent` can run forever on a local server, subscribing to the exact physical telemetry data streaming out of your industrial hardware.
+
+```mermaid
+%%{init: {'theme': 'dark'}}%%
+flowchart LR
+    subgraph Factory Floor
+        Sensors(("Sensors\n(OPC-UA / MQTT)"))
+    end
+
+    subgraph Server [Server: Digital Twin]
+        ZMQ(("ZMQTransport\n(PUB/SUB)"))
+        VirtualTwin["PlantAgent\n(Mathematical Model)"]
+    end
+    
+    Sensors -- "Real u(t), y(t) Streams" --> ZMQ
+    ZMQ -- "Sync" --> VirtualTwin
+```
+
+By continuously evaluating the virtual state matrix (`x_virtual`) using the exact physical input signals `u(t)` received from the hardware, engineers can compare the mathematical `.evolve(x, u)` output with the real physical sensor data. **Divergence** between the two implies that the physical plant has changed—a common indicator of mechanical wear, unpredicted friction buildup, or imminent system faults.
+
+---
+
+## 2. Real-Time Plotting and Oscilloscopes
+
+If you plot simulation data using `matplotlib` within the exact same loop that computes your control laws, the GUI rendering time will block the control thread, causing immense lag and destroying your physics simulation.
+
+Synapsys's agent separation solves this trivially: you just connect a **third independent process** to the active bus as a read-only "Monitor".
+
+```python
+import time
+from synapsys.transport import SharedMemoryTransport
+# You could launch real-time rendering libraries like PyQtGraph here!
+
+# Attach a read-only handle to the ongoing simulation
+monitor = SharedMemoryTransport("ctrl_bus", {"y": 2, "u": 1}, create=False)
+
+try:
+    while True:
+        y = monitor.read("y")
+        u = monitor.read("u")
+        
+        print(f"Time: {time.time():.4f} | Output: {y} | Input: {u}")
+        
+        # Run extremely fast async GUI scope updates here
+        time.sleep(0.01) 
+        
+except KeyboardInterrupt:
+    pass
+```
+
+The `ControllerAgent` and `PlantAgent` processes never know the monitor exists. Their strict microsecond mathematical timings continue performing flawlessly.
+
+---
+
+## 3. Injecting Custom Signals (Ramps, Sines, Time Windows)
+
+Most classical control textbooks only teach the concept of the **Step Response** (`.step()`). In the real world, systems are evaluated against continuous sweeping vibrations, timed duty intervals, and ramp constraints.
+
+### Batch Simulation (NumPy superposition)
+Because the core math engine evaluates `u` as an arbitrary array over generic arrays of time `t`, you can compose highly complex test signals using the sheer strength of NumPy:
+
+```python
+import numpy as np
+from synapsys.api import tf
+import matplotlib.pyplot as plt
+
+G = tf([10], [1, 5, 10])
+
+# Time vector (0 to 10 seconds, 1000 uniform points)
+t = np.linspace(0, 10, 1000)
+
+# 1. Base Sine Wave (Simulating mechanical vibration)
+u_sine = np.sin(2 * np.pi * 1.5 * t)
+
+# 2. Logic Step Injection (Triggers active only after t = 5s)
+u_step = np.where(t >= 5, 2.0, 0.0)
+
+# Principle of Superposition: Combine the signals
+u_total = u_sine + u_step
+
+# Simulate the LTI plant with the complex signal
+t_out, y_out = G.simulate(t, u_total)
+
+plt.plot(t_out, u_total, label="Input u(t) - Sine + Step")
+plt.plot(t_out, y_out, label="Output y(t)")
+plt.legend()
+plt.show()
+```
+
+### Real-Time In-Loop Injection
+For a live simulation being paced by an agent's tick, you evaluate your custom functions against the elapsed clock continuously on the fly:
+
+```python
+import numpy as np
+from synapsys.agents import ControllerAgent, SyncEngine, SyncMode
+
+sync = SyncEngine(mode=SyncMode.WALL_CLOCK, dt=0.01)
+
+def ramp_control_law(y: np.ndarray) -> np.ndarray:
+    # sync.elapsed = wall-clock seconds since the engine was created
+    # sync.t       = simulated time (k * dt) — use this for deterministic signals
+    u = 0.5 * sync.elapsed   # linear ramp: +0.5 u per real second
+    return np.array([u])
+
+ctrl = ControllerAgent("ramp_ctrl", ramp_control_law, transport, sync)
+ctrl.start()
+```
+
+Whether you want Brownian noise modeling, sine sweeps for Bode validation, or precise logical time bounds, your test configurations are constrained only by Python's mathematical ecosystem, freeing you from rigid GUI configurators.

--- a/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/guide/agents/hil-sil.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/guide/agents/hil-sil.md
@@ -1,0 +1,233 @@
+---
+id: hil-sil
+title: SIL, HIL & AI Integration
+sidebar_position: 4
+---
+
+# SIL, HIL & AI Integration
+
+One of the main advantages of Synapsys's agent-based architecture is the seamless transition through different stages of the control system development lifecycle: **MIL**, **SIL**, and **HIL**. 
+
+Because the transport layer is heavily detached from the control algorithms, you can move your controller from a local simulation script to a separate network node, and finally to physical hardware, without altering the control logic itself. This paradigm is especially powerful when validating **Artificial Intelligence (AI)** and **Machine Learning (ML)** models in realistic scenarios.
+
+---
+
+## 1. MIL: Model-in-the-Loop
+
+In **Model-in-the-Loop (MIL)** simulation, both the plant and the controller exist within the same process and simulation thread. Time is advanced artificially by a synchronous `for` loop.
+
+```mermaid
+%%{init: {'theme': 'dark'}}%%
+flowchart LR
+    subgraph SingleProcess [Single Process]
+        direction LR
+        Controller["Controller\n(e.g., PID, LQR)"] -- "u(k)" --> Plant["Plant Model\n(StateSpace)"]
+        Plant -- "y(k)" --> Controller
+    end
+```
+
+This is the standard approach for early validation, mathematical tuning, and stability proofs.
+
+```python
+from synapsys.api import c2d, tf
+from synapsys.algorithms import PID
+import numpy as np
+
+# Both exist in the same Python script memory
+plant = c2d(tf([1], [1, 1]), dt=0.01)
+pid = PID(Kp=2.0, Ki=0.5, dt=0.01)
+
+x = np.zeros(plant.n_states)
+y = 0.0
+
+# MIL execution
+for k in range(100):
+    u = pid.compute(setpoint=1.0, measurement=y)
+    x, y = plant.evolve(x, u)  # direct method call
+```
+
+:::info
+**Focus:** Mathematical correctness, algorithm tuning, and continuous-time analysis.
+
+**Limitation:** It assumes zero execution time for the controller and perfect synchrony. It cannot capture operating system latency, network delays, or unpredictable computation jitter.
+:::
+
+---
+
+## 2. SIL: Software-in-the-Loop
+
+In **Software-in-the-Loop (SIL)**, the control algorithm runs exactly as it would in deployment, but it executes on a desktop/server (often in a separate process or Docker container) rather than embedded hardware. The plant remains simulated.
+
+To transition from MIL to SIL in Synapsys, you wrap your components into **Agents** and connect them using a real transport mechanism (e.g., `SharedMemoryTransport` or `ZMQTransport`).
+
+```mermaid
+%%{init: {'theme': 'dark'}}%%
+flowchart LR
+    subgraph Process_B [Process B]
+        Controller["ControllerAgent"]
+    end
+    
+    subgraph OS_Network [OS / Network]
+        Transport(("SharedMemory /\nZeroMQ"))
+    end
+    
+    subgraph Process_A [Process A]
+        Plant["PlantAgent"]
+    end
+    
+    Controller -- "u(k)" --> Transport
+    Transport -- "y(k)" --> Controller
+    Plant -- "y(k)" --> Transport
+    Transport -- "u(k)" --> Plant
+```
+
+### SIL Implementation
+
+**Terminal 1 (Plant)**
+```python
+transport_plant = SharedMemoryTransport("bus", {"y": 1, "u": 1}, create=True)
+plant_agent = PlantAgent("plant", plant_d, transport_plant, SyncEngine())
+plant_agent.start(blocking=True)
+```
+
+**Terminal 2 (Controller)**
+```python
+transport_ctrl = SharedMemoryTransport("bus", {"y": 1, "u": 1}, create=False)
+law = lambda y: pid.compute(setpoint=1.0, measurement=y[0])
+
+ctrl_agent = ControllerAgent("ctrl", law, transport_ctrl, SyncEngine())
+ctrl_agent.start(blocking=True)
+```
+
+:::tip
+**Focus:** Concurrency, transport latency, zero-copy architecture limits, and software integration tests.
+
+**Advantage:** Exposes real-world race conditions and sampling jitter before physical hardware is ever integrated.
+:::
+
+---
+
+## 3. HIL: Hardware-in-the-Loop
+
+In **Hardware-in-the-Loop (HIL)**, the control software runs on the **target embedded hardware** (e.g., an ESP32, STM32, or PLC), while the plant is still simulated by Synapsys. 
+
+The physical hardware receives simulated sensor signals and generates physical control actions (like actual PWM or voltage signals) that are fed back into the simulation through a hardware interface bridge.
+
+```mermaid
+%%{init: {'theme': 'dark'}}%%
+flowchart LR
+    subgraph PhysicalEnvironment [Physical Environment]
+        MCU["Embedded MCU\n(ESP32, STM32)"]
+    end
+    
+    subgraph IOBridge [I/O Bridge]
+        Serial(("Serial / UART /\nOPC-UA"))
+    end
+    
+    subgraph Computer_System [Computer]
+        Plant["PlantAgent"]
+    end
+    
+    MCU -- "Physical u(k)" --> Serial
+    Serial -- "Serial u(k)" --> Plant
+    Plant -- "Simulated y(k)" --> Serial
+    Serial -- "Electrical y(k)" --> MCU
+```
+
+### HIL Bridge Concept
+
+Instead of instantiating a `ControllerAgent`, you bind the plant's transport to a hardware bridge layer (`synapsys.hw`). *Note: Concrete hardware interfaces are planned for v0.5.*
+
+```python
+from synapsys.hw import SerialHardwareInterface
+
+# Connect to the physical controller via USB/UART
+hw_bridge = SerialHardwareInterface(port="/dev/ttyACM0", baudrate=115200)
+
+while True:
+    y = transport_plant.read("y")
+    hw_bridge.write(y)           # Send sensor data over Serial
+    
+    u = hw_bridge.read()         # Wait for MCU control action
+    transport_plant.write("u", u)
+```
+
+:::note
+**Advantage:** You can rigorously test boundary conditions, system failures, and corner cases on the final compiled C/C++ firmware without risking physical damage to an expensive, actual plant (e.g., drones, industrial motors).
+:::
+
+---
+
+## 4. Integrating AI and Machine Learning
+
+The classical controls world (PID, LQR) heavily relies on MIL. However, when working with **Reinforcement Learning (RL)**, **Neural Networks**, or complex stochastic models, MIL is often insufficient. AI inference is highly non-deterministic regarding computation time.
+
+Synapsys's decoupled architecture makes it an incredibly robust environment for AI integration.
+
+### The Problem with AI in Control Loops
+
+1. **Inference Time Jitter:** A neural network forward pass (`model(state)`) might take 2ms on one tick, and 15ms on the next due to Python garbage collection, OS scheduling, or GPU transfer limits.
+2. **Language Barriers:** AI is predominantly built in Python (PyTorch, TensorFlow, JAX), but traditional HIL environments are heavily C++/Simulink based, requiring complex compilation steps, ONNX exports, or slow middleware.
+
+### The Synapsys Solution
+
+Since Synapsys is **natively Python**, you can run massive, uncompiled PyTorch models directly inside a `ControllerAgent` in a SIL setup.
+
+```mermaid
+%%{init: {'theme': 'dark'}}%%
+flowchart TD
+    subgraph Process_B [Process B: AI Controller]
+        Torch["PyTorch / TensorFlow Model"]
+        Agent["ControllerAgent"]
+        Torch <-- "Inference" --> Agent
+    end
+    
+    subgraph TransportLayer [Transport]
+        ZMQ(("ZMQTransport\n(Async PUB/SUB)"))
+    end
+
+    subgraph Process_A [Process A: Physics Engine Simulator]
+        Plant["PlantAgent (Real-Time loop)"]
+    end
+    
+    Agent -- "u(k)" --> ZMQ
+    ZMQ -- "y(k)" --> Agent
+    Plant -- "y(k)" --> ZMQ
+    ZMQ -- "u(k)" --> Plant
+```
+
+### Key Advantages for AI Testing
+
+1. **Fault Isolation:** If your PyTorch inference spikes to 100ms, your `PlantAgent` doesn't freeze or crash. It continues running the physical simulation in real-time independently, holding the last known control signal (Zero-Order Hold). This perfectly replicates how a physical system behaves when its smart controller lags.
+2. **Gymnasium Wrappers:** You can train your RL agent using standard OpenAI Gym / Gymnasium APIs (which are purely sequential), and then validate the pre-trained weights in a Synapsys SIL environment that introduces real-time constraints, latency, and network drops. This proves if your AI is robust enough for the real world.
+3. **Zero-Effort Transition to Reality:** Once your RL agent successfully controls the simulated `PlantAgent` in the SIL environment, you can drop the simulated plant and connect the **exact same PyTorch script** to physical hardware via the HIL bridge. The AI model doesn't know it's now controlling a real motor instead of a matrix array!
+
+### Example: PyTorch RL Agent in a SIL loop
+
+```python
+import torch
+import numpy as np
+from synapsys.agents import ControllerAgent, SyncEngine, SyncMode
+from synapsys.transport import SharedMemoryTransport
+
+# Load your pre-trained PyTorch model
+model = torch.load("rl_controller.pth")
+model.eval()
+
+def ai_control_law(y: np.ndarray) -> np.ndarray:
+    # Convert latest sensor data to tensor
+    state_tensor = torch.tensor(y, dtype=torch.float32)
+    
+    # Run inference to predict control action
+    with torch.no_grad():
+        action = model(state_tensor).numpy()
+        
+    return action
+
+# Create transport and run the AI controller as an agent
+ai_transport = SharedMemoryTransport("ctrl_bus", {"y": 2, "u": 1}, create=False)
+sync = SyncEngine(mode=SyncMode.WALL_CLOCK, dt=0.01)
+
+ai_agent = ControllerAgent("ai_ctrl", ai_control_law, ai_transport, sync)
+ai_agent.start(blocking=True)
+```

--- a/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/guide/agents/plant-agent.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/guide/agents/plant-agent.md
@@ -1,0 +1,59 @@
+---
+id: plant-agent
+title: PlantAgent
+sidebar_position: 2
+---
+
+# PlantAgent
+
+`PlantAgent` simula uma **planta discreta** (`StateSpace` com `dt > 0`) em tempo real, publicando `y` e consumindo `u` a cada tick.
+
+## Requisitos
+
+- A planta deve ser discreta. Use `c2d()` para discretizar uma planta continua.
+- O transporte deve ter dois canais: um para `y` (saida) e um para `u` (entrada).
+
+## Exemplo completo
+
+```python
+import numpy as np
+from synapsys.api import ss, c2d
+from synapsys.agents import PlantAgent, SyncEngine, SyncMode
+from synapsys.transport import SharedMemoryTransport
+
+# 1. Definir e discretizar a planta
+plant_c = ss([[-1.0]], [[1.0]], [[1.0]], [[0.0]])   # G(s) = 1/(s+1)
+plant_d = c2d(plant_c, dt=0.01)                      # ZOH, 100 Hz
+
+# 2. Criar o barramento de memoria compartilhada
+BUS = "minha_simulacao"
+CHANNELS = {"y": 1, "u": 1}
+
+owner = SharedMemoryTransport(BUS, CHANNELS, create=True)
+owner.write("u", np.array([0.0]))
+owner.write("y", np.array([0.0]))
+
+# 3. Cada agente tem seu proprio handle
+t_plant = SharedMemoryTransport(BUS, CHANNELS)
+
+sync = SyncEngine(SyncMode.WALL_CLOCK, dt=0.01)
+agent = PlantAgent("planta", plant_d, t_plant, sync)
+
+# 4. Iniciar em background
+agent.start(blocking=False)
+
+agent.stop()
+t_plant.close()
+owner.close()
+```
+
+## Estado inicial
+
+```python
+x0 = np.array([2.0])    # estado inicial nao-zero
+agent = PlantAgent("planta", plant_d, transport, sync, x0=x0)
+```
+
+## Referência da API
+
+Consulte a referência completa em [synapsys.agents — PlantAgent](/docs/api/agents).

--- a/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/guide/algorithms/lqr.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/guide/algorithms/lqr.md
@@ -1,0 +1,52 @@
+---
+id: lqr
+title: LQR — Regulador Quadrático Linear
+sidebar_position: 2
+---
+
+# LQR — Regulador Quadrático Linear
+
+O LQR encontra o ganho de realimentação de estados $K$ que minimiza o custo quadrático:
+
+$$J = \int_0^\infty \left( x^\top Q x + u^\top R u \right) dt$$
+
+A solução e $u = -Kx$, onde $K = R^{-1} B^\top P$ e $P$ e a solução da **Equacao Algebrica de Riccati (ARE)**.
+
+## Uso
+
+```python
+import numpy as np
+from synapsys.algorithms import lqr
+from synapsys.api import ss
+
+# Pendulo invertido simplificado
+A = np.array([[0, 1], [10, 0]])
+B = np.array([[0], [1]])
+
+Q = np.diag([10.0, 1.0])   # penaliza posicao mais que velocidade
+R = np.array([[0.1]])       # penaliza esforco de controle
+
+K, P = lqr(A, B, Q, R)
+print(f"Ganho K: {K}")      # ex: [[-29.14, -7.61]]
+
+# Verificar estabilidade da malha fechada
+A_cl = A - B @ K
+sys_cl = ss(A_cl, B, np.eye(2), np.zeros((2, 1)))
+print(f"Estavel: {sys_cl.is_stable()}")   # True
+```
+
+## Ajuste de Q e R
+
+| Objetivo | Ajuste |
+|----------|--------|
+| Resposta mais rápida | Aumentar $Q$ (penalizar erro de estado) |
+| Menor esforco de atuacao | Aumentar $R$ |
+| Priorizar um estado especifico | Aumentar elemento diagonal de $Q$ correspondente |
+
+:::tip Regra de Bryson
+Um ponto de partida clássico: $Q_{ii} = 1 / x_{i,max}^2$ e $R_{jj} = 1 / u_{j,max}^2$
+:::
+
+## Referência da API
+
+Consulte a referência completa em [synapsys.algorithms — lqr](/docs/api/algorithms).

--- a/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/guide/algorithms/pid.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/guide/algorithms/pid.md
@@ -1,0 +1,70 @@
+---
+format: md
+id: pid
+title: Controlador PID
+sidebar_position: 1
+---
+
+# Controlador PID
+
+O `PID` implementa um controlador Proporcional-Integral-Derivativo discreto com **saturação de saida** e **anti-windup por back-calculation**.
+
+## Formula
+
+$$
+u(k) = K_p \, e(k) + K_i \sum_{j=0}^{k} e(j)\,\Delta t + K_d \, \frac{e(k) - e(k-1)}{\Delta t}
+$$
+
+O anti-windup corrige o integrador quando a saida satura:
+
+$$
+\text{integral} \mathrel{+}= \frac{u_{sat}(k) - u(k)}{K_i}
+$$
+
+## Uso basico
+
+```python
+from synapsys.algorithms import PID
+
+pid = PID(
+    Kp=2.0,
+    Ki=0.5,
+    Kd=0.1,
+    dt=0.01,
+    u_min=-10.0,
+    u_max=10.0,
+)
+
+setpoint = 5.0
+y = 0.0
+
+for _ in range(1000):
+    u = pid.compute(setpoint=setpoint, measurement=y)
+    # ... aplica u na planta, le novo y ...
+```
+
+## Anti-windup
+
+Sem anti-windup, o integrador continua acumulando erro durante a saturação, causando **integrator windup**: atraso excessivo ao sair da saturação.
+
+Com back-calculation, quando `u` satura, o integrador e corrigido na direção oposta:
+
+```python
+pid_sem = PID(Kp=5.0, Ki=10.0, dt=0.01)
+pid_com = PID(Kp=5.0, Ki=10.0, dt=0.01,
+              u_min=-1.0, u_max=1.0)
+
+# pid_com converge muito mais rapido ao sair de uma saturacao prolongada
+```
+
+## Reset do estado
+
+```python
+pid.reset()    # zera integrador e erro anterior
+```
+
+Útil em trocas de modo (manual para automatico) ou ao mudar o setpoint abruptamente.
+
+## Referência da API
+
+Consulte a referência completa em [synapsys.algorithms — PID](/docs/api/algorithms).

--- a/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/guide/core/discrete.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/guide/core/discrete.md
@@ -1,0 +1,81 @@
+---
+id: discrete
+title: Sistemas de Tempo Discreto
+sidebar_position: 3
+---
+
+# Sistemas de Tempo Discreto
+
+O Synapsys diferencia sistemas continuos e discretos pelo atributo `dt`:
+
+| `dt` | Dominio | Estabilidade |
+|------|---------|-------------|
+| `0.0` (padrão) | Continuo — s | `Re(polos) < 0` |
+| `> 0` | Discreto — z | `\|polos\| < 1` |
+
+## Discretização (ZOH)
+
+Use `c2d()` para converter um sistema continuo em discreto pelo método **Zero-Order Hold**:
+
+```python
+from synapsys.api import tf, ss, c2d
+
+# Sistema continuo
+G_c = tf([1], [1, 1])   # G(s) = 1/(s+1)
+
+# Discretizar com Ts = 10 ms
+G_d = c2d(G_c, dt=0.01)
+
+print(G_d.is_discrete)   # True
+print(G_d.dt)            # 0.01
+print(G_d.poles())       # [exp(-0.01)] ≈ [0.990]
+```
+
+O mesmo funciona para `StateSpace`:
+
+```python
+import numpy as np
+from synapsys.api import ss, c2d
+
+sys_c = ss(np.array([[-1.0]]), np.array([[1.0]]),
+           np.array([[1.0]]), np.array([[0.0]]))
+sys_d = c2d(sys_c, dt=0.05)
+```
+
+## Resposta ao degrau discreta
+
+```python
+t, y = G_d.step(n=300)   # 300 amostras
+```
+
+Ou com tempo continuo equivalente:
+
+```python
+import numpy as np
+t = np.arange(300) * G_d.dt
+t_out, y_out = G_d.step(n=300)
+```
+
+## Simulação passo a passo
+
+`StateSpace.evolve(x, u)` avanca um tick — o bloco basico para agentes em tempo real:
+
+```python
+x = np.zeros(sys_d.A.shape[0])
+u = np.array([1.0])
+
+for k in range(200):
+    x, y = sys_d.evolve(x, u)
+```
+
+## Estabilidade discreta
+
+```python
+G_d = c2d(tf([1], [1, -0.5]), dt=0.1)
+print(G_d.is_stable())   # |polo| < 1?
+print(abs(G_d.poles()))
+```
+
+## Referência da API
+
+Consulte a referência completa em [synapsys.core — StateSpace](/docs/api/core) e [synapsys.api — c2d](/docs/api/matlab-compat).

--- a/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/guide/core/state-space.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/guide/core/state-space.md
@@ -1,0 +1,87 @@
+---
+id: state-space
+title: Espaço de Estados
+sidebar_position: 2
+---
+
+# Espaço de Estados
+
+`StateSpace(A, B, C, D, dt=0.0)` representa um sistema LTI na forma matricial:
+
+$$
+\dot{x} = Ax + Bu
+$$
+$$
+y = Cx + Du
+$$
+
+Para sistemas discretos (dt > 0):
+
+$$
+x(k+1) = Ax(k) + Bu(k)
+$$
+$$
+y(k) = Cx(k) + Du(k)
+$$
+
+## Criacao
+
+```python
+import numpy as np
+from synapsys.api import ss
+
+# Pendulo invertido simplificado
+A = np.array([[0, 1], [10, 0]])
+B = np.array([[0], [1]])
+C = np.eye(2)
+D = np.zeros((2, 1))
+
+sys = ss(A, B, C, D)
+```
+
+## Estabilidade
+
+```python
+print(sys.is_stable())   # False — polo em +sqrt(10)
+print(sys.poles())       # [+3.16, -3.16]
+```
+
+## Resposta ao degrau e Bode
+
+```python
+t, y = sys.step()
+w, mag, phase = sys.bode()
+```
+
+## Evolucao passo a passo (discreto)
+
+Para simulação em tempo real dentro de agentes, use `evolve()`:
+
+```python
+from synapsys.api import ss, c2d
+import numpy as np
+
+sys_c = ss([[-1.0]], [[1.0]], [[1.0]], [[0.0]])
+sys_d = c2d(sys_c, dt=0.01)   # ZOH
+
+x = np.array([0.0])
+for _ in range(100):
+    x, y = sys_d.evolve(x, np.array([1.0]))   # degrau unitario
+```
+
+## Conversão para função de transferencia
+
+```python
+G = sys.to_transfer_function()
+```
+
+## Álgebra
+
+```python
+sys_series   = sys1 * sys2
+sys_parallel = sys1 + sys2
+```
+
+## Referência da API
+
+Consulte a referência completa em [synapsys.core — StateSpace](/docs/api/core).

--- a/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/guide/core/transfer-function.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/guide/core/transfer-function.md
@@ -1,0 +1,87 @@
+---
+id: transfer-function
+title: Função de Transferencia
+sidebar_position: 1
+---
+
+# Função de Transferencia
+
+`TransferFunction(num, den, dt=0.0)` representa um sistema LTI por seus polinomios numerador e denominador no dominio de Laplace (continuo) ou Z (discreto).
+
+## Criacao
+
+```python
+from synapsys.api import tf
+
+# G(s) = (s + 2) / (s^2 + 3s + 2)
+G = tf([1, 2], [1, 3, 2])
+
+# Equivalente com construtor direto
+from synapsys.core import TransferFunction
+G = TransferFunction([1, 2], [1, 3, 2])
+```
+
+Para sistemas discretos, passe `dt`:
+
+```python
+# H(z) = 0.1 / (z - 0.9),  Ts = 10 ms
+H = tf([0.1], [1, -0.9], dt=0.01)
+print(H.is_discrete)   # True
+```
+
+## Polos, zeros e estabilidade
+
+```python
+G = tf([1, 2], [1, 3, 2])   # polos em -1 e -2
+
+print(G.poles())             # [-1. -2.]
+print(G.zeros())             # [-2.]
+print(G.is_stable())         # True  (Re(polos) < 0)
+```
+
+## Álgebra de blocos
+
+```python
+from synapsys.api import tf, feedback, series, parallel
+
+G = tf([10], [1, 1])
+H = tf([1], [1, 0])   # integrador
+
+# Serie: G * H
+GH = series(G, H)    # equivalente a G * H
+
+# Paralelo: G + H
+GP = parallel(G, H)  # equivalente a G + H
+
+# Realimentacao negativa unitaria: G / (1 + G)
+T = feedback(G)
+
+# Realimentacao com H no ramo de retorno
+T2 = feedback(G, H)
+```
+
+Os operadores Python também funcionam:
+
+```python
+T = G * H      # serie
+P = G + H      # paralelo
+N = -G         # negacao
+```
+
+## Resposta ao degrau e Bode
+
+```python
+from synapsys.api import step, bode
+import matplotlib.pyplot as plt
+
+G = tf([1], [1, 2, 1])
+
+t, y = step(G)
+plt.plot(t, y)
+
+w, mag, phase = bode(G)
+```
+
+## Referência da API
+
+Consulte a referência completa em [synapsys.core — TransferFunction](/docs/api/core).

--- a/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/guide/transport/broker.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/guide/transport/broker.md
@@ -1,0 +1,184 @@
+---
+id: broker
+title: MessageBroker
+sidebar_position: 2
+---
+
+# MessageBroker — Camada Central de Roteamento
+
+O `MessageBroker` é a forma **recomendada** de conectar agentes no Synapsys. Ele atua como mediador: agentes publicam em `Topic`s nomeados e leem deles sem manter nenhuma referência direta ao transporte. Esse desacoplamento permite topologias **many-to-many** impossíveis com um único transporte ponto a ponto.
+
+---
+
+## Abstrações principais
+
+### Topic
+
+Um `Topic` descreve um sinal nomeado: seu shape e dtype. Funciona como uma chave tipada no registro do broker.
+
+```python
+from synapsys.broker import Topic
+import numpy as np
+
+topic_y = Topic("plant/y", shape=(4,))          # vetor float64 de 4 elementos
+topic_u = Topic("plant/u", shape=(1,))
+topic_cfg = Topic("ctrl/config", shape=(1,), dtype=np.dtype(np.float32))
+```
+
+Topics são **dataclasses imutáveis** — hasháveis e congelados. O broker os usa para validar cada chamada `publish()`: se o shape do array não corresponder ao shape declarado, um `ValueError` é lançado antes de qualquer escrita.
+
+Nomes de topic seguem convenção hierárquica: `"<sistema>/<sinal>"`.  
+Exemplos: `"plant/y"`, `"quad/state"`, `"ctrl/config"`.
+
+### BrokerBackend
+
+Um `BrokerBackend` é o transporte físico abaixo do broker. Os dois backends embutidos são:
+
+| Backend | Transporte | Melhor para |
+|---|---|---|
+| `SharedMemoryBackend` | Memória compartilhada do SO | Agentes na mesma máquina, latência < 1 µs |
+| `ZMQBrokerBackend` | ZeroMQ PUB/SUB | Agentes entre máquinas, pub/sub assíncrono |
+
+### MessageBroker
+
+```python
+from synapsys.broker import MessageBroker, Topic, SharedMemoryBackend
+
+broker = MessageBroker()
+broker.declare_topic(topic_y)
+broker.declare_topic(topic_u)
+broker.add_backend(SharedMemoryBackend("my_bus", [topic_y, topic_u], create=True))
+
+# Inicializar antes de os agentes iniciarem
+broker.publish("plant/y", np.zeros(4))
+broker.publish("plant/u", np.zeros(1))
+```
+
+| Método | Descrição |
+|---|---|
+| `declare_topic(topic)` | Registra um `Topic`. Deve ser chamado antes de `publish` ou `read`. |
+| `add_backend(backend)` | Anexa um backend. Um topic é roteado ao primeiro backend que o suporta. |
+| `publish(name, data)` | Valida shape → escreve no backend → notifica callbacks. |
+| `read(name)` | Leitura não-bloqueante do backend (ZOH se não houver dados novos). |
+| `subscribe(name, callback)` | Registra callback invocado a cada `publish`. |
+| `read_wait(name, timeout)` | Leitura bloqueante — aguarda novos dados ou timeout. |
+| `close()` | Fecha todos os backends e libera recursos. |
+
+---
+
+## Conectando agentes
+
+Agentes aceitam o argumento de palavra-chave `broker=`. Passe `None` como argumento posicional `transport` ao usar o broker:
+
+```python
+from synapsys.agents import PlantAgent, ControllerAgent, SyncEngine
+from synapsys.algorithms import PID
+
+plant_agent = PlantAgent(
+    "plant", plant_d, None, SyncEngine(),
+    channel_y="plant/y", channel_u="plant/u", broker=broker,
+)
+
+pid = PID(Kp=3.0, Ki=0.5, dt=0.01)
+ctrl_agent = ControllerAgent(
+    "ctrl",
+    lambda y: np.array([pid.compute(5.0, y[0])]),
+    None, SyncEngine(),
+    channel_y="plant/y", channel_u="plant/u", broker=broker,
+)
+
+plant_agent.start(blocking=False)
+ctrl_agent.start(blocking=True)
+```
+
+Ambos os agentes compartilham a **mesma instância do broker**. O broker roteia `"plant/y"` e `"plant/u"` pelo `SharedMemoryBackend` sem que nenhum agente saiba sobre memória compartilhada.
+
+---
+
+## Padrão Observer
+
+Qualquer código que precise monitorar sinais pode chamar `broker.read()` diretamente — sem handle de transporte extra, sem impacto nos agentes em malha fechada:
+
+```python
+import time
+
+# Monitor terceiro — somente leitura, completamente transparente
+try:
+    while True:
+        y = broker.read("plant/y")
+        u = broker.read("plant/u")
+        print(f"y={y}  u={u}")
+        time.sleep(0.05)
+except KeyboardInterrupt:
+    broker.close()
+```
+
+---
+
+## Reconfiguração multi-agente
+
+Como qualquer número de agentes pode publicar e assinar qualquer topic, um `ReconfigAgent` pode enviar atualizações de parâmetros ao vivo para um controlador em execução:
+
+```mermaid
+%%{init: {'theme': 'dark'}}%%
+flowchart LR
+    P["PlantAgent"] -->|publish plant/y| B(["MessageBroker"])
+    B -->|read plant/y| C["ControllerAgent"]
+    C -->|publish plant/u| B
+    B -->|read plant/u| P
+    R["ReconfigAgent"] -->|publish ctrl/config| B
+    B -->|read ctrl/config| C
+```
+
+```python
+topic_cfg = Topic("ctrl/config", shape=(1,))
+broker.declare_topic(topic_cfg)
+broker.publish("ctrl/config", np.array([5.0]))   # setpoint inicial
+
+def adaptive_law(y: np.ndarray) -> np.ndarray:
+    setpoint = broker.read("ctrl/config")[0]
+    return np.array([pid.compute(setpoint, y[0])])
+
+# Publica novo setpoint a qualquer momento
+broker.publish("ctrl/config", np.array([10.0]))  # atualização ao vivo
+```
+
+---
+
+## Escolhendo um backend
+
+```mermaid
+%%{init: {'theme': 'dark'}}%%
+flowchart LR
+    Q{Mesma máquina?}
+    Q -->|Sim| SHM["SharedMemoryBackend\nZero-copy, < 1 µs"]
+    Q -->|Não| ZMQ["ZMQBrokerBackend\nTCP PUB/SUB, ~100 µs"]
+```
+
+Para setups entre máquinas, cada processo cria seu **próprio** broker e conecta duas instâncias de `ZMQBrokerBackend` (uma para topics PUB, uma para SUB). Veja [Transporte ZeroMQ](zmq.md) para detalhes de conexão bidirecional.
+
+---
+
+## Ciclo de vida
+
+```python
+# Setup
+broker = MessageBroker()
+broker.declare_topic(topic_y)
+broker.add_backend(SharedMemoryBackend("bus", [topic_y], create=True))
+broker.publish("plant/y", np.zeros(1))   # inicializar antes dos agentes
+
+# Execução
+agent.start(blocking=True)
+
+# Teardown — sempre feche o broker
+broker.close()
+```
+
+Chamar `broker.close()` fecha todos os backends registrados. Para `SharedMemoryBackend`, a instância com `create=True` também chama `unlink()` para liberar o bloco de memória compartilhada do SO.
+
+---
+
+## Referência da API
+
+Veja a referência completa em [synapsys.broker →](../../api/transport).

--- a/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/guide/transport/overview.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/guide/transport/overview.md
@@ -1,0 +1,60 @@
+---
+id: overview
+title: Camada de Transporte — Visao Geral
+sidebar_position: 1
+---
+
+# Camada de Transporte — Visao Geral
+
+A camada de transporte abstrai **como os dados fluem** entre agentes. Toda implementação segue a interface `TransportStrategy`:
+
+```python
+transport.write("canal", np.array([1.0, 2.0]))
+data = transport.read("canal")   # -> np.ndarray
+```
+
+## Escolhendo o transporte
+
+```mermaid
+%%{init: {'theme': 'dark'}}%%
+flowchart LR
+    Q{Planta e controlador\nna mesma maquina?}
+    Q -->|Sim| SM["SharedMemoryTransport\nZero-copy, latencia ~µs"]
+    Q -->|Nao| ZQ{Sincronia\nnecessaria?}
+    ZQ -->|Assincrono| PUB["ZMQTransport\nPUB/SUB"]
+    ZQ -->|Lock-step| REP["ZMQReqRepTransport\nREQ/REP"]
+```
+
+| Transporte | Latência tipica | Topologia | Caso de uso |
+|---|---|---|---|
+| `SharedMemoryTransport` | < 1 µs | mesma máquina | Simulação de alta frequência |
+| `ZMQTransport` (PUB/SUB) | ~100 µs–1 ms | rede | Controlador em outra máquina, múltiplos observadores |
+| `ZMQReqRepTransport` | ~100 µs–1 ms | rede | Simulação lock-step sobre rede |
+
+## Interface comum
+
+```python
+from synapsys.transport import SharedMemoryTransport
+
+with SharedMemoryTransport("bus", {"y": 2, "u": 1}, create=True) as t:
+    t.write("y", np.array([0.0, 0.0]))
+    y = t.read("y")
+```
+
+## Implementando um transporte customizado
+
+```python
+import numpy as np
+from synapsys.transport import TransportStrategy
+
+class RedisTransport(TransportStrategy):
+    def write(self, channel: str, data: np.ndarray) -> None:
+        self._redis.set(channel, data.tobytes())
+
+    def read(self, channel: str) -> np.ndarray:
+        raw = self._redis.get(channel)
+        return np.frombuffer(raw, dtype=np.float64)
+
+    def close(self) -> None:
+        self._redis.close()
+```

--- a/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/guide/transport/shared-memory.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/guide/transport/shared-memory.md
@@ -1,0 +1,64 @@
+---
+id: shared-memory
+title: Transporte por Memória Compartilhada
+sidebar_position: 2
+---
+
+# Transporte por Memória Compartilhada
+
+`SharedMemoryTransport` usa o mecanismo de **memória compartilhada do SO** (`multiprocessing.shared_memory`) para comunicação **zero-copy** entre processos na mesma máquina.
+
+Os dados são escritos diretamente em endereços de RAM física mapeados como arrays NumPy. Sem serialização, sem copia — apenas um ponteiro para o mesmo endereço.
+
+## Como funciona
+
+```
+Processo A (planta)           RAM Fisica               Processo B (controlador)
+─────────────────────    ┌──────────────────────┐    ──────────────────────────
+bus._buf -> array  ─────▶│  [y0, y1, ..., u0]  │◀────── bus._buf -> array
+                         └──────────────────────┘
+                              "ctrl_bus" (nome OS)
+```
+
+## Uso
+
+```python
+from synapsys.transport import SharedMemoryTransport
+import numpy as np
+
+CHANNELS = {
+    "y": 2,    # saida da planta — 2 floats
+    "u": 1,    # sinal de controle — 1 float
+}
+
+# Processo owner: cria o bloco (create=True)
+owner = SharedMemoryTransport("ctrl_bus", CHANNELS, create=True)
+owner.write("y", np.array([0.0, 0.0]))
+owner.write("u", np.array([0.0]))
+
+# Outros processos: conectam pelo nome
+client = SharedMemoryTransport("ctrl_bus", CHANNELS)
+y = client.read("y")
+```
+
+:::warning Owner e responsavel pelo unlink
+Apenas o processo `create=True` libera a memória no SO ao fechar. Os clientes chamam apenas `close()`.
+:::
+
+## Múltiplos agentes no mesmo bloco
+
+```python
+t_plant = SharedMemoryTransport("ctrl_bus", CHANNELS)
+t_ctrl  = SharedMemoryTransport("ctrl_bus", CHANNELS)
+
+plant_agent = PlantAgent(..., transport=t_plant, ...)
+ctrl_agent  = ControllerAgent(..., transport=t_ctrl, ...)
+```
+
+:::danger Race conditions
+Não ha mutex na implementação atual. Arquitete seus canais para que cada processo seja o único escritor do seu canal.
+:::
+
+## Referência da API
+
+Consulte a referência completa em [synapsys.transport — SharedMemoryTransport](/docs/api/transport).

--- a/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/guide/transport/zmq.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/guide/transport/zmq.md
@@ -1,0 +1,69 @@
+---
+id: zmq
+title: Transporte ZeroMQ
+sidebar_position: 3
+---
+
+# Transporte ZeroMQ
+
+O transporte ZMQ permite que agentes se comuniquem **por rede**, incluindo máquinas diferentes. É baseado na biblioteca [ZeroMQ](https://zeromq.org/), que usa C/C++ internamente e opera na casa dos microssegundos em rede local.
+
+## PUB/SUB — Assíncrono
+
+Cada agente publica em um endereço e assina em outro. Não ha bloqueio — se o consumidor estiver atrasado, ele le a última mensagem disponível.
+
+```python
+from synapsys.transport import ZMQTransport
+import numpy as np
+
+# Planta (publicador)
+pub = ZMQTransport("tcp://0.0.0.0:5555", mode="pub")
+pub.write("y", np.array([3.14]))
+
+# Controlador (assinante)
+sub = ZMQTransport("tcp://192.168.1.10:5555", mode="sub")
+y = sub.read("y")
+```
+
+### Topologia bidirecional
+
+```
+Planta:       PUB :5555  ->  SUB :5556
+Controlador:  PUB :5556  ->  SUB :5555
+```
+
+## REQ/REP — Lock-step
+
+Garante sincronismo total: o cliente bloqueia até receber a resposta.
+
+```python
+from synapsys.transport import ZMQReqRepTransport
+
+# Planta (servidor)
+server = ZMQReqRepTransport("tcp://0.0.0.0:5555", mode="server")
+u = server.read("u")
+server.write("y", y_array)
+
+# Controlador (cliente)
+client = ZMQReqRepTransport("tcp://localhost:5555", mode="client")
+client.write("u", u_array)
+y = client.read("y")
+```
+
+:::warning Ordem importa no REQ/REP
+O servidor deve fazer `read()` antes de `write()`, e o cliente `write()` antes de `read()`. Inverter a ordem causa deadlock.
+:::
+
+## Latência
+
+| Cenario | Latência tipica |
+|---------|----------------|
+| Loopback (`localhost`) | ~50–100 µs |
+| LAN 1 Gbps | ~100–300 µs |
+| WAN / Internet | > 1 ms |
+
+Para comparação, `SharedMemoryTransport` opera em < 1 µs.
+
+## Referência da API
+
+Consulte a referência completa em [synapsys.transport — ZMQTransport](/docs/api/transport).

--- a/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/guide/utils/matrix-builders.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/guide/utils/matrix-builders.md
@@ -1,0 +1,136 @@
+---
+format: md
+id: matrix-builders
+title: Matrix Builders
+sidebar_position: 1
+---
+
+# Matrix Builders
+
+`synapsys.utils` provides concise helpers to construct NumPy arrays and build
+$(A, B, C, D)$ matrices from named differential equations — no raw
+`np.array` boilerplate required.
+
+## Helpers: `mat`, `col`, `row`
+
+| Helper | Output shape | Use for |
+|---|---|---|
+| `mat(rows)` | $(m \times n)$ | any 2-D matrix |
+| `col(*values)` | $(n \times 1)$ | input matrix **B**, column vector |
+| `row(*values)` | $(1 \times n)$ | output matrix **C**, row selector |
+
+```python
+from synapsys.utils import mat, col, row
+
+A = mat([
+    [ 0,  1],
+    [-2, -3],
+])                    # shape (2, 2)
+
+B = col(0, 1)         # shape (2, 1)
+C = row(1, 0)         # shape (1, 2)
+```
+
+All three return `np.ndarray` with `dtype=float64` and are drop-in replacements
+for `np.array(...)`.
+
+---
+
+## `StateEquations` — named differential equations
+
+`StateEquations` lets you declare each differential equation **by name** instead
+of managing matrix indices manually.
+
+$$\dot{x}_i = \sum_j a_{ij}\,x_j + \sum_k b_{ik}\,u_k$$
+
+Each call to `.eq(state, **coeffs)` fills the corresponding row of **A** (for
+state names) and **B** (for input names). The builder is **fluent** — every
+`.eq()` returns `self`.
+
+### Example — 2-DOF mass–spring–damper
+
+$$
+\begin{bmatrix} \dot{x}_1 \\ \dot{x}_2 \\ \dot{v}_1 \\ \dot{v}_2 \end{bmatrix}
+=
+\underbrace{\begin{bmatrix}
+0 & 0 & 1 & 0 \\
+0 & 0 & 0 & 1 \\
+-2k/m & k/m & -c/m & 0 \\
+k/m & -2k/m & 0 & -c/m
+\end{bmatrix}}_{A}
+\begin{bmatrix} x_1 \\ x_2 \\ v_1 \\ v_2 \end{bmatrix}
++
+\underbrace{\begin{bmatrix} 0 \\ 0 \\ 0 \\ k/m \end{bmatrix}}_{B}
+F
+$$
+
+```python
+from synapsys.utils import StateEquations
+
+m, c, k = 1.0, 0.1, 2.0
+
+eqs = (
+    StateEquations(states=["x1", "x2", "v1", "v2"], inputs=["F"])
+    .eq("x1", v1=1)                                         # ẋ1 = v1
+    .eq("x2", v2=1)                                         # ẋ2 = v2
+    .eq("v1", x1=-2*k/m, x2=k/m,  v1=-c/m)                # v̇1 = …
+    .eq("v2", x1=k/m,  x2=-2*k/m, v2=-c/m, F=k/m)         # v̇2 = …
+)
+
+A = eqs.A                       # np.ndarray (4, 4)
+B = eqs.B                       # np.ndarray (4, 1)
+C = eqs.output("x1", "x2")     # np.ndarray (2, 4) — observe positions
+```
+
+### Building the `StateSpace` model
+
+```python
+import numpy as np
+from synapsys.api import ss
+
+D = np.zeros((2, 1))
+G = ss(eqs.A, eqs.B, eqs.output("x1", "x2"), D)
+
+print(G.is_stable())   # True
+print(G.n_states)      # 4
+```
+
+### `output()` — selecting outputs
+
+`output(*state_names)` generates the **C** matrix that selects the given states
+as system outputs:
+
+```python
+# observe only positions
+C_pos = eqs.output("x1", "x2")     # shape (2, 4)
+
+# observe all states
+C_all = eqs.output("x1", "x2", "v1", "v2")   # shape (4, 4) == np.eye(4)
+```
+
+---
+
+## Error handling
+
+Both `.eq()` and `.output()` raise `ValueError` with a descriptive message if a
+name is not declared:
+
+```python
+eqs.eq("z", x1=1.0)        # ValueError: 'z' is not a declared state
+eqs.eq("v1", q=1.0)        # ValueError: 'q' is not a declared state or input
+eqs.output("z")             # ValueError: 'z' is not a declared state
+```
+
+---
+
+## Top-level import
+
+All helpers are re-exported from the `synapsys` root package:
+
+```python
+from synapsys import mat, col, row, StateEquations
+```
+
+## API Reference
+
+See the full reference at [synapsys.utils](../../api/core).

--- a/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/guide/viz/custom-controller.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/guide/viz/custom-controller.md
@@ -1,0 +1,252 @@
+---
+id: custom-controller
+title: Conectando seu Controlador
+sidebar_label: Controlador Customizado
+sidebar_position: 3
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Conectando seu Controlador
+
+Qualquer callable Python pode ser usado como controlador nas views 3D.
+Basta passar a função para o parâmetro `controller=`:
+
+```python
+CartPoleView(controller=minha_funcao).run()
+```
+
+---
+
+## Assinatura esperada
+
+```python
+controller(x: np.ndarray) -> np.ndarray | float
+```
+
+| Argumento | Tipo | Descrição |
+|---|---|---|
+| `x` | `np.ndarray` shape `(n,)` | vetor de estado completo no instante atual |
+| retorno | `np.ndarray` shape `(m,)` ou `float` | ação de controle (será convertida para array internamente) |
+
+O controlador é chamado a cada `dt` segundos na **thread da UI**.
+Para modelos pesados (> 5 ms de inferência), veja a seção [Thread-safety](#thread-safety).
+
+:::tip
+Quando `controller=None` (padrão), a lib projeta um LQR automaticamente
+via `sim.linearize()` + `lqr(Q, R)`. O controlador customizado **substitui** o LQR.
+A perturbação interativa dos botões é adicionada **depois** do retorno do seu controlador.
+:::
+
+---
+
+## Exemplos
+
+<Tabs>
+  <TabItem value="lqr" label="LQR manual">
+
+Projete o LQR fora da lib e passe o ganho K como controlador:
+
+```python
+import numpy as np
+from synapsys.viz import CartPoleView
+from synapsys.simulators import CartPoleSim
+from synapsys.algorithms.lqr import lqr
+
+# 1. Obter o modelo linearizado
+sim = CartPoleSim(m_c=1.0, m_p=0.1, l=0.5)
+sim.reset()
+ss = sim.linearize(np.zeros(4), np.zeros(1))
+
+# 2. Projetar LQR com pesos customizados
+Q = np.diag([5.0, 0.1, 500.0, 50.0])  # penaliza mais o ângulo
+R = 0.001 * np.eye(1)                  # permite forças maiores
+K, _ = lqr(ss.A, ss.B, Q, R)
+
+# 3. Passar para a view
+CartPoleView(
+    controller=lambda x: np.clip(-K @ x, -100, 100)
+).run()
+```
+
+  </TabItem>
+  <TabItem value="pid" label="PID">
+
+Um controlador PID para o pêndulo (controla apenas o ângulo θ):
+
+```python
+import numpy as np
+from synapsys.viz import PendulumView
+from synapsys.algorithms.pid import PID
+
+pid = PID(kp=80.0, ki=5.0, kd=8.0, dt=0.01,
+          u_min=-30.0, u_max=30.0)
+
+def pid_ctrl(x: np.ndarray) -> np.ndarray:
+    theta = x[0]            # ângulo (rad)
+    tau = pid.compute(setpoint=0.0, measurement=theta)
+    return np.array([tau])
+
+PendulumView(controller=pid_ctrl).run()
+```
+
+  </TabItem>
+  <TabItem value="pytorch" label="PyTorch">
+
+Uma política neural treinada com PyTorch:
+
+```python
+import numpy as np
+import torch
+from synapsys.viz import CartPoleView
+
+# Carregar modelo pré-treinado
+model = torch.load("cartpole_policy.pt", map_location="cpu")
+model.eval()
+
+def neural_ctrl(x: np.ndarray) -> np.ndarray:
+    with torch.no_grad():
+        t = torch.tensor(x, dtype=torch.float32).unsqueeze(0)
+        u = model(t).squeeze(0).numpy()
+    return np.clip(u, -80, 80)
+
+CartPoleView(controller=neural_ctrl).run()
+```
+
+> **Dica:** se o modelo foi treinado com normalização de estado,
+> aplique o mesmo scaler antes de passar `x` para o modelo.
+
+  </TabItem>
+  <TabItem value="sb3" label="Stable-Baselines3 (RL)">
+
+Um agente RL treinado com Stable-Baselines3:
+
+```python
+import numpy as np
+from stable_baselines3 import SAC
+from synapsys.viz import CartPoleView
+
+agent = SAC.load("cartpole_sac_trained")
+
+def rl_ctrl(x: np.ndarray) -> np.ndarray:
+    action, _ = agent.predict(x, deterministic=True)
+    return action
+
+CartPoleView(controller=rl_ctrl).run()
+```
+
+  </TabItem>
+  <TabItem value="residual" label="Neural-LQR residual">
+
+Arquitetura residual: o LQR garante estabilidade, a rede aprende o resíduo.
+Mesma arquitetura do exemplo Quadcopter MIMO da lib:
+
+```python
+import numpy as np
+import torch
+import torch.nn as nn
+from synapsys.viz import PendulumView
+from synapsys.simulators import InvertedPendulumSim
+from synapsys.algorithms.lqr import lqr
+
+# LQR base
+sim = InvertedPendulumSim()
+sim.reset()
+ss = sim.linearize(np.zeros(2), np.zeros(1))
+K, _ = lqr(ss.A, ss.B, np.diag([80, 5]), np.eye(1))
+
+# Rede residual (inicia zerada → comportamento = LQR puro)
+class ResidualMLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(2, 32), nn.Tanh(),
+            nn.Linear(32, 32), nn.Tanh(),
+            nn.Linear(32, 1),
+        )
+        # Inicializar última camada com zeros
+        nn.init.zeros_(self.net[-1].weight)
+        nn.init.zeros_(self.net[-1].bias)
+
+mlp = ResidualMLP().eval()
+
+def residual_lqr(x: np.ndarray) -> np.ndarray:
+    u_lqr = float((-K @ x).ravel()[0])
+    with torch.no_grad():
+        t = torch.tensor(x, dtype=torch.float32)
+        delta_u = mlp(t).item()
+    return np.array([np.clip(u_lqr + delta_u, -30, 30)])
+
+PendulumView(controller=residual_lqr).run()
+```
+
+  </TabItem>
+</Tabs>
+
+---
+
+## Thread-safety
+
+O controlador é executado na **thread principal da UI** (mesma thread do Qt).
+Isso significa:
+
+- **Modelos rápidos (< 2 ms):** sem problema, use diretamente.
+- **Modelos médios (2–10 ms):** a animação ficará um pouco lenta mas funciona.
+- **Modelos lentos (> 10 ms):** a UI trava. Use um thread separado com fila:
+
+```python
+import threading
+import queue
+import numpy as np
+from synapsys.viz import CartPoleView
+
+# Fila para comunicação entre threads
+action_queue: queue.Queue[np.ndarray] = queue.Queue(maxsize=1)
+state_queue:  queue.Queue[np.ndarray] = queue.Queue(maxsize=1)
+
+def slow_model_thread():
+    while True:
+        x = state_queue.get()
+        u = meu_modelo_lento(x)          # pode demorar
+        try:
+            action_queue.put_nowait(u)
+        except queue.Full:
+            pass
+
+last_u = np.zeros(1)
+
+def controller(x: np.ndarray) -> np.ndarray:
+    global last_u
+    try:
+        state_queue.put_nowait(x)
+        last_u = action_queue.get_nowait()
+    except (queue.Full, queue.Empty):
+        pass
+    return last_u
+
+threading.Thread(target=slow_model_thread, daemon=True).start()
+CartPoleView(controller=controller).run()
+```
+
+---
+
+## Verificando o controlador antes de rodar
+
+Antes de passar um controlador para a view, você pode testá-lo diretamente
+com o simulador:
+
+```python
+import numpy as np
+from synapsys.simulators import CartPoleSim
+
+sim = CartPoleSim()
+sim.reset(x0=np.array([0, 0, 0.2, 0]))
+
+x = sim.state
+u = meu_controlador(x)
+print("u =", u, "shape =", np.asarray(u).shape)   # deve ser (1,)
+
+y, info = sim.step(np.asarray(u).ravel(), dt=0.02)
+print("próximo estado:", info["x"])
+```

--- a/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/guide/viz/overview.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/guide/viz/overview.md
@@ -1,0 +1,114 @@
+---
+id: viz-overview
+title: Visualização 3D — Visão Geral
+sidebar_label: Visão Geral
+sidebar_position: 1
+---
+
+# Simuladores 3D — Visão Geral
+
+![Cart-Pole — simulação 3D em tempo real](/img/simview/docs/cartpole.gif)
+
+`synapsys.viz.simview` fornece janelas de simulação **plug-and-play** que combinam
+renderização 3D em tempo real (PyVista) e telemetria (matplotlib) em uma única
+interface PySide6 — pronta para receber qualquer controlador que você projetar.
+
+---
+
+## O que você obtém com uma linha
+
+```python
+from synapsys.viz import CartPoleView
+CartPoleView().run()
+```
+
+Uma janela completa com:
+
+- **Painel 3D** — animação física em tempo real (PyVista + VTK)
+- **Painel de telemetria** — 4 gráficos matplotlib sincronizados (posição, ângulo, controle, retrato de fase)
+- **Barra de controles** — botões de perturbação hold-to-apply, slider de magnitude, pausa/reset
+- **LQR automático** — se nenhum controlador for passado, a lib lineariza o simulador e projeta um LQR internamente
+- **Captura de teclado global** — A/D (perturbação), R (reset), Espaço (pausa), Q (fechar)
+
+---
+
+## Arquitetura
+
+```
+SimulatorBase          ← synapsys.simulators
+│  dynamics(), step(), linearize()
+│
+SimViewBase            ← synapsys.viz.simview._base  (QMainWindow)
+│  • cria janela Qt (splitter 3D + matplotlib)
+│  • QTimer loop → _on_tick()
+│  • auto-LQR via linearize() + lqr()
+│  • teclado, perturbações, pausa, reset
+│  • _build_all() chamado em run()
+│
+├── CartPoleView        ← state: [x, ẋ, θ, θ̇]
+├── PendulumView        ← state: [θ, θ̇]
+└── MassSpringDamperView ← state: [q, q̇]  + setpoint tracking
+```
+
+Cada subclasse implementa apenas o que é específico do seu sistema físico
+(cena 3D, gráficos, HUD, parâmetros LQR). Todo o boilerplate Qt é herdado da base.
+
+---
+
+## Simuladores disponíveis
+
+| Classe | Sistema físico | Estado | Entradas | Perturbação |
+|---|---|---|---|---|
+| `CartPoleView` | Carrinho + pêndulo | `[x, ẋ, θ, θ̇]` | Força no carrinho (N) | ◀/▶ força horizontal |
+| `PendulumView` | Pêndulo invertido | `[θ, θ̇]` | Torque na junta (N·m) | ↺/↻ torque angular |
+| `MassSpringDamperView` | Massa-mola-amortecedor | `[q, q̇]` | Força externa (N) | ◀/▶ força + setpoints 1/2/3 |
+
+---
+
+## Comparação: código standalone vs. módulo da lib
+
+<table>
+<thead><tr><th>Abordagem</th><th>Linhas de código</th><th>Requer conhecimento de Qt?</th></tr></thead>
+<tbody>
+<tr>
+<td>Arquivo <code>viz3d_cartpole_qt.py</code> (standalone)</td>
+<td>~470 linhas</td>
+<td>Sim — layout, QTimer, splitter, canvas</td>
+</tr>
+<tr>
+<td><code>CartPoleView().run()</code></td>
+<td>1 linha</td>
+<td>Não</td>
+</tr>
+<tr>
+<td><code>CartPoleView(controller=minha_rede).run()</code></td>
+<td>1 linha + sua função</td>
+<td>Não</td>
+</tr>
+</tbody>
+</table>
+
+Os arquivos standalone em `examples/simulators/` continuam disponíveis como
+referência didática para quem quiser entender a implementação interna ou criar
+UIs altamente customizadas além do que a lib oferece.
+
+---
+
+## Dependências
+
+```bash
+pip install synapsys[viz]
+# ou individualmente:
+pip install pyside6 pyvistaqt matplotlib numpy
+```
+
+> **Nota:** `pyvistaqt` requer uma instalação de VTK compatível com Qt.
+> Em ambientes headless (servidores sem display), use `pyvista` com backend offscreen.
+
+---
+
+## Próximos passos
+
+- [Guia completo de uso →](./simview)
+- [Conectar seu próprio controlador →](./custom-controller)
+- [Referência da API →](../../api/viz)

--- a/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/guide/viz/simview.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/guide/viz/simview.md
@@ -1,0 +1,265 @@
+---
+id: simview
+title: Guia de Uso — SimView
+sidebar_label: Uso dos Simuladores
+sidebar_position: 2
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Simuladores 3D — Guia de Uso
+
+Este guia mostra como usar os três simuladores 3D da lib, desde o
+caso mais simples (`CartPoleView().run()`) até customização de parâmetros físicos.
+
+---
+
+## Cart-Pole
+
+Sistema clássico de controle: um carrinho sobre trilho com um pêndulo invertido
+articulado. Estado de 4 dimensões, instável no equilíbrio vertical.
+
+![CartPole — simulação 3D em tempo real](/img/simview/docs/cartpole.gif)
+
+```python
+from synapsys.viz import CartPoleView
+
+CartPoleView().run()
+```
+
+**Parâmetros físicos (valores padrão):**
+
+| Parâmetro | Padrão | Descrição |
+|---|---|---|
+| `m_c` | `1.0` kg | massa do carrinho |
+| `m_p` | `0.1` kg | massa do bob |
+| `l` | `0.5` m | comprimento da haste |
+| `g` | `9.81` m/s² | gravidade |
+
+**Estado:** `x = [posição do carrinho, velocidade, ângulo θ, velocidade angular θ̇]`
+
+**LQR padrão:** `Q = diag([1, 0.1, 100, 10])`, `R = 0.01·I`
+
+**Estado inicial customizado:**
+
+```python
+import numpy as np
+CartPoleView(x0=np.array([0.0, 0.0, 0.30, 0.0])).run()  # ângulo inicial 0.30 rad
+```
+
+:::note Auto-reset
+O carrinho muda de cor para **âmbar** ao atingir 72% do trilho e para **vermelho** em 92%. Ao ultrapassar 92%, a simulação é resetada automaticamente.
+:::
+
+---
+
+## Pêndulo Invertido
+
+Pêndulo de 1 elo articulado numa base fixa. O sistema mais simples para testar
+controladores — apenas 2 estados, polo instável em `+√(g/l)`.
+
+![Pêndulo Invertido — simulação 3D em tempo real](/img/simview/docs/pendulum.gif)
+
+```python
+from synapsys.viz import PendulumView
+
+PendulumView().run()
+```
+
+**Parâmetros físicos (valores padrão):**
+
+| Parâmetro | Padrão | Descrição |
+|---|---|---|
+| `m` | `1.0` kg | massa do bob |
+| `l` | `1.0` m | comprimento da haste |
+| `g` | `9.81` m/s² | gravidade |
+| `b` | `0.1` | coeficiente de amortecimento viscoso |
+
+**Estado:** `x = [θ, θ̇]`
+
+**LQR padrão:** `Q = diag([80, 5])`, `R = I`
+
+---
+
+## Mass-Spring-Damper
+
+Sistema massa-mola-amortecedor com rastreamento de setpoint.
+O MSD tem controles extras na barra: botões para selecionar 3 posições
+de referência (0 m, +1.5 m, −1.5 m) e atalhos de teclado 1/2/3.
+
+![Mass-Spring-Damper — simulação 3D em tempo real](/img/simview/docs/msd.gif)
+
+```python
+from synapsys.viz import MassSpringDamperView
+
+MassSpringDamperView().run()
+```
+
+**Parâmetros físicos (valores padrão):**
+
+| Parâmetro | Padrão | Descrição |
+|---|---|---|
+| `m` | `1.0` kg | massa |
+| `c` | `0.5` N·s/m | coeficiente de amortecimento |
+| `k` | `2.0` N/m | constante da mola |
+
+**Estado:** `x = [q, q̇]`
+
+**Lei de controle LQR (com feed-forward de setpoint):**
+
+```
+u = −K·(x − x_ref) + k·sp
+```
+
+**Setpoints disponíveis (teclado):**
+
+| Tecla | Setpoint |
+|---|---|
+| `1` | 0.0 m |
+| `2` | +1.5 m |
+| `3` | −1.5 m |
+
+**Setpoints e estado inicial customizados:**
+
+```python
+import numpy as np
+MassSpringDamperView(
+    setpoints=[("0", 0.0), ("+2m", 2.0), ("-2m", -2.0)],
+    x0=np.array([1.0, 0.0]),
+).run()
+```
+
+---
+
+## Anatomia da janela
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  Título da janela                                                    │
+├──────────────────────────────┬───────────────────────────────────────┤
+│                              │  ┌─────────────────────────────────┐  │
+│   PyVista 3D                 │  │  Posição / ângulo               │  │
+│   • animação física          │  ├─────────────────────────────────┤  │
+│   • HUD com valores          │  │  Velocidade / vel. angular      │  │
+│     do estado em             │  ├─────────────────────────────────┤  │
+│     tempo real               │  │  Força / torque de controle     │  │
+│                              │  ├─────────────────────────────────┤  │
+│   A/D=pert  R=reset          │  │  Retrato de fase                │  │
+│   SPACE=pausa  Q=fechar      │  │  (ponto atual em ciano)         │  │
+│                              │  └─────────────────────────────────┘  │
+├──────────────────────────────┴───────────────────────────────────────┤
+│  [◀ Perturbar]  [──●────── Magnitude: 20 N ──]  [Perturbar ▶]       │
+│  [⏸ Pausa]  [↺ Reset]                                               │
+├──────────────────────────────────────────────────────────────────────┤
+│  t = 3.42 s  |  pos = +0.012 m  |  θ = −0.03°  |  rodando           │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+| Região | O que mostra |
+|---|---|
+| Painel 3D (esquerda, ~55%) | Cena física animada + HUD de estado + indicações de teclado |
+| Painel telemetria (direita, ~45%) | 4 gráficos matplotlib (atualização: CartPole ~17 Hz · Pêndulo/MSD ~20 Hz) |
+| Barra de controles (80 px) | Perturbação hold-to-apply + slider + pausa/reset |
+| Status bar | Tempo de simulação, variáveis principais, estado (rodando/PAUSADO) |
+
+### Gráficos de telemetria por simulador
+
+<Tabs>
+  <TabItem value="cartpole" label="Cart-Pole">
+
+| Painel | Conteúdo | Cor |
+|---|---|---|
+| 1 | Posição x(t) em m (eixo esq.) + Velocidade ẋ(t) em m/s (eixo dir.) | Azul + laranja tracejado |
+| 2 | Ângulo da haste θ(t) em graus | Laranja |
+| 3 | Força de controle u(t) em N | Vermelho |
+| 4 | Retrato de fase (θ vs θ̇) | Violeta + ponto ciano |
+
+  </TabItem>
+  <TabItem value="pendulum" label="Pêndulo">
+
+| Painel | Conteúdo | Cor |
+|---|---|---|
+| 1 | Ângulo θ(t) em graus | Azul |
+| 2 | Velocidade angular θ̇(t) em °/s | Laranja |
+| 3 | Torque de controle τ(t) em N·m | Vermelho |
+| 4 | Retrato de fase (θ vs θ̇) | Violeta + ponto ciano |
+
+  </TabItem>
+  <TabItem value="msd" label="MSD">
+
+| Painel | Conteúdo | Cor |
+|---|---|---|
+| 1 | Posição q(t) com setpoint | Azul + linha verde tracejada |
+| 2 | Velocidade q̇(t) em m/s | Laranja |
+| 3 | Força de controle u(t) em N | Vermelho |
+| 4 | Retrato de fase (q vs q̇) | Violeta + ponto ciano |
+
+  </TabItem>
+</Tabs>
+
+---
+
+## Controles de teclado
+
+| Tecla | Ação | Observação |
+|---|---|---|
+| `A` (hold) | Perturbação negativa | Liberando → perturbação volta a zero |
+| `D` (hold) | Perturbação positiva | Liberando → perturbação volta a zero |
+| `R` | Reset completo | Volta ao estado inicial, limpa histórico |
+| `Space` | Pausa / Retomar | Alterna entre `⏸` e `▶` |
+| `Q` / `Esc` | Fechar janela | Para o timer e fecha o PyVista |
+| `1` / `2` / `3` | Mudar setpoint | **Apenas MSD** |
+
+> Os atalhos funcionam independente de qual painel tem foco (3D ou matplotlib).
+
+---
+
+## Parâmetros físicos customizados
+
+Todos os parâmetros físicos podem ser passados no construtor:
+
+```python
+from synapsys.viz import CartPoleView, PendulumView, MassSpringDamperView
+
+# Carrinho pesado, haste longa
+CartPoleView(m_c=3.0, m_p=0.5, l=1.0).run()
+
+# Pêndulo curto com amortecimento maior
+PendulumView(m=0.5, l=0.6, b=0.3).run()
+
+# Mola mais rígida, amortecimento baixo (subamortecido)
+MassSpringDamperView(m=1.0, c=0.1, k=10.0).run()
+```
+
+> Ao mudar os parâmetros físicos, o LQR automático é reprojetado internamente
+> via `sim.linearize()` — nenhum ajuste manual necessário.
+
+---
+
+## Perturbações
+
+Os botões `◀ Perturbar` e `Perturbar ▶` aplicam uma força/torque **enquanto
+o botão está pressionado** (hold-to-apply). Ao soltar, a perturbação vai a zero.
+Equivalente a segurar A ou D no teclado.
+
+O **slider de magnitude** define o valor máximo da perturbação. Faixas por simulador:
+
+| Simulador | Faixa | Padrão |
+|---|---|---|
+| Cart-Pole | 1–80 N | 30 N |
+| Pêndulo | 1–40 N·m | 20 N·m |
+| MSD | 1–30 N | 15 N |
+
+---
+
+## Paleta de cores
+
+Todos os elementos visuais usam os tokens da paleta canônica.
+Ver [tokens de cor `Dark` →](../../api/viz#dark)
+
+```python
+from synapsys.viz.palette import Dark, mpl_theme
+
+mpl_theme()  # aplica tema escuro globalmente no matplotlib
+```

--- a/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/intro.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/intro.md
@@ -1,0 +1,111 @@
+---
+id: intro
+title: Introdução
+slug: /
+---
+
+# Synapsys
+
+**Framework moderno de sistemas de controle em Python com simulação multiagente distribuída.**
+
+Synapsys é uma alternativa compatível com MATLAB para engenheiros de controle que buscam:
+
+- Uma **API Python limpa** que espelha a sintaxe do MATLAB/Simulink
+- **Simulação distribuída** — planta e controlador rodando como processos independentes
+- Comunicação de **ultra-baixa latência** via memória compartilhada (zero-copy) ou ZeroMQ
+- Um **núcleo LTI sólido** que escala de malhas PID simples até arquiteturas CPS multiagente
+
+---
+
+## Funcionalidades
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+  <TabItem value="core" label="Núcleo Matemático">
+
+```python
+from synapsys.api import tf, ss, step, bode, feedback, c2d
+
+# Função de transferência — mesma sintaxe do MATLAB
+G = tf([1], [1, 2, 1])        # G(s) = 1 / (s^2 + 2s + 1)
+
+# Álgebra de blocos
+T = feedback(G)                # T = G / (1 + G)
+t, y = step(T)                 # resposta ao degrau
+w, mag, ph = bode(G)           # diagrama de Bode
+
+# Discretização ZOH
+Gd = c2d(G, dt=0.05)
+```
+
+  </TabItem>
+  <TabItem value="algorithms" label="Algoritmos">
+
+```python
+from synapsys.algorithms import PID, lqr
+
+# PID discreto com anti-windup
+pid = PID(Kp=3.0, Ki=0.5, Kd=0.1, dt=0.01,
+          u_min=-10.0, u_max=10.0)
+u = pid.compute(setpoint=5.0, measurement=y)
+
+# LQR — resolve a equação algébrica de Riccati
+K, P = lqr(A, B, Q, R)
+```
+
+  </TabItem>
+  <TabItem value="distributed" label="Simulação Distribuída">
+
+```python
+from synapsys.api import ss, c2d
+from synapsys.agents import PlantAgent, ControllerAgent, SyncEngine, SyncMode
+from synapsys.transport import SharedMemoryTransport
+
+# Discretizar a planta
+plant_d = c2d(ss([[-1]], [[1]], [[1]], [[0]]), dt=0.01)
+
+# Cada processo tem seu próprio handle para o mesmo barramento
+bus = SharedMemoryTransport("ctrl_bus", {"y": 1, "u": 1}, create=True)
+t_plant = SharedMemoryTransport("ctrl_bus", {"y": 1, "u": 1})
+
+agent = PlantAgent("planta", plant_d, t_plant, SyncEngine())
+agent.start()   # thread em background, não-bloqueante
+```
+
+  </TabItem>
+</Tabs>
+
+---
+
+## Instalação
+
+```bash
+pip install synapsys
+```
+
+Ou com [uv](https://docs.astral.sh/uv/):
+
+```bash
+uv add synapsys
+```
+
+---
+
+## Status do Projeto
+
+:::warning[Pré-Alpha]
+O Synapsys está em desenvolvimento ativo. A API pode mudar entre versões.
+:::
+
+| Módulo | Status |
+|--------|--------|
+| `synapsys.core` — LTI, StateSpace, TransferFunction | Estável |
+| `synapsys.algorithms` — PID, LQR | Estável |
+| `synapsys.agents` — PlantAgent, ControllerAgent | Funcional |
+| `synapsys.transport` — SharedMemory, ZMQ | Funcional |
+| `synapsys.api` — camada MATLAB-compat | Estável |
+| `synapsys.hw` — abstração de hardware | Interface apenas |
+| MPC, controle adaptativo | Planejado |
+| Editor gráfico de blocos | Planejado |

--- a/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/roadmap.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/version-0.2.7/roadmap.md
@@ -1,0 +1,89 @@
+---
+id: roadmap
+title: Roadmap
+sidebar_position: 99
+---
+
+# Roadmap
+
+## Estado atual — v0.2.0
+
+A biblioteca está completa e testada (184 testes, Python 3.10–3.12, cobertura 90 %).
+
+| Módulo | Status |
+|--------|--------|
+| `synapsys.core` — TransferFunction, StateSpace, TransferFunctionMatrix (contínuo + discreto) | Concluído |
+| `synapsys.algorithms` — PID (anti-windup), LQR (Q/R validados) | Concluído |
+| `synapsys.agents` — PlantAgent, ControllerAgent, FIPA ACL, SyncEngine | Concluído |
+| `synapsys.transport` — SharedMemory (zero-copy), ZMQ (PUB/SUB, REQ/REP) | Concluído |
+| `synapsys.api` — tf(), ss(), c2d(), step(), bode(), feedback() (SISO + MIMO) | Concluído |
+| `synapsys.hw` — Interface definida, sem implementações concretas | Pendente |
+
+---
+
+## v0.1.0 ✅ — Fundação
+
+- LTI SISO (`TransferFunction`, `StateSpace`), PID, LQR, multi-agente, memória compartilhada, ZMQ, abstração de hardware.
+
+## v0.2.0 ✅ — MIMO
+
+- `TransferFunctionMatrix` — matriz de funções de transferência MIMO com álgebra de operadores, `to_state_space()`, polos/zeros/estabilidade.
+- `feedback()` MIMO — malha fechada em espaço de estados para plantas `StateSpace` e `TransferFunctionMatrix`.
+- Zeros de transmissão via matriz de Rosenbrock.
+- Validação de semi-definição positiva de Q no `lqr()`.
+- Anotações de tipo covariantes no `LTIModel` para mypy/pyright.
+
+---
+
+## v0.3 — Análise avançada
+
+- [ ] **Atraso de transporte** — aproximação de Pade `pade(T, n)`
+- [ ] **Margem de fase e ganho** — `margin(G)`
+- [ ] **Root locus** — `rlocus(G)`
+- [ ] **Alocação de polos** — `place(A, B, poles)`
+- [ ] **LQI** — LQR com ação integral
+- [ ] **Observadores** — filtro de Kalman e Luenberger
+
+---
+
+## v0.4 — Controle avançado
+
+- [ ] **MPC** — Model Predictive Control com restrições
+- [ ] **Controle adaptativo** — MRAC para plantas com parâmetros variantes
+- [ ] **Reconfiguração em tempo real** — troca de lei sem parar a simulação
+
+---
+
+## v0.4 — Infraestrutura distribuída
+
+- [ ] **Semáforos OS** — proteger `SharedMemoryTransport` em multi-process
+- [ ] **Barreira lock-step entre processos** — `multiprocessing.Barrier`
+- [ ] **Protocolo de clock distribuído** — coordenar agentes em máquinas diferentes
+- [ ] **Tolerância a falhas** — ZOH quando o par desconecta
+
+---
+
+## v0.5 — Hardware
+
+- [ ] **Serial/UART** — ESP32, STM32
+- [ ] **OPC-UA** — PLCs e sistemas SCADA
+- [ ] **FPGA/FPAA** — co-simulação analógico-digital
+- [ ] **ROS 2 bridge** — integração com robótica
+
+---
+
+## v1.0 — Interface gráfica
+
+- [ ] **JSON netlist parser** — diagrama de blocos via JSON/YAML
+- [ ] **REST API** — FastAPI expondo o motor de simulação
+- [ ] **Editor visual web** — React + React Flow drag-and-drop
+- [ ] **Scope em tempo real** — WebSocket para streaming no browser
+
+---
+
+## Ideias de longo prazo
+
+- **Antifragilidade** — algoritmos que melhoram sob perturbações
+- **Digital twins** — sincronização com planta física
+- **Compilação para C** — exportar lei de controle para embarcado
+- **Integração com Julia** — solvers de EDOs de alta performance


### PR DESCRIPTION
## Summary

- Commit 41 missing PT-BR translation files for the v0.2.7 snapshot that were never staged
- These files caused the PT locale to fall back to English for all non-simulator pages in v0.2.7 while older versioned docs (0.2.6, etc.) worked correctly
- Also includes the CI fix for PT locale paths on GitHub Pages and the 4 simulator-page translations from the previous PR

## What was missing

All pages outside `guide/simulators/` in the v0.2.7 PT locale were absent from every GitHub Pages deployment:
`api/*`, `architecture`, `intro`, `roadmap`, `examples/*`, `getting-started/*`, `guide/agents/*`, `guide/algorithms/*`, `guide/core/*`, `guide/transport/*`, `guide/utils/*`, `guide/viz/*`

## Test plan

- [ ] GitHub Pages deployment succeeds after merge
- [ ] Navigating to `https://synapsys-lab.github.io/synapsys/` and switching to PT shows Portuguese content for all v0.2.7 pages
- [ ] Version dropdown for 0.2.7 in PT locale works correctly